### PR TITLE
feat: add route protection middleware (Issue #15)

### DIFF
--- a/apps/web/components/auth/auth-form.tsx
+++ b/apps/web/components/auth/auth-form.tsx
@@ -2,6 +2,7 @@
 
 import type { FormEvent } from "react";
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import type { AuthErrors, AuthMode, AuthValues } from "@/lib/auth";
 import { useAuth } from "@/lib/auth-context";
 import {
@@ -35,6 +36,7 @@ const copy = {
 } as const;
 
 export function AuthForm({ mode }: AuthFormProps) {
+  const router = useRouter();
   const { isLoading, login, signup } = useAuth();
   const [values, setValues] = useState<AuthValues>(() => createInitialAuthValues());
   const [errors, setErrors] = useState<AuthErrors>({});
@@ -85,10 +87,8 @@ export function AuthForm({ mode }: AuthFormProps) {
 
     if (result.ok) {
       setErrors({});
-      setSubmitState({
-        status: "success",
-        message: result.message
-      });
+      setSubmitState({ status: "idle" });
+      router.replace("/");
       return;
     }
 

--- a/apps/web/lib/auth-context.tsx
+++ b/apps/web/lib/auth-context.tsx
@@ -9,6 +9,10 @@ import {
   type AuthUser
 } from "@/lib/api-client";
 import { toAuthErrors, type AuthErrors } from "@/lib/auth";
+import {
+  clearAuthSessionCookie,
+  setAuthSessionCookie
+} from "@/lib/auth-session";
 
 type LoginInput = {
   email: string;
@@ -62,6 +66,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       if (!refreshResult.ok) {
         clearAccessToken();
+        clearAuthSessionCookie();
         setUser(null);
         setIsLoading(false);
         return;
@@ -74,9 +79,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
 
       if (meResult.ok) {
+        setAuthSessionCookie();
         setUser(meResult.data);
       } else {
         clearAccessToken();
+        clearAuthSessionCookie();
         setUser(null);
       }
 
@@ -96,6 +103,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const result = await authApiClient.login(input);
 
     if (result.ok) {
+      setAuthSessionCookie();
       setUser(result.data.user);
       setIsLoading(false);
 
@@ -120,6 +128,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const result = await authApiClient.register(input);
 
     if (result.ok) {
+      setAuthSessionCookie();
       setUser(result.data.user);
       setIsLoading(false);
 
@@ -143,6 +152,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     await authApiClient.logout();
     clearAccessToken();
+    clearAuthSessionCookie();
     setUser(null);
     setIsLoading(false);
     router.replace("/login");

--- a/apps/web/lib/auth-session.ts
+++ b/apps/web/lib/auth-session.ts
@@ -1,0 +1,21 @@
+export const AUTH_SESSION_COOKIE = "ootd_session";
+export const AUTH_SESSION_COOKIE_VALUE = "active";
+export const AUTH_SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 7;
+
+export function setAuthSessionCookie() {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  document.cookie =
+    `${AUTH_SESSION_COOKIE}=${AUTH_SESSION_COOKIE_VALUE}; ` +
+    `Path=/; Max-Age=${AUTH_SESSION_MAX_AGE_SECONDS}; SameSite=Lax`;
+}
+
+export function clearAuthSessionCookie() {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  document.cookie = `${AUTH_SESSION_COOKIE}=; Path=/; Max-Age=0; SameSite=Lax`;
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,0 +1,45 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import {
+  AUTH_SESSION_COOKIE,
+  AUTH_SESSION_COOKIE_VALUE
+} from "@/lib/auth-session";
+
+const AUTH_ROUTES = new Set(["/login", "/signup"]);
+const PROTECTED_ROUTE_PREFIXES = ["/feed", "/vault", "/upload"];
+
+function isProtectedRoute(pathname: string) {
+  return PROTECTED_ROUTE_PREFIXES.some(
+    (route) => pathname === route || pathname.startsWith(`${route}/`)
+  );
+}
+
+function hasActiveSession(request: NextRequest) {
+  return request.cookies.get(AUTH_SESSION_COOKIE)?.value === AUTH_SESSION_COOKIE_VALUE;
+}
+
+export function middleware(request: NextRequest) {
+  const { pathname, search } = request.nextUrl;
+  const isAuthenticated = hasActiveSession(request);
+
+  if (AUTH_ROUTES.has(pathname) && isAuthenticated) {
+    return NextResponse.redirect(new URL("/", request.url));
+  }
+
+  if (isProtectedRoute(pathname) && !isAuthenticated) {
+    const loginUrl = new URL("/login", request.url);
+    const nextPath = `${pathname}${search}`;
+
+    if (nextPath !== "/login") {
+      loginUrl.searchParams.set("next", nextPath);
+    }
+
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico|.*\\..*).*)"]
+};


### PR DESCRIPTION
## What changed
- added apps/web/middleware.ts to protect future authenticated routes and redirect signed-in users away from /login and /signup
- added a lightweight frontend auth session cookie helper in apps/web/lib/auth-session.ts
- synced the auth provider to set and clear the middleware session marker during bootstrap, login, signup, and logout
- updated the auth form to redirect successful auth attempts away from auth pages

## Why
The web app had no route protection layer yet. Unauthenticated users could reach future protected routes directly, and authenticated users could still sit on auth pages.

## Impact
- unauthenticated requests to /feed, /vault, and /upload now redirect to /login?next=...
- authenticated requests to /login and /signup now redirect to /
- middleware does not run on API routes or static assets

## Validation
- npx.cmd tsc --noEmit
- npm.cmd run build
- verified runtime responses from a built Next.js server for auth and protected-route redirects

## Notes
This uses a lightweight frontend session marker for middleware gating. Full backend-authoritative session hardening can happen after live Postgres-backed auth verification and auth smoke tests land.