### PR TITLE
feat: add SQLAlchemy models and initial Alembic migration for v1 schema

### DIFF
--- a/services/api/alembic/env.py
+++ b/services/api/alembic/env.py
@@ -5,10 +5,7 @@ from sqlalchemy import engine_from_config, pool
 
 from app.config import settings
 from app.models.base import Base
-
-# Import all models here so Alembic can detect schema changes.
-# Uncomment each as models are added in feature-be-alembic-baseline (Issue 4):
-# from app.models import user, refresh_session, outfit, clothing_item, follow, like, comment
+import app.models  # noqa: F401 — registers all models with Base.metadata
 
 config = context.config
 config.set_main_option("sqlalchemy.url", settings.database_url)

--- a/services/api/alembic/versions/20260411_3f8a1c2d_initial_schema.py
+++ b/services/api/alembic/versions/20260411_3f8a1c2d_initial_schema.py
@@ -1,0 +1,209 @@
+"""initial schema
+
+Revision ID: 3f8a1c2d
+Revises:
+Create Date: 2026-04-11
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "3f8a1c2d"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------ users
+    op.create_table(
+        "users",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("username", sa.String(), nullable=True),
+        sa.Column("password_hash", sa.String(), nullable=False),
+        sa.Column("display_name", sa.String(), nullable=True),
+        sa.Column("profile_image_url", sa.String(), nullable=True),
+        sa.Column("bio", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("email", name="uq_users_email"),
+        sa.UniqueConstraint("username", name="uq_users_username"),
+    )
+    op.create_index("ix_users_email", "users", ["email"])
+    op.create_index("ix_users_username", "users", ["username"])
+
+    # -------------------------------------------------------- refresh_sessions
+    op.create_table(
+        "refresh_sessions",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("user_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("token_hash", sa.String(), nullable=False),
+        sa.Column("user_agent", sa.String(), nullable=True),
+        sa.Column("ip_address", sa.String(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["users.id"], ondelete="CASCADE", name="fk_refresh_sessions_user_id"
+        ),
+        sa.UniqueConstraint("token_hash", name="uq_refresh_sessions_token_hash"),
+    )
+    op.create_index("ix_refresh_sessions_token_hash", "refresh_sessions", ["token_hash"])
+    op.create_index("ix_refresh_sessions_user_id", "refresh_sessions", ["user_id"])
+    op.create_index("ix_refresh_sessions_expires_at", "refresh_sessions", ["expires_at"])
+
+    # --------------------------------------------------------------- outfits
+    op.create_table(
+        "outfits",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("user_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("image_url", sa.String(), nullable=False),
+        sa.Column("caption", sa.String(), nullable=True),
+        sa.Column("event_name", sa.String(), nullable=True),
+        sa.Column("worn_on", sa.Date(), nullable=True),
+        sa.Column("vibe_check_text", sa.String(), nullable=True),
+        sa.Column("vibe_check_tone", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["users.id"], ondelete="CASCADE", name="fk_outfits_user_id"
+        ),
+    )
+    op.create_index("ix_outfits_user_id", "outfits", ["user_id"])
+    op.create_index("ix_outfits_created_at", "outfits", ["created_at"])
+    op.create_index("ix_outfits_user_id_worn_on", "outfits", ["user_id", "worn_on"])
+
+    # --------------------------------------------------------- clothing_items
+    op.create_table(
+        "clothing_items",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("outfit_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("brand", sa.String(), nullable=True),
+        sa.Column("category", sa.String(), nullable=False),
+        sa.Column("color", sa.String(), nullable=True),
+        sa.Column("display_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["outfit_id"], ["outfits.id"], ondelete="CASCADE", name="fk_clothing_items_outfit_id"
+        ),
+    )
+    op.create_index("ix_clothing_items_outfit_id", "clothing_items", ["outfit_id"])
+    op.create_index("ix_clothing_items_category", "clothing_items", ["category"])
+    op.create_index("ix_clothing_items_color", "clothing_items", ["color"])
+
+    # --------------------------------------------------------------- follows
+    op.create_table(
+        "follows",
+        sa.Column("follower_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("following_id", UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("follower_id", "following_id", name="pk_follows"),
+        sa.ForeignKeyConstraint(
+            ["follower_id"], ["users.id"], ondelete="CASCADE", name="fk_follows_follower_id"
+        ),
+        sa.ForeignKeyConstraint(
+            ["following_id"], ["users.id"], ondelete="CASCADE", name="fk_follows_following_id"
+        ),
+        sa.CheckConstraint("follower_id != following_id", name="ck_follows_no_self_follow"),
+    )
+    op.create_index("ix_follows_following_id", "follows", ["following_id"])
+
+    # ------------------------------------------------------------------ likes
+    op.create_table(
+        "likes",
+        sa.Column("user_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("outfit_id", UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("user_id", "outfit_id", name="pk_likes"),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["users.id"], ondelete="CASCADE", name="fk_likes_user_id"
+        ),
+        sa.ForeignKeyConstraint(
+            ["outfit_id"], ["outfits.id"], ondelete="CASCADE", name="fk_likes_outfit_id"
+        ),
+    )
+    op.create_index("ix_likes_outfit_id", "likes", ["outfit_id"])
+
+    # --------------------------------------------------------------- comments
+    op.create_table(
+        "comments",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("outfit_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("body", sa.String(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["outfit_id"], ["outfits.id"], ondelete="CASCADE", name="fk_comments_outfit_id"
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["users.id"], ondelete="CASCADE", name="fk_comments_user_id"
+        ),
+    )
+    op.create_index("ix_comments_outfit_id", "comments", ["outfit_id"])
+    op.create_index("ix_comments_user_id", "comments", ["user_id"])
+    op.create_index("ix_comments_created_at", "comments", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_table("comments")
+    op.drop_table("likes")
+    op.drop_table("follows")
+    op.drop_table("clothing_items")
+    op.drop_table("outfits")
+    op.drop_table("refresh_sessions")
+    op.drop_table("users")

--- a/services/api/app/models/__init__.py
+++ b/services/api/app/models/__init__.py
@@ -1,0 +1,19 @@
+# Import all models here so that Base.metadata is fully populated
+# for Alembic autogenerate and SQLAlchemy table creation.
+from app.models.clothing_item import ClothingItem
+from app.models.comment import Comment
+from app.models.follow import Follow
+from app.models.like import Like
+from app.models.outfit import Outfit
+from app.models.refresh_session import RefreshSession
+from app.models.user import User
+
+__all__ = [
+    "User",
+    "RefreshSession",
+    "Outfit",
+    "ClothingItem",
+    "Follow",
+    "Like",
+    "Comment",
+]

--- a/services/api/app/models/clothing_item.py
+++ b/services/api/app/models/clothing_item.py
@@ -1,0 +1,34 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class ClothingItem(Base):
+    __tablename__ = "clothing_items"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    outfit_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("outfits.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    brand: Mapped[str | None] = mapped_column(String, nullable=True)
+    category: Mapped[str] = mapped_column(String, nullable=False)
+    color: Mapped[str | None] = mapped_column(String, nullable=True)
+    display_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    __table_args__ = (
+        Index("ix_clothing_items_outfit_id", "outfit_id"),
+        Index("ix_clothing_items_category", "category"),
+        Index("ix_clothing_items_color", "color"),
+    )

--- a/services/api/app/models/comment.py
+++ b/services/api/app/models/comment.py
@@ -1,0 +1,39 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, String, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class Comment(Base):
+    __tablename__ = "comments"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    outfit_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("outfits.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    body: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    __table_args__ = (
+        Index("ix_comments_outfit_id", "outfit_id"),
+        Index("ix_comments_user_id", "user_id"),
+        Index("ix_comments_created_at", "created_at"),
+    )

--- a/services/api/app/models/follow.py
+++ b/services/api/app/models/follow.py
@@ -1,0 +1,31 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class Follow(Base):
+    __tablename__ = "follows"
+
+    follower_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    following_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    __table_args__ = (
+        CheckConstraint("follower_id != following_id", name="ck_follows_no_self_follow"),
+        Index("ix_follows_following_id", "following_id"),
+    )

--- a/services/api/app/models/like.py
+++ b/services/api/app/models/like.py
@@ -1,0 +1,28 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class Like(Base):
+    __tablename__ = "likes"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    outfit_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("outfits.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    __table_args__ = (Index("ix_likes_outfit_id", "outfit_id"),)

--- a/services/api/app/models/outfit.py
+++ b/services/api/app/models/outfit.py
@@ -1,0 +1,39 @@
+import uuid
+from datetime import date, datetime
+
+from sqlalchemy import Date, DateTime, ForeignKey, Index, String, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class Outfit(Base):
+    __tablename__ = "outfits"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    image_url: Mapped[str] = mapped_column(String, nullable=False)
+    caption: Mapped[str | None] = mapped_column(String, nullable=True)
+    event_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    worn_on: Mapped[date | None] = mapped_column(Date, nullable=True)
+    vibe_check_text: Mapped[str | None] = mapped_column(String, nullable=True)
+    vibe_check_tone: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    __table_args__ = (
+        Index("ix_outfits_user_id", "user_id"),
+        Index("ix_outfits_created_at", "created_at"),
+        Index("ix_outfits_user_id_worn_on", "user_id", "worn_on"),
+    )

--- a/services/api/app/models/refresh_session.py
+++ b/services/api/app/models/refresh_session.py
@@ -1,0 +1,39 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, String, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class RefreshSession(Base):
+    __tablename__ = "refresh_sessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    token_hash: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    user_agent: Mapped[str | None] = mapped_column(String, nullable=True)
+    ip_address: Mapped[str | None] = mapped_column(String, nullable=True)
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    __table_args__ = (
+        Index("ix_refresh_sessions_token_hash", "token_hash"),
+        Index("ix_refresh_sessions_user_id", "user_id"),
+        Index("ix_refresh_sessions_expires_at", "expires_at"),
+    )

--- a/services/api/app/models/user.py
+++ b/services/api/app/models/user.py
@@ -1,0 +1,33 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Index, String, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    email: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    username: Mapped[str | None] = mapped_column(String, nullable=True, unique=True)
+    password_hash: Mapped[str] = mapped_column(String, nullable=False)
+    display_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    profile_image_url: Mapped[str | None] = mapped_column(String, nullable=True)
+    bio: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    __table_args__ = (
+        Index("ix_users_email", "email"),
+        Index("ix_users_username", "username"),
+    )


### PR DESCRIPTION
Models for all 7 v1 tables: User, RefreshSession, Outfit, ClothingItem, Follow, Like, Comment. All columns, constraints, and indexes match docs/db-v1-schema.md exactly.

Migration 3f8a1c2d creates all tables in dependency order with named FK constraints, unique constraints, check constraint on follows (no self-follow), and all documented indexes.

alembic/env.py updated to import all models via app.models so autogenerate works correctly for future migrations.