### PR TITLE
feat(api): create-outfit endpoint (#20)

### DIFF
--- a/packages/contracts/outfit-contract.md
+++ b/packages/contracts/outfit-contract.md
@@ -1,0 +1,120 @@
+# Outfit API Contract
+
+Request and response shapes for outfit endpoints.
+Source of truth for `@otthomas` building the upload flow UI (Issue #19).
+
+## Base URL
+
+```
+http://localhost:8000   (local dev)
+https://api.ootd.app   (production — TBD on Railway)
+```
+
+All endpoints are prefixed with `/outfits`.
+
+All endpoints require authentication:
+```
+Authorization: Bearer <access_token>
+```
+
+---
+
+## POST /outfits — Create outfit
+
+**Request: `multipart/form-data`**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `image` | File | ✅ | Photo file. Allowed: jpeg, png, webp, heic. Max 10 MB. |
+| `metadata` | string (JSON) | ❌ | JSON-encoded outfit details (see below). Defaults to `{}`. |
+
+`metadata` JSON shape:
+
+```ts
+{
+  caption?: string
+  event_name?: string
+  worn_on?: string          // ISO date: "2026-04-13"
+  clothing_items?: {
+    category: string        // required — e.g. "top", "pants", "shoes"
+    brand?: string
+    color?: string
+    display_order?: number  // 0-based, controls render order
+  }[]
+}
+```
+
+**Example fetch (TypeScript):**
+
+```ts
+const form = new FormData()
+form.append('image', file)
+form.append('metadata', JSON.stringify({
+  caption: 'Sunday brunch fit',
+  worn_on: '2026-04-13',
+  clothing_items: [
+    { category: 'top', brand: 'Zara', color: 'white', display_order: 0 },
+    { category: 'pants', brand: 'Levis', color: 'blue', display_order: 1 },
+  ],
+}))
+
+const res = await fetch(`${API_URL}/outfits`, {
+  method: 'POST',
+  headers: { Authorization: `Bearer ${accessToken}` },
+  body: form,
+  // Do NOT set Content-Type — the browser sets it with the boundary automatically
+})
+```
+
+**Response `201 Created`**
+
+```json
+{
+  "id": "a1b2c3d4-...",
+  "user_id": "e5f6g7h8-...",
+  "image_url": "https://ootd-outfits-prod.s3.us-east-1.amazonaws.com/outfits/user_id/uuid.jpg",
+  "caption": "Sunday brunch fit",
+  "event_name": null,
+  "worn_on": "2026-04-13",
+  "vibe_check_text": null,
+  "vibe_check_tone": null,
+  "created_at": "2026-04-13T21:00:00Z",
+  "updated_at": "2026-04-13T21:00:00Z",
+  "clothing_items": [
+    {
+      "id": "...",
+      "outfit_id": "...",
+      "category": "top",
+      "brand": "Zara",
+      "color": "white",
+      "display_order": 0,
+      "created_at": "2026-04-13T21:00:00Z"
+    },
+    {
+      "id": "...",
+      "outfit_id": "...",
+      "category": "pants",
+      "brand": "Levis",
+      "color": "blue",
+      "display_order": 1,
+      "created_at": "2026-04-13T21:00:00Z"
+    }
+  ]
+}
+```
+
+**Error responses**
+
+| Status | `detail` | Cause |
+|---|---|---|
+| `401 Unauthorized` | `"Not authenticated."` | Missing or invalid access token |
+| `422 Unprocessable Entity` | `"Unsupported file type '...'. Allowed: ..."` | Bad image type |
+| `422 Unprocessable Entity` | `"File too large (12.3 MB). Maximum is 10 MB."` | Image too big |
+| `422 Unprocessable Entity` | `"Invalid metadata JSON: ..."` | Malformed metadata field |
+| `500 Internal Server Error` | `"S3 upload failed: ..."` | Storage failure |
+
+**Notes for Tomi:**
+- Do **not** manually set `Content-Type` on the fetch — let the browser set it automatically so the multipart boundary is included correctly
+- `clothing_items` can be an empty array or omitted entirely if the user skips that step
+- `image_url` is a permanent URL — safe to store and render directly as `<img src={outfit.image_url} />`
+- `worn_on` is an ISO date string (`"2026-04-13"`), not a full timestamp

--- a/services/api/app/crud/outfit.py
+++ b/services/api/app/crud/outfit.py
@@ -1,0 +1,51 @@
+import uuid
+from datetime import date
+
+from sqlalchemy.orm import Session
+
+from app.models.clothing_item import ClothingItem
+from app.models.outfit import Outfit
+from app.schemas.outfit import ClothingItemIn
+
+
+def create_outfit(
+    db: Session,
+    user_id: uuid.UUID,
+    image_url: str,
+    clothing_items: list[ClothingItemIn],
+    caption: str | None = None,
+    event_name: str | None = None,
+    worn_on: date | None = None,
+) -> Outfit:
+    """
+    Insert one outfit row and all its clothing_items in a single transaction.
+    Returns the outfit with clothing_items already loaded.
+    """
+    outfit = Outfit(
+        user_id=user_id,
+        image_url=image_url,
+        caption=caption,
+        event_name=event_name,
+        worn_on=worn_on,
+    )
+    db.add(outfit)
+    db.flush()  # get outfit.id without committing yet
+
+    for item in clothing_items:
+        db.add(
+            ClothingItem(
+                outfit_id=outfit.id,
+                brand=item.brand,
+                category=item.category,
+                color=item.color,
+                display_order=item.display_order,
+            )
+        )
+
+    db.commit()
+    db.refresh(outfit)
+    return outfit
+
+
+def get_outfit_with_items(db: Session, outfit_id: uuid.UUID) -> Outfit | None:
+    return db.query(Outfit).filter(Outfit.id == outfit_id).first()

--- a/services/api/app/models/clothing_item.py
+++ b/services/api/app/models/clothing_item.py
@@ -1,11 +1,15 @@
 import uuid
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, text
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base
+
+if TYPE_CHECKING:
+    from app.models.outfit import Outfit
 
 
 class ClothingItem(Base):
@@ -26,6 +30,8 @@ class ClothingItem(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=text("now()")
     )
+
+    outfit: Mapped["Outfit"] = relationship("Outfit", back_populates="clothing_items")
 
     __table_args__ = (
         Index("ix_clothing_items_outfit_id", "outfit_id"),

--- a/services/api/app/models/outfit.py
+++ b/services/api/app/models/outfit.py
@@ -1,11 +1,15 @@
 import uuid
 from datetime import date, datetime
+from typing import TYPE_CHECKING
 
 from sqlalchemy import Date, DateTime, ForeignKey, Index, String, text
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base
+
+if TYPE_CHECKING:
+    from app.models.clothing_item import ClothingItem
 
 
 class Outfit(Base):
@@ -30,6 +34,10 @@ class Outfit(Base):
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    clothing_items: Mapped[list["ClothingItem"]] = relationship(
+        "ClothingItem", back_populates="outfit", order_by="ClothingItem.display_order"
     )
 
     __table_args__ = (

--- a/services/api/app/routers/outfits.py
+++ b/services/api/app/routers/outfits.py
@@ -1,5 +1,87 @@
-from fastapi import APIRouter
+import json
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from sqlalchemy.orm import Session
+
+from app.crud import outfit as outfit_crud
+from app.dependencies import get_current_user, get_db
+from app.models.user import User
+from app.schemas.outfit import OutfitMetadata, OutfitOut
+from app.services.storage import InvalidImageError, StorageError, upload_image
 
 router = APIRouter(prefix="/outfits", tags=["outfits"])
 
-# Endpoints implemented in Phase 2 (Issues 14-15, 19)
+
+@router.post("", response_model=OutfitOut, status_code=status.HTTP_201_CREATED)
+def create_outfit(
+    image: UploadFile = File(...),
+    metadata: str = Form(default="{}"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> OutfitOut:
+    """
+    Create a new outfit with an image and optional clothing items.
+
+    Request: multipart/form-data
+      - image:    the photo file (jpeg, png, webp, or heic — max 10 MB)
+      - metadata: JSON string with optional fields:
+                    caption, event_name, worn_on (YYYY-MM-DD),
+                    clothing_items: [{ category, brand, color, display_order }]
+
+    Example fetch (JavaScript):
+        const form = new FormData()
+        form.append('image', file)
+        form.append('metadata', JSON.stringify({
+            caption: 'Sunday brunch fit',
+            worn_on: '2026-04-13',
+            clothing_items: [
+                { category: 'top', brand: 'Zara', color: 'white', display_order: 0 },
+                { category: 'pants', brand: 'Levis', color: 'blue', display_order: 1 },
+            ]
+        }))
+        await fetch('/outfits', {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${token}` },
+            body: form,
+        })
+    """
+    # Parse metadata JSON
+    try:
+        meta = OutfitMetadata.model_validate(json.loads(metadata))
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid metadata JSON: {exc}",
+        )
+
+    # Upload image to S3
+    try:
+        file_bytes = image.file.read()
+        image_url = upload_image(
+            file_bytes=file_bytes,
+            content_type=image.content_type or "",
+            user_id=current_user.id,
+        )
+    except InvalidImageError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        )
+    except StorageError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(exc),
+        )
+
+    # Persist to DB
+    outfit = outfit_crud.create_outfit(
+        db,
+        user_id=current_user.id,
+        image_url=image_url,
+        caption=meta.caption,
+        event_name=meta.event_name,
+        worn_on=meta.worn_on,
+        clothing_items=meta.clothing_items,
+    )
+
+    return OutfitOut.model_validate(outfit)

--- a/services/api/app/schemas/outfit.py
+++ b/services/api/app/schemas/outfit.py
@@ -1,0 +1,65 @@
+import uuid
+from datetime import date, datetime
+
+from pydantic import BaseModel, Field
+
+
+# ------------------------------------------------------------------ input
+
+
+class ClothingItemIn(BaseModel):
+    brand: str | None = None
+    category: str
+    color: str | None = None
+    display_order: int = 0
+
+
+class OutfitMetadata(BaseModel):
+    """
+    The non-file fields for POST /outfits, sent as a JSON string in the
+    multipart form field named 'metadata'.
+
+    Example (JavaScript):
+        const form = new FormData()
+        form.append('image', file)
+        form.append('metadata', JSON.stringify({
+            caption: 'Sunday brunch fit',
+            clothing_items: [{ category: 'top', brand: 'Zara', color: 'white' }]
+        }))
+    """
+
+    caption: str | None = None
+    event_name: str | None = None
+    worn_on: date | None = None
+    clothing_items: list[ClothingItemIn] = Field(default_factory=list)
+
+
+# ------------------------------------------------------------------ output
+
+
+class ClothingItemOut(BaseModel):
+    id: uuid.UUID
+    outfit_id: uuid.UUID
+    brand: str | None
+    category: str
+    color: str | None
+    display_order: int
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class OutfitOut(BaseModel):
+    id: uuid.UUID
+    user_id: uuid.UUID
+    image_url: str
+    caption: str | None
+    event_name: str | None
+    worn_on: date | None
+    vibe_check_text: str | None
+    vibe_check_tone: str | None
+    created_at: datetime
+    updated_at: datetime
+    clothing_items: list[ClothingItemOut]
+
+    model_config = {"from_attributes": True}


### PR DESCRIPTION
- POST /outfits accepts multipart/form-data: image file + JSON metadata
- Uploads image to S3 via storage adapter, stores returned URL
- Inserts outfit + all clothing_items in a single DB transaction
- Returns full OutfitOut shape with clothing_items sorted by display_order
- Invalid file type or oversized image -> 422; S3 failure -> 500
- Added relationship() between Outfit <-> ClothingItem models
- outfit-contract.md documents request/response shape for Tomi