### PR TITLE
chore: add Docker Compose local dev stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
-# Web
+# Frontend
 NEXT_PUBLIC_API_URL=http://localhost:8000
 
-# API
-APP_ENV=development
-APP_PORT=8000
-DATABASE_URL=postgresql://postgres:postgres@db:5432/ootd
-JWT_SECRET=change-me
-JWT_REFRESH_SECRET=change-me-too
+# Backend
+# When running outside Docker, use localhost. Docker Compose overrides this internally.
+DATABASE_URL=postgresql://ootd:ootd@localhost:5432/ootd
+SECRET_KEY=changeme-replace-with-a-secure-random-string
+ENVIRONMENT=development
+DEBUG=false

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ docs/             Product, planning, and engineering docs
 
 ## Ownership Split
 
-- `@otthomas`: frontend + database
-- `@reaganbourne`: backend
+- `@otthomas`: frontend (`apps/web/`)
+- `@reaganbourne`: backend + database (`services/api/`, models, migrations)
 
 ## Working Model
 
@@ -36,6 +36,59 @@ docs/             Product, planning, and engineering docs
 - Lock auth API contract
 - Build auth screens
 
-## Local Setup
+## Local development
 
-The app stack is not wired yet. This scaffold establishes the repo layout so each area can be built in parallel.
+### 1. Clone and set up env
+
+```bash
+git clone https://github.com/reaganbourne/OOTD.git
+cd OOTD
+cp .env.example .env
+```
+
+Open `.env` and set a real value for `SECRET_KEY`. Everything else works as-is.
+
+### 2. Start the backend
+
+```bash
+docker compose up
+```
+
+This starts Postgres and the FastAPI service. On first run it:
+- Pulls the Postgres image and builds the API container
+- Runs `alembic upgrade head` to create all tables
+- Starts the API with hot reload
+
+API: `http://localhost:8000`
+Interactive docs: `http://localhost:8000/docs`
+
+### 3. Start the frontend
+
+```bash
+cd apps/web
+npm install
+npm run dev
+```
+
+Frontend: `http://localhost:3000`
+
+### Useful commands
+
+```bash
+# View logs
+docker compose logs -f api
+docker compose logs -f db
+
+# Stop everything
+docker compose down
+
+# Stop and wipe the database (full reset)
+docker compose down -v
+
+# Generate a new migration after changing a model
+docker compose exec api alembic revision --autogenerate -m "describe change"
+docker compose exec api alembic upgrade head
+
+# Open a Postgres shell
+docker compose exec db psql -U ootd -d ootd
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: ootd
+      POSTGRES_PASSWORD: ootd
+      POSTGRES_DB: ootd
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ootd -d ootd"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  api:
+    build: ./services/api
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./services/api:/app
+    environment:
+      - DATABASE_URL=postgresql://ootd:ootd@db:5432/ootd
+      - SECRET_KEY=${SECRET_KEY}
+      - ENVIRONMENT=${ENVIRONMENT:-development}
+      - DEBUG=${DEBUG:-false}
+    depends_on:
+      db:
+        condition: service_healthy
+    command: >
+      sh -c "alembic upgrade head &&
+             uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
+
+volumes:
+  postgres_data:

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
- docker-compose.yml: postgres:16 with health check + named volume, FastAPI service with hot reload and live code mount
- API container runs alembic upgrade head before starting so migrations apply automatically on every docker compose up
- services/api/Dockerfile for building the API image
- .env.example updated to match actual config keys (SECRET_KEY, DATABASE_URL, ENVIRONMENT, DEBUG)
- README updated with full local setup instructions and useful commands