### PR TITLE
feat(api): S3 image storage adapter (#18)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,12 @@ SECRET_KEY=changeme-replace-with-a-secure-random-string
 ENVIRONMENT=development
 DEBUG=false
 
+# S3 image storage
+S3_BUCKET=your-bucket-name
+AWS_ACCESS_KEY_ID=your-access-key-id
+AWS_SECRET_ACCESS_KEY=your-secret-access-key
+AWS_REGION=us-east-1
+
 # Testing (optional — defaults to ootd_test on port 5433 if not set)
 # Create locally: docker compose exec db createdb -U ootd ootd_test
 TEST_DATABASE_URL=postgresql://ootd:ootd@localhost:5433/ootd_test

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -2,7 +2,6 @@ name: API CI
 
 on:
   push:
-    branches: [main]
     paths:
       - "services/api/**"
       - ".github/workflows/api-ci.yml"

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -7,6 +7,12 @@ class Settings(BaseSettings):
     environment: str = "development"
     debug: bool = False
 
+    # S3 image storage
+    s3_bucket: str = ""
+    aws_access_key_id: str = ""
+    aws_secret_access_key: str = ""
+    aws_region: str = "us-east-1"
+
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
 

--- a/services/api/app/crud/session.py
+++ b/services/api/app/crud/session.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session as DbSession
 
@@ -36,5 +36,5 @@ def get_by_token_hash(db: DbSession, token_hash: str) -> RefreshSession | None:
 
 
 def revoke_session(db: DbSession, session: RefreshSession) -> None:
-    session.revoked_at = datetime.utcnow()
+    session.revoked_at = datetime.now(timezone.utc)
     db.commit()

--- a/services/api/app/routers/auth.py
+++ b/services/api/app/routers/auth.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response, status
 from sqlalchemy.orm import Session
@@ -73,7 +73,7 @@ def refresh(
     if (
         not session
         or session.revoked_at is not None
-        or session.expires_at < datetime.utcnow()
+        or session.expires_at < datetime.now(timezone.utc)
     ):
         raise HTTPException(
             status.HTTP_401_UNAUTHORIZED, detail="Refresh token expired or revoked."

--- a/services/api/app/services/auth.py
+++ b/services/api/app/services/auth.py
@@ -1,11 +1,11 @@
 import hashlib
 import secrets
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
+import bcrypt
 from fastapi import Response
 from jose import jwt
-from passlib.context import CryptContext
 
 from app.config import settings
 
@@ -14,19 +14,17 @@ ACCESS_TOKEN_EXPIRE_MINUTES = 15
 REFRESH_TOKEN_EXPIRE_DAYS = 7
 COOKIE_NAME = "refresh_token"
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-
 
 def hash_password(password: str) -> str:
-    return pwd_context.hash(password)
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
 
 
 def verify_password(plain: str, hashed: str) -> bool:
-    return pwd_context.verify(plain, hashed)
+    return bcrypt.checkpw(plain.encode(), hashed.encode())
 
 
 def create_access_token(user_id: uuid.UUID) -> str:
-    expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    expire = datetime.now(timezone.utc) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     payload = {"sub": str(user_id), "exp": expire}
     return jwt.encode(payload, settings.secret_key, algorithm=ALGORITHM)
 
@@ -47,7 +45,7 @@ def hash_token(token: str) -> str:
 
 
 def refresh_token_expires_at() -> datetime:
-    return datetime.utcnow() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+    return datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
 
 
 def set_refresh_cookie(response: Response, token: str) -> None:

--- a/services/api/app/services/storage.py
+++ b/services/api/app/services/storage.py
@@ -1,0 +1,110 @@
+"""
+S3 image storage adapter.
+
+Single responsibility: take raw bytes + metadata, put them in S3,
+return the public HTTPS URL. Everything S3-specific is contained here
+so the rest of the app never imports boto3 directly.
+
+Usage:
+    from app.services.storage import upload_image
+
+    url = upload_image(
+        file_bytes=await file.read(),
+        content_type=file.content_type,
+        user_id=current_user.id,
+    )
+"""
+
+import uuid
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+from app.config import settings
+
+# Allowed MIME types → file extension mapping.
+# Reject anything not in this list at the service layer.
+_ALLOWED: dict[str, str] = {
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/webp": "webp",
+    "image/heic": "heic",
+}
+
+# 10 MB hard limit — large enough for a decent phone photo, small enough
+# to keep S3 costs and upload times sane.
+MAX_BYTES = 10 * 1024 * 1024
+
+
+class StorageError(Exception):
+    """Raised when an upload fails so routers can return a clean 500."""
+
+
+class InvalidImageError(ValueError):
+    """Raised for bad content-type or oversized files — routers return 422."""
+
+
+def upload_image(
+    file_bytes: bytes,
+    content_type: str,
+    user_id: uuid.UUID,
+) -> str:
+    """
+    Upload an image to S3 and return its public URL.
+
+    Args:
+        file_bytes:   Raw file content read from the multipart upload.
+        content_type: MIME type declared by the client (e.g. "image/jpeg").
+        user_id:      ID of the uploading user — used to namespace the S3 key.
+
+    Returns:
+        The public HTTPS URL of the uploaded object.
+
+    Raises:
+        InvalidImageError: File type not allowed or file too large.
+        StorageError:      S3 call failed (network, permissions, etc.).
+    """
+    _validate(file_bytes, content_type)
+
+    ext = _ALLOWED[content_type]
+    key = f"outfits/{user_id}/{uuid.uuid4()}.{ext}"
+
+    try:
+        client = _s3_client()
+        client.put_object(
+            Bucket=settings.s3_bucket,
+            Key=key,
+            Body=file_bytes,
+            ContentType=content_type,
+        )
+    except (BotoCoreError, ClientError) as exc:
+        raise StorageError(f"S3 upload failed: {exc}") from exc
+
+    return _public_url(key)
+
+
+# ------------------------------------------------------------------ internals
+
+
+def _validate(file_bytes: bytes, content_type: str) -> None:
+    if content_type not in _ALLOWED:
+        raise InvalidImageError(
+            f"Unsupported file type '{content_type}'. "
+            f"Allowed: {', '.join(_ALLOWED)}."
+        )
+    if len(file_bytes) > MAX_BYTES:
+        mb = len(file_bytes) / 1024 / 1024
+        raise InvalidImageError(f"File too large ({mb:.1f} MB). Maximum is 10 MB.")
+
+
+def _s3_client():
+    return boto3.client(
+        "s3",
+        region_name=settings.aws_region,
+        aws_access_key_id=settings.aws_access_key_id or None,
+        aws_secret_access_key=settings.aws_secret_access_key or None,
+    )
+
+
+def _public_url(key: str) -> str:
+    return f"https://{settings.s3_bucket}.s3.{settings.aws_region}.amazonaws.com/{key}"

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -6,5 +6,6 @@ sqlalchemy==2.0.36
 psycopg2-binary==2.9.10
 alembic==1.14.0
 python-jose[cryptography]==3.3.0
-passlib[bcrypt]==1.7.4
+bcrypt==4.2.1
 python-multipart==0.0.20
+boto3==1.35.99

--- a/services/api/tests/test_auth.py
+++ b/services/api/tests/test_auth.py
@@ -156,8 +156,12 @@ class TestRefresh:
         assert "missing" in res.json()["detail"].lower()
 
     def test_revoked_token_returns_401(self, client):
+        # After rotation the old token is revoked in the DB.
+        # Grab it before it's overwritten, then replay it.
         _register(client)
-        client.post(LOGOUT_URL)
+        old_token = client.cookies.get("refresh_token")
+        client.post(REFRESH_URL)  # rotates — old_token is now revoked
+        client.cookies.set("refresh_token", old_token, path="/auth")
         res = client.post(REFRESH_URL)
         assert res.status_code == 401
         assert "revoked" in res.json()["detail"].lower()


### PR DESCRIPTION
- storage.py: upload_image() puts files at outfits/{user_id}/{uuid}.ext and returns the public S3 URL; raises InvalidImageError (422) for bad type/size, StorageError (500) for S3 failures
- Allowed types: jpeg, png, webp, heic — 10 MB max
- New env vars: S3_BUCKET, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION
- Also backports fixes from chore-be-auth-ci-tests that were missed in merge: passlib -> bcrypt directly, datetime.utcnow() -> datetime.now(timezone.utc), CI workflow push trigger, test_revoked_token fix