### PR TITLE
feat(api): follow/unfollow, feed, vault, and profile endpoints (#22 #…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       POSTGRES_PASSWORD: ootd
       POSTGRES_DB: ootd
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/services/api/alembic/versions/20260417_a1b2c3d4_add_link_url_to_clothing_items.py
+++ b/services/api/alembic/versions/20260417_a1b2c3d4_add_link_url_to_clothing_items.py
@@ -1,0 +1,24 @@
+"""add link_url to clothing_items
+
+Revision ID: a1b2c3d4
+Revises: 3f8a1c2d
+Create Date: 2026-04-17
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a1b2c3d4"
+down_revision: Union[str, None] = "3f8a1c2d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("clothing_items", sa.Column("link_url", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("clothing_items", "link_url")

--- a/services/api/app/crud/follow.py
+++ b/services/api/app/crud/follow.py
@@ -1,0 +1,45 @@
+import uuid
+
+from sqlalchemy.orm import Session
+
+from app.models.follow import Follow
+
+
+def is_following(db: Session, follower_id: uuid.UUID, following_id: uuid.UUID) -> bool:
+    return (
+        db.query(Follow)
+        .filter(Follow.follower_id == follower_id, Follow.following_id == following_id)
+        .first()
+        is not None
+    )
+
+
+def follow(db: Session, follower_id: uuid.UUID, following_id: uuid.UUID) -> None:
+    if is_following(db, follower_id, following_id):
+        return
+    db.add(Follow(follower_id=follower_id, following_id=following_id))
+    db.commit()
+
+
+def unfollow(db: Session, follower_id: uuid.UUID, following_id: uuid.UUID) -> None:
+    row = (
+        db.query(Follow)
+        .filter(Follow.follower_id == follower_id, Follow.following_id == following_id)
+        .first()
+    )
+    if row:
+        db.delete(row)
+        db.commit()
+
+
+def follower_count(db: Session, user_id: uuid.UUID) -> int:
+    return db.query(Follow).filter(Follow.following_id == user_id).count()
+
+
+def following_count(db: Session, user_id: uuid.UUID) -> int:
+    return db.query(Follow).filter(Follow.follower_id == user_id).count()
+
+
+def following_ids(db: Session, user_id: uuid.UUID) -> list[uuid.UUID]:
+    rows = db.query(Follow.following_id).filter(Follow.follower_id == user_id).all()
+    return [r[0] for r in rows]

--- a/services/api/app/crud/outfit.py
+++ b/services/api/app/crud/outfit.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import date
+from datetime import date, datetime, timezone
 
 from sqlalchemy.orm import Session
 
@@ -39,6 +39,7 @@ def create_outfit(
                 category=item.category,
                 color=item.color,
                 display_order=item.display_order,
+                link_url=item.link_url,
             )
         )
 
@@ -49,3 +50,59 @@ def create_outfit(
 
 def get_outfit_with_items(db: Session, outfit_id: uuid.UUID) -> Outfit | None:
     return db.query(Outfit).filter(Outfit.id == outfit_id).first()
+
+
+def get_user_outfits(
+    db: Session,
+    user_id: uuid.UUID,
+    cursor: str | None = None,
+    limit: int = 20,
+) -> tuple[list[Outfit], str | None]:
+    """
+    Paginated vault for one user, newest first.
+    cursor is the ISO timestamp of the last item seen.
+    Returns (outfits, next_cursor).
+    """
+    query = db.query(Outfit).filter(Outfit.user_id == user_id)
+
+    if cursor:
+        cursor_dt = datetime.fromisoformat(cursor.replace(" ", "+"))
+        query = query.filter(Outfit.created_at < cursor_dt)
+
+    outfits = query.order_by(Outfit.created_at.desc()).limit(limit + 1).all()
+
+    next_cursor = None
+    if len(outfits) > limit:
+        outfits = outfits[:limit]
+        next_cursor = outfits[-1].created_at.isoformat()
+
+    return outfits, next_cursor
+
+
+def get_feed(
+    db: Session,
+    following_ids: list[uuid.UUID],
+    cursor: str | None = None,
+    limit: int = 20,
+) -> tuple[list[Outfit], str | None]:
+    """
+    Feed of outfits from a set of users, newest first.
+    Returns empty list immediately if following_ids is empty.
+    """
+    if not following_ids:
+        return [], None
+
+    query = db.query(Outfit).filter(Outfit.user_id.in_(following_ids))
+
+    if cursor:
+        cursor_dt = datetime.fromisoformat(cursor.replace(" ", "+"))
+        query = query.filter(Outfit.created_at < cursor_dt)
+
+    outfits = query.order_by(Outfit.created_at.desc()).limit(limit + 1).all()
+
+    next_cursor = None
+    if len(outfits) > limit:
+        outfits = outfits[:limit]
+        next_cursor = outfits[-1].created_at.isoformat()
+
+    return outfits, next_cursor

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -2,7 +2,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
-from app.routers import auth, health, outfits
+from app.routers import auth, health, outfits, users
 
 
 @asynccontextmanager
@@ -19,3 +19,4 @@ app = FastAPI(
 app.include_router(health.router)
 app.include_router(auth.router)
 app.include_router(outfits.router)
+app.include_router(users.router)

--- a/services/api/app/models/clothing_item.py
+++ b/services/api/app/models/clothing_item.py
@@ -27,6 +27,7 @@ class ClothingItem(Base):
     category: Mapped[str] = mapped_column(String, nullable=False)
     color: Mapped[str | None] = mapped_column(String, nullable=True)
     display_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    link_url: Mapped[str | None] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=text("now()")
     )

--- a/services/api/app/routers/outfits.py
+++ b/services/api/app/routers/outfits.py
@@ -1,12 +1,14 @@
 import json
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
 from sqlalchemy.orm import Session
 
+from app.crud import follow as follow_crud
 from app.crud import outfit as outfit_crud
+from app.crud import user as user_crud
 from app.dependencies import get_current_user, get_db
 from app.models.user import User
-from app.schemas.outfit import OutfitMetadata, OutfitOut
+from app.schemas.outfit import OutfitMetadata, OutfitOut, VaultPage
 from app.services.storage import InvalidImageError, StorageError, upload_image
 
 router = APIRouter(prefix="/outfits", tags=["outfits"])
@@ -26,54 +28,21 @@ def create_outfit(
       - image:    the photo file (jpeg, png, webp, or heic — max 10 MB)
       - metadata: JSON string with optional fields:
                     caption, event_name, worn_on (YYYY-MM-DD),
-                    clothing_items: [{ category, brand, color, display_order }]
-
-    Example fetch (JavaScript):
-        const form = new FormData()
-        form.append('image', file)
-        form.append('metadata', JSON.stringify({
-            caption: 'Sunday brunch fit',
-            worn_on: '2026-04-13',
-            clothing_items: [
-                { category: 'top', brand: 'Zara', color: 'white', display_order: 0 },
-                { category: 'pants', brand: 'Levis', color: 'blue', display_order: 1 },
-            ]
-        }))
-        await fetch('/outfits', {
-            method: 'POST',
-            headers: { Authorization: `Bearer ${token}` },
-            body: form,
-        })
+                    clothing_items: [{ category, brand, color, display_order, link_url }]
     """
-    # Parse metadata JSON
     try:
         meta = OutfitMetadata.model_validate(json.loads(metadata))
     except (json.JSONDecodeError, ValueError) as exc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Invalid metadata JSON: {exc}",
-        )
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Invalid metadata JSON: {exc}")
 
-    # Upload image to S3
     try:
         file_bytes = image.file.read()
-        image_url = upload_image(
-            file_bytes=file_bytes,
-            content_type=image.content_type or "",
-            user_id=current_user.id,
-        )
+        image_url = upload_image(file_bytes=file_bytes, content_type=image.content_type or "", user_id=current_user.id)
     except InvalidImageError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=str(exc),
-        )
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
     except StorageError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(exc),
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc))
 
-    # Persist to DB
     outfit = outfit_crud.create_outfit(
         db,
         user_id=current_user.id,
@@ -83,5 +52,47 @@ def create_outfit(
         worn_on=meta.worn_on,
         clothing_items=meta.clothing_items,
     )
-
     return OutfitOut.model_validate(outfit)
+
+
+@router.get("/feed", response_model=VaultPage)
+def get_feed(
+    cursor: str | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=50),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> VaultPage:
+    """
+    Outfits from users the current user follows, newest first.
+    Returns an empty list if the user follows nobody yet.
+    """
+    ids = follow_crud.following_ids(db, current_user.id)
+    outfits, next_cursor = outfit_crud.get_feed(db, ids, cursor, limit)
+    return VaultPage(outfits=[OutfitOut.model_validate(o) for o in outfits], next_cursor=next_cursor)
+
+
+@router.get("/me", response_model=VaultPage)
+def my_vault(
+    cursor: str | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=50),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> VaultPage:
+    """Current user's own vault, newest first."""
+    outfits, next_cursor = outfit_crud.get_user_outfits(db, current_user.id, cursor, limit)
+    return VaultPage(outfits=[OutfitOut.model_validate(o) for o in outfits], next_cursor=next_cursor)
+
+
+@router.get("/user/{username}", response_model=VaultPage)
+def user_vault(
+    username: str,
+    cursor: str | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=50),
+    db: Session = Depends(get_db),
+) -> VaultPage:
+    """Public vault for any user — no auth required."""
+    user = user_crud.get_by_username(db, username)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
+    outfits, next_cursor = outfit_crud.get_user_outfits(db, user.id, cursor, limit)
+    return VaultPage(outfits=[OutfitOut.model_validate(o) for o in outfits], next_cursor=next_cursor)

--- a/services/api/app/routers/users.py
+++ b/services/api/app/routers/users.py
@@ -1,0 +1,58 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.crud import follow as follow_crud
+from app.crud import user as user_crud
+from app.dependencies import get_current_user, get_db
+from app.models.user import User
+from app.schemas.user import FollowResponse, PublicProfile
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+@router.get("/{username}", response_model=PublicProfile)
+def get_profile(username: str, db: Session = Depends(get_db)) -> PublicProfile:
+    """Public profile — no auth required."""
+    user = user_crud.get_by_username(db, username)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
+    return PublicProfile(
+        id=user.id,
+        username=user.username,
+        display_name=user.display_name,
+        bio=user.bio,
+        profile_image_url=user.profile_image_url,
+        follower_count=follow_crud.follower_count(db, user.id),
+        following_count=follow_crud.following_count(db, user.id),
+        created_at=user.created_at,
+    )
+
+
+@router.post("/{user_id}/follow", response_model=FollowResponse)
+def follow_user(
+    user_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> FollowResponse:
+    if user_id == current_user.id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Cannot follow yourself.")
+    if not user_crud.get_by_id(db, user_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
+    follow_crud.follow(db, follower_id=current_user.id, following_id=user_id)
+    return FollowResponse(following=True, follower_count=follow_crud.follower_count(db, user_id))
+
+
+@router.delete("/{user_id}/follow", response_model=FollowResponse)
+def unfollow_user(
+    user_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> FollowResponse:
+    if user_id == current_user.id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Cannot unfollow yourself.")
+    if not user_crud.get_by_id(db, user_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
+    follow_crud.unfollow(db, follower_id=current_user.id, following_id=user_id)
+    return FollowResponse(following=False, follower_count=follow_crud.follower_count(db, user_id))

--- a/services/api/app/schemas/outfit.py
+++ b/services/api/app/schemas/outfit.py
@@ -12,6 +12,7 @@ class ClothingItemIn(BaseModel):
     category: str
     color: str | None = None
     display_order: int = 0
+    link_url: str | None = None
 
 
 class OutfitMetadata(BaseModel):
@@ -44,6 +45,7 @@ class ClothingItemOut(BaseModel):
     category: str
     color: str | None
     display_order: int
+    link_url: str | None
     created_at: datetime
 
     model_config = {"from_attributes": True}
@@ -63,3 +65,8 @@ class OutfitOut(BaseModel):
     clothing_items: list[ClothingItemOut]
 
     model_config = {"from_attributes": True}
+
+
+class VaultPage(BaseModel):
+    outfits: list[OutfitOut]
+    next_cursor: str | None

--- a/services/api/app/schemas/user.py
+++ b/services/api/app/schemas/user.py
@@ -1,0 +1,22 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class PublicProfile(BaseModel):
+    id: uuid.UUID
+    username: str | None
+    display_name: str | None
+    bio: str | None
+    profile_image_url: str | None
+    follower_count: int
+    following_count: int
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class FollowResponse(BaseModel):
+    following: bool
+    follower_count: int

--- a/services/api/tests/test_feed.py
+++ b/services/api/tests/test_feed.py
@@ -1,0 +1,107 @@
+"""Tests for feed, vault, and profile outfit endpoints."""
+
+import io
+from starlette.testclient import TestClient
+
+REGISTER_URL = "/auth/register"
+FOLLOW_URL = "/users/{user_id}/follow"
+FEED_URL = "/outfits/feed"
+MY_VAULT_URL = "/outfits/me"
+USER_VAULT_URL = "/outfits/user/{username}"
+
+USER_A = {"username": "usera", "email": "a@example.com", "password": "password123"}
+USER_B = {"username": "userb", "email": "b@example.com", "password": "password123"}
+USER_C = {"username": "userc", "email": "c@example.com", "password": "password123"}
+
+
+def _register(client, payload):
+    res = client.post(REGISTER_URL, json=payload)
+    assert res.status_code == 201
+    return res.json()
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _post_outfit(client, token, caption="test outfit"):
+    """Post a fake outfit — S3 upload is mocked via monkeypatch in conftest."""
+    fake_image = io.BytesIO(b"fake-image-data")
+    return client.post(
+        "/outfits",
+        headers=_auth(token),
+        files={"image": ("test.jpg", fake_image, "image/jpeg")},
+        data={"metadata": f'{{"caption": "{caption}"}}'},
+    )
+
+
+class TestFeed:
+    def test_empty_feed_when_following_nobody(self, client):
+        a = _register(client, USER_A)
+        res = client.get(FEED_URL, headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        body = res.json()
+        assert body["outfits"] == []
+        assert body["next_cursor"] is None
+
+    def test_feed_shows_followed_users_outfits(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        client.post(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=_auth(a["access_token"]))
+        _post_outfit(client, b["access_token"], "b's outfit")
+        res = client.get(FEED_URL, headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        assert len(res.json()["outfits"]) == 1
+        assert res.json()["outfits"][0]["caption"] == "b's outfit"
+
+    def test_feed_does_not_show_unfollowed_users(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        _post_outfit(client, b["access_token"], "b's outfit")
+        res = client.get(FEED_URL, headers=_auth(a["access_token"]))
+        assert res.json()["outfits"] == []
+
+    def test_feed_requires_auth(self, client):
+        assert client.get(FEED_URL).status_code == 401
+
+    def test_feed_cursor_pagination(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        client.post(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=_auth(a["access_token"]))
+        for i in range(3):
+            _post_outfit(client, b["access_token"], f"outfit {i}")
+        res = client.get(FEED_URL + "?limit=2", headers=_auth(a["access_token"]))
+        assert len(res.json()["outfits"]) == 2
+        assert res.json()["next_cursor"] is not None
+        cursor = res.json()["next_cursor"]
+        res2 = client.get(FEED_URL + f"?limit=2&cursor={cursor}", headers=_auth(a["access_token"]))
+        assert len(res2.json()["outfits"]) == 1
+        assert res2.json()["next_cursor"] is None
+
+
+class TestVault:
+    def test_my_vault_returns_own_outfits(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
+        a = _register(client, USER_A)
+        _post_outfit(client, a["access_token"], "my outfit")
+        res = client.get(MY_VAULT_URL, headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        assert len(res.json()["outfits"]) == 1
+        assert res.json()["outfits"][0]["caption"] == "my outfit"
+
+    def test_my_vault_requires_auth(self, client):
+        assert client.get(MY_VAULT_URL).status_code == 401
+
+    def test_user_vault_is_public(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
+        a = _register(client, USER_A)
+        _post_outfit(client, a["access_token"], "public outfit")
+        res = client.get(USER_VAULT_URL.format(username="usera"))
+        assert res.status_code == 200
+        assert len(res.json()["outfits"]) == 1
+
+    def test_user_vault_unknown_user_returns_404(self, client):
+        assert client.get(USER_VAULT_URL.format(username="nobody")).status_code == 404

--- a/services/api/tests/test_follows.py
+++ b/services/api/tests/test_follows.py
@@ -1,0 +1,110 @@
+"""Tests for follow/unfollow and public profile endpoints."""
+
+from starlette.testclient import TestClient
+
+REGISTER_URL = "/auth/register"
+FOLLOW_URL = "/users/{user_id}/follow"
+PROFILE_URL = "/users/{username}"
+
+USER_A = {"username": "usera", "email": "a@example.com", "password": "password123"}
+USER_B = {"username": "userb", "email": "b@example.com", "password": "password123"}
+
+
+def _register(client: TestClient, payload: dict) -> dict:
+    res = client.post(REGISTER_URL, json=payload)
+    assert res.status_code == 201
+    return res.json()
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestPublicProfile:
+    def test_returns_profile(self, client):
+        _register(client, USER_A)
+        res = client.get(PROFILE_URL.format(username="usera"))
+        assert res.status_code == 200
+        body = res.json()
+        assert body["username"] == "usera"
+        assert body["follower_count"] == 0
+        assert body["following_count"] == 0
+        assert "password" not in body
+        assert "password_hash" not in body
+
+    def test_unknown_username_returns_404(self, client):
+        assert client.get(PROFILE_URL.format(username="nobody")).status_code == 404
+
+    def test_no_auth_required(self, client):
+        _register(client, USER_A)
+        assert client.get(PROFILE_URL.format(username="usera")).status_code == 200
+
+
+class TestFollow:
+    def test_follow_returns_200_with_counts(self, client):
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        res = client.post(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        assert res.json()["following"] is True
+        assert res.json()["follower_count"] == 1
+
+    def test_follow_is_idempotent(self, client):
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        headers = _auth(a["access_token"])
+        client.post(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=headers)
+        res = client.post(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=headers)
+        assert res.status_code == 200
+        assert res.json()["follower_count"] == 1
+
+    def test_follow_updates_profile_counts(self, client):
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        client.post(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=_auth(a["access_token"]))
+        assert client.get(PROFILE_URL.format(username="userb")).json()["follower_count"] == 1
+        assert client.get(PROFILE_URL.format(username="usera")).json()["following_count"] == 1
+
+    def test_self_follow_returns_400(self, client):
+        a = _register(client, USER_A)
+        res = client.post(FOLLOW_URL.format(user_id=a["user"]["id"]), headers=_auth(a["access_token"]))
+        assert res.status_code == 400
+
+    def test_follow_unknown_user_returns_404(self, client):
+        a = _register(client, USER_A)
+        res = client.post(
+            FOLLOW_URL.format(user_id="00000000-0000-0000-0000-000000000000"),
+            headers=_auth(a["access_token"]),
+        )
+        assert res.status_code == 404
+
+    def test_follow_requires_auth(self, client):
+        b = _register(client, USER_B)
+        assert client.post(FOLLOW_URL.format(user_id=b["user"]["id"])).status_code == 401
+
+
+class TestUnfollow:
+    def test_unfollow_returns_200_with_counts(self, client):
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        headers = _auth(a["access_token"])
+        client.post(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=headers)
+        res = client.delete(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=headers)
+        assert res.status_code == 200
+        assert res.json()["following"] is False
+        assert res.json()["follower_count"] == 0
+
+    def test_unfollow_is_idempotent(self, client):
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        res = client.delete(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+
+    def test_self_unfollow_returns_400(self, client):
+        a = _register(client, USER_A)
+        res = client.delete(FOLLOW_URL.format(user_id=a["user"]["id"]), headers=_auth(a["access_token"]))
+        assert res.status_code == 400
+
+    def test_unfollow_requires_auth(self, client):
+        b = _register(client, USER_B)
+        assert client.delete(FOLLOW_URL.format(user_id=b["user"]["id"])).status_code == 401


### PR DESCRIPTION
…23 #39 #40)

- POST/DELETE /users/{user_id}/follow — idempotent follow/unfollow with self-follow guard
- GET /users/{username} — public profile with follower/following counts
- GET /outfits/feed — cursor-paginated feed from followed users
- GET /outfits/me — authenticated personal vault
- GET /outfits/user/{username} — public vault by username
- Added link_url field to clothing items with Alembic migration
- Fixed cursor pagination URL-decoding bug (+ decoded as space in query params)
- Fixed docker-compose.yml port to 5433 to avoid local Postgres conflict
- 52/52 tests passing