### PR TITLE
feat: replace home scaffold with real landing (Issue #16)

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,69 +1,129 @@
 import Link from "next/link";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import {
+  AUTH_SESSION_COOKIE,
+  AUTH_SESSION_COOKIE_VALUE
+} from "@/lib/auth-session";
 
 const productPillars = [
-  "Personal outfit vault",
-  "Event board coordination",
-  "AI vibe checks",
-  "Story card export"
-];
+  {
+    title: "Personal outfit vault",
+    description:
+      "Log the looks you actually wore so your closet becomes a searchable memory, not a blur."
+  },
+  {
+    title: "Event board coordination",
+    description:
+      "Plan girls' nights, birthday dinners, and group trips without duplicate outfits or last-minute chaos."
+  },
+  {
+    title: "AI vibe checks",
+    description:
+      "Get quick caption ideas, styling feedback, and a second opinion before you step out."
+  },
+  {
+    title: "Story card export",
+    description:
+      "Turn a saved fit into a clean, story-ready card you can post without rebuilding it from scratch."
+  }
+] as const;
 
-export default function HomePage() {
+const highlights = [
+  "Archive every fit with context",
+  "Coordinate group events visually",
+  "Keep your style history in one place"
+] as const;
+
+export default async function HomePage() {
+  const cookieStore = await cookies();
+  const hasActiveSession =
+    cookieStore.get(AUTH_SESSION_COOKIE)?.value === AUTH_SESSION_COOKIE_VALUE;
+
+  if (hasActiveSession) {
+    redirect("/vault");
+  }
+
   return (
     <main className="px-4 py-6 sm:px-6 lg:px-10">
       <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-6xl items-center">
         <section className="soft-panel w-full overflow-hidden">
-          <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+          <div className="grid gap-8 lg:grid-cols-[1.05fr_0.95fr]">
             <div className="bg-brand-glow px-6 py-8 sm:px-8 sm:py-10 lg:px-10 lg:py-12">
               <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-plum/70">
                 OOTD Vault
               </p>
-              <h1 className="mt-4 max-w-xl text-5xl leading-none text-ink sm:text-6xl">
-                Your style archive, your social loop, your next night out.
+              <h1 className="mt-4 max-w-2xl text-5xl leading-none text-ink sm:text-6xl">
+                Your personal style archive, built for the plans that become memories.
               </h1>
-              <p className="mt-5 max-w-xl text-base leading-7 text-plum/85 sm:text-lg">
-                This frontend branch starts the auth experience for a fashion-first
-                social product built around logging looks, coordinating events, and
-                exporting story-ready moments.
+              <p className="mt-5 max-w-2xl text-base leading-7 text-plum/85 sm:text-lg">
+                OOTD Vault helps you log outfits, coordinate looks with friends, and turn
+                great nights into reusable style history instead of one-off screenshots.
               </p>
+
               <div className="mt-8 flex flex-wrap gap-3">
-                {productPillars.map((pillar) => (
+                {highlights.map((highlight) => (
                   <span
-                    key={pillar}
-                    className="rounded-full border border-plum/15 bg-white/70 px-4 py-2 text-sm text-plum/85"
+                    key={highlight}
+                    className="rounded-full border border-plum/15 bg-white/75 px-4 py-2 text-sm text-plum/85"
                   >
-                    {pillar}
+                    {highlight}
                   </span>
+                ))}
+              </div>
+
+              <div className="mt-10 grid gap-4 sm:grid-cols-2">
+                {productPillars.map((pillar) => (
+                  <article
+                    key={pillar.title}
+                    className="rounded-[1.75rem] border border-plum/12 bg-white/72 p-5 shadow-card"
+                  >
+                    <h2 className="text-2xl text-ink">{pillar.title}</h2>
+                    <p className="mt-3 text-sm leading-6 text-plum/82">
+                      {pillar.description}
+                    </p>
+                  </article>
                 ))}
               </div>
             </div>
 
-            <div className="flex flex-col justify-between gap-6 px-6 py-8 sm:px-8 sm:py-10 lg:px-10 lg:py-12">
+            <div className="flex flex-col justify-between gap-8 px-6 py-8 sm:px-8 sm:py-10 lg:px-10 lg:py-12">
               <div>
                 <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-plum/70">
-                  Start Here
+                  Launch loop
                 </p>
-                <h2 className="mt-4 text-4xl leading-tight text-ink">
-                  Auth flow scaffold is ready for review.
+                <h2 className="mt-4 max-w-lg text-4xl leading-tight text-ink">
+                  Save the outfit, share the vibe, and remember what actually worked.
                 </h2>
                 <p className="mt-4 max-w-lg text-base leading-7 text-plum/85">
-                  Use the links below to inspect the initial login and sign-up
-                  screens. They currently run against mocked submit behavior so the
-                  UI can be built before the backend auth contract is wired in.
+                  Start with your archive, then layer on social discovery, event planning,
+                  AI support, and instant export for the looks worth keeping.
                 </p>
+              </div>
+
+              <div className="rounded-[1.75rem] border border-plum/12 bg-cream/75 p-5">
+                <p className="text-[0.72rem] font-semibold uppercase tracking-[0.26em] text-plum/70">
+                  Built for
+                </p>
+                <ul className="mt-4 grid gap-3 text-sm leading-6 text-plum/85">
+                  <li>People who want a real archive of what they wore and loved</li>
+                  <li>Friends coordinating events without matching by accident</li>
+                  <li>Creators who want captions and exports without extra steps</li>
+                </ul>
               </div>
 
               <div className="grid gap-4">
                 <Link
-                  href="/login"
+                  href="/signup"
                   className="rounded-[1.5rem] bg-plum px-5 py-4 text-center text-sm font-semibold text-white transition hover:bg-[#5c3049]"
                 >
-                  Review login screen
+                  Create your account
                 </Link>
                 <Link
-                  href="/signup"
+                  href="/login"
                   className="rounded-[1.5rem] border border-plum/20 bg-white/80 px-5 py-4 text-center text-sm font-semibold text-plum transition hover:bg-white"
                 >
-                  Review sign-up screen
+                  Log in
                 </Link>
               </div>
             </div>

--- a/apps/web/app/vault/page.tsx
+++ b/apps/web/app/vault/page.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/lib/auth-context";
+
+const nextUp = [
+  "Your saved outfits and filters",
+  "Event-linked looks and memories",
+  "Quick export paths into story cards"
+] as const;
+
+export default function VaultPage() {
+  const router = useRouter();
+  const { isAuthenticated, isLoading, user } = useAuth();
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.replace("/login");
+    }
+  }, [isAuthenticated, isLoading, router]);
+
+  if (isLoading || !isAuthenticated) {
+    return (
+      <main className="px-4 py-6 sm:px-6 lg:px-10">
+        <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-5xl items-center justify-center">
+          <section className="soft-panel w-full max-w-xl px-6 py-10 text-center sm:px-8">
+            <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-plum/70">
+              OOTD Vault
+            </p>
+            <h1 className="mt-4 text-4xl text-ink">Checking your session</h1>
+            <p className="mt-4 text-sm leading-6 text-plum/82">
+              We&apos;re getting your vault entrance ready.
+            </p>
+          </section>
+        </div>
+      </main>
+    );
+  }
+
+  const displayName = user?.display_name ?? user?.username ?? user?.email ?? "you";
+
+  return (
+    <main className="px-4 py-6 sm:px-6 lg:px-10">
+      <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-5xl items-center">
+        <section className="soft-panel w-full overflow-hidden">
+          <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+            <div className="bg-brand-glow px-6 py-8 sm:px-8 sm:py-10 lg:px-10 lg:py-12">
+              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-plum/70">
+                Your vault
+              </p>
+              <h1 className="mt-4 max-w-xl text-5xl leading-none text-ink sm:text-6xl">
+                Welcome back, {displayName}.
+              </h1>
+              <p className="mt-5 max-w-xl text-base leading-7 text-plum/85 sm:text-lg">
+                This is the authenticated landing spot for now while the full feed and
+                outfit archive screens are being built.
+              </p>
+            </div>
+
+            <div className="flex flex-col justify-between gap-8 px-6 py-8 sm:px-8 sm:py-10 lg:px-10 lg:py-12">
+              <div>
+                <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-plum/70">
+                  Next up
+                </p>
+                <h2 className="mt-4 text-4xl leading-tight text-ink">
+                  Your private home base for every look you log.
+                </h2>
+                <ul className="mt-5 grid gap-3 text-sm leading-6 text-plum/82">
+                  {nextUp.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+
+              <div className="grid gap-4">
+                <Link
+                  href="/"
+                  className="rounded-[1.5rem] bg-plum px-5 py-4 text-center text-sm font-semibold text-white transition hover:bg-[#5c3049]"
+                >
+                  Back to landing
+                </Link>
+                <Link
+                  href="/login"
+                  className="rounded-[1.5rem] border border-plum/20 bg-white/80 px-5 py-4 text-center text-sm font-semibold text-plum transition hover:bg-white"
+                >
+                  Switch account
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## What changed
- replaced the developer-facing home page scaffold in apps/web/app/page.tsx with a real public landing page
- retained the four product pillars as part of the marketing surface
- added a lightweight server-side cookie check on / so authenticated sessions redirect to /vault
- added apps/web/app/vault/page.tsx as a real authenticated landing route while the feed and full archive screens are still in progress

## Why
The old home page was still written as an internal scaffold review screen. Once auth wiring was in place, the root route needed to behave like a real product entry point for both signed-out and signed-in users.

## Impact
- signed-out visitors see a proper landing page instead of developer copy
- signed-in visitors hitting / are redirected to /vault
- /vault now exists as a real authenticated destination instead of redirecting to a future missing page
- the product pillars remain visible on the public landing page

## Validation
- npx.cmd tsc --noEmit
- npm.cmd run build
- verified runtime responses from a built Next.js server:
  - / without a session cookie returns 200
  - / with ootd_session=active redirects to /vault
  - /vault without a session cookie redirects to /login?next=%2Fvault
  - /vault with a session cookie returns 200
  - the old scaffold copy is gone and all four product pillars render on the landing page

## Notes
This keeps the authenticated root redirect aligned with the current frontend session-marker approach. It uses /vault instead of /feed because the feed route is not built yet.