### PR TITLE
feat(api): story card image generation endpoint (#53)

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.12-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    fonts-dejavu-core \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY requirements.txt .

--- a/services/api/app/routers/outfits.py
+++ b/services/api/app/routers/outfits.py
@@ -1,6 +1,7 @@
 import json
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
+from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
 from app.crud import follow as follow_crud
@@ -10,6 +11,7 @@ from app.dependencies import get_current_user, get_db
 from app.models.user import User
 from app.schemas.outfit import OutfitMetadata, OutfitOut, VaultPage
 from app.services.storage import InvalidImageError, StorageError, upload_image
+from app.services.story_card import fetch_image, generate_story_card
 from app.services.vibe_check import run_vibe_check
 
 router = APIRouter(prefix="/outfits", tags=["outfits"])
@@ -92,6 +94,49 @@ def my_vault(
     """Current user's own vault, newest first."""
     outfits, next_cursor = outfit_crud.get_user_outfits(db, current_user.id, cursor, limit)
     return VaultPage(outfits=[OutfitOut.model_validate(o) for o in outfits], next_cursor=next_cursor)
+
+
+@router.get("/{outfit_id}/story-card", response_class=Response)
+def story_card(
+    outfit_id: str,
+    db: Session = Depends(get_db),
+) -> Response:
+    """
+    Generate and return a 1080×1920 PNG story card for an outfit.
+    No auth required — designed to be shared publicly.
+    """
+    import uuid as _uuid
+    try:
+        oid = _uuid.UUID(outfit_id)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Outfit not found.")
+
+    outfit = outfit_crud.get_outfit_with_items(db, oid)
+    if not outfit:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Outfit not found.")
+
+    owner = user_crud.get_by_id(db, outfit.user_id)
+    username = owner.username or str(outfit.user_id) if owner else str(outfit.user_id)
+
+    try:
+        image_bytes = fetch_image(outfit.image_url)
+    except Exception:
+        image_bytes = b""
+
+    png_bytes = generate_story_card(
+        image_bytes=image_bytes,
+        username=username,
+        caption=outfit.caption,
+        vibe_check_text=outfit.vibe_check_text,
+        vibe_check_tone=outfit.vibe_check_tone,
+        worn_on=outfit.worn_on,
+    )
+
+    return Response(
+        content=png_bytes,
+        media_type="image/png",
+        headers={"Content-Disposition": f'inline; filename="ootd-{outfit_id[:8]}.png"'},
+    )
 
 
 @router.get("/user/{username}", response_model=VaultPage)

--- a/services/api/app/services/story_card.py
+++ b/services/api/app/services/story_card.py
@@ -1,0 +1,209 @@
+"""
+Story card generator — produces a 1080×1920 PNG shareable card for an outfit.
+
+Single responsibility: take outfit data + raw image bytes, return PNG bytes.
+Everything Pillow-specific is contained here.
+
+Layout (Instagram story format, 1080×1920):
+  ┌──────────────────────────────────┐
+  │                                  │
+  │         OUTFIT IMAGE             │  top 65%
+  │          (cover fit)             │
+  │                                  │
+  │        ↓ gradient fade           │
+  ├──────────────────────────────────┤
+  │  [tone badge]                    │
+  │                                  │
+  │  vibe check text                 │  bottom 35%
+  │                                  │
+  │  @username                       │
+  │  "caption"                       │
+  │  April 17, 2026                  │
+  │                          OOTD ✦  │
+  └──────────────────────────────────┘
+
+Usage:
+    from app.services.story_card import generate_story_card
+
+    png_bytes = generate_story_card(
+        image_bytes=...,
+        username="usera",
+        caption="Sunday brunch fit",
+        vibe_check_text="Effortlessly cool.",
+        vibe_check_tone="streetwear",
+        worn_on=date(2026, 4, 17),
+    )
+"""
+
+import io
+import textwrap
+import urllib.request
+from datetime import date
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFilter, ImageFont
+
+# ── Card dimensions (Instagram story) ────────────────────────────────────────
+CARD_W = 1080
+CARD_H = 1920
+IMAGE_H = int(CARD_H * 0.65)       # 1248px — outfit photo area
+BOTTOM_Y = IMAGE_H                  # where the dark panel starts
+GRADIENT_H = 220                    # fade zone between photo and panel
+
+# ── Colours ───────────────────────────────────────────────────────────────────
+BG_DARK = (13, 15, 20)             # near-black background
+TEXT_PRIMARY = (242, 242, 242)
+TEXT_SECONDARY = (148, 163, 184)   # slate-400
+BRAND_COLOUR = (129, 140, 248)     # indigo-400
+
+TONE_COLOURS: dict[str, tuple[int, int, int]] = {
+    "casual":      (96, 165, 250),   # blue
+    "formal":      (251, 191, 36),   # amber
+    "streetwear":  (251, 113, 133),  # rose
+    "preppy":      (74, 222, 128),   # green
+    "boho":        (196, 132, 252),  # violet
+    "athletic":    (34, 211, 238),   # cyan
+    "vintage":     (251, 146, 60),   # orange
+    "minimalist":  (203, 213, 225),  # slate-300
+    "maximalist":  (244, 114, 182),  # pink
+    "business":    (147, 197, 253),  # blue-300
+}
+
+# ── Font paths (DejaVu ships with fonts-dejavu-core on Debian/Ubuntu) ─────────
+_FONT_DIR = Path("/usr/share/fonts/truetype/dejavu")
+_FONT_REGULAR = _FONT_DIR / "DejaVuSans.ttf"
+_FONT_BOLD = _FONT_DIR / "DejaVuSans-Bold.ttf"
+
+
+def _font(path: Path, size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    """Load a TrueType font, falling back to PIL's default if unavailable."""
+    try:
+        return ImageFont.truetype(str(path), size)
+    except (OSError, IOError):
+        return ImageFont.load_default()
+
+
+def fetch_image(url: str) -> bytes:
+    """Download image bytes from a URL. Isolated for easy monkeypatching in tests."""
+    with urllib.request.urlopen(url, timeout=10) as resp:  # noqa: S310
+        return resp.read()
+
+
+def generate_story_card(
+    image_bytes: bytes,
+    username: str,
+    caption: str | None = None,
+    vibe_check_text: str | None = None,
+    vibe_check_tone: str | None = None,
+    worn_on: date | None = None,
+) -> bytes:
+    """
+    Render a 1080×1920 story card PNG and return raw bytes.
+
+    Args:
+        image_bytes:     Raw bytes of the outfit photo.
+        username:        The outfit owner's username (displayed as @username).
+        caption:         Optional outfit caption.
+        vibe_check_text: Optional AI-generated vibe sentence.
+        vibe_check_tone: Optional tone label (e.g. "streetwear").
+        worn_on:         Optional date the outfit was worn.
+
+    Returns:
+        PNG bytes ready to stream as image/png.
+    """
+    card = Image.new("RGB", (CARD_W, CARD_H), BG_DARK)
+
+    # ── 1. Outfit photo (cover-fit into the top 65%) ──────────────────────────
+    try:
+        outfit_img = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+        outfit_img = _cover_fit(outfit_img, CARD_W, IMAGE_H)
+        card.paste(outfit_img, (0, 0))
+    except Exception:
+        pass  # leave dark bg if image is broken
+
+    # ── 2. Gradient overlay (photo → dark panel) ──────────────────────────────
+    _apply_gradient(card, BOTTOM_Y - GRADIENT_H, GRADIENT_H)
+
+    # ── 3. Bottom panel text ──────────────────────────────────────────────────
+    draw = ImageDraw.Draw(card)
+    y = BOTTOM_Y + 48
+
+    # Tone badge
+    if vibe_check_tone:
+        badge_colour = TONE_COLOURS.get(vibe_check_tone.lower(), TEXT_SECONDARY)
+        badge_font = _font(_FONT_BOLD, 32)
+        badge_text = f"  {vibe_check_tone.upper()}  "
+        bbox = draw.textbbox((0, 0), badge_text, font=badge_font)
+        bw, bh = bbox[2] - bbox[0], bbox[3] - bbox[1]
+        pad = 12
+        rx0, ry0 = 64, y
+        rx1, ry1 = rx0 + bw + pad * 2, y + bh + pad * 2
+        draw.rounded_rectangle([rx0, ry0, rx1, ry1], radius=8, fill=(*badge_colour, 40))
+        draw.rounded_rectangle([rx0, ry0, rx1, ry1], radius=8, outline=badge_colour, width=2)
+        draw.text((rx0 + pad, ry0 + pad), badge_text.strip(), font=badge_font, fill=badge_colour)
+        y = ry1 + 36
+
+    # Vibe check text
+    if vibe_check_text:
+        vibe_font = _font(_FONT_REGULAR, 42)
+        wrapped = textwrap.fill(vibe_check_text, width=32)
+        draw.text((64, y), wrapped, font=vibe_font, fill=TEXT_PRIMARY)
+        line_count = wrapped.count("\n") + 1
+        y += line_count * 52 + 40
+
+    # Divider line
+    draw.line([(64, y), (CARD_W - 64, y)], fill=(255, 255, 255, 25), width=1)
+    y += 36
+
+    # @username
+    user_font = _font(_FONT_BOLD, 44)
+    draw.text((64, y), f"@{username}", font=user_font, fill=TEXT_PRIMARY)
+    y += 62
+
+    # Caption
+    if caption:
+        cap_font = _font(_FONT_REGULAR, 38)
+        wrapped_cap = textwrap.fill(caption, width=36)
+        draw.text((64, y), wrapped_cap, font=cap_font, fill=TEXT_SECONDARY)
+        y += (wrapped_cap.count("\n") + 1) * 48 + 12
+
+    # Date worn
+    if worn_on:
+        date_font = _font(_FONT_REGULAR, 34)
+        date_str = worn_on.strftime("%B %-d, %Y")
+        draw.text((64, y), date_str, font=date_font, fill=TEXT_SECONDARY)
+
+    # ── 4. OOTD branding (bottom-right) ───────────────────────────────────────
+    brand_font = _font(_FONT_BOLD, 38)
+    brand_text = "OOTD ✦"
+    bbox = draw.textbbox((0, 0), brand_text, font=brand_font)
+    bw = bbox[2] - bbox[0]
+    draw.text((CARD_W - 64 - bw, CARD_H - 72), brand_text, font=brand_font, fill=BRAND_COLOUR)
+
+    # ── 5. Encode to PNG bytes ────────────────────────────────────────────────
+    buf = io.BytesIO()
+    card.save(buf, format="PNG", optimize=True)
+    return buf.getvalue()
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _cover_fit(img: Image.Image, target_w: int, target_h: int) -> Image.Image:
+    """Scale and centre-crop the image to fill target_w × target_h (cover fit)."""
+    src_w, src_h = img.size
+    scale = max(target_w / src_w, target_h / src_h)
+    new_w = int(src_w * scale)
+    new_h = int(src_h * scale)
+    img = img.resize((new_w, new_h), Image.LANCZOS)
+    left = (new_w - target_w) // 2
+    top = (new_h - target_h) // 2
+    return img.crop((left, top, left + target_w, top + target_h))
+
+
+def _apply_gradient(card: Image.Image, start_y: int, height: int) -> None:
+    """Paint a vertical gradient from transparent to BG_DARK over the card."""
+    draw = ImageDraw.Draw(card)
+    for i in range(height):
+        alpha = int(255 * (i / height) ** 1.5)   # accelerating fade
+        r, g, b = BG_DARK
+        draw.line([(0, start_y + i), (CARD_W, start_y + i)], fill=(r, g, b, alpha))

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -10,3 +10,4 @@ bcrypt==4.2.1
 python-multipart==0.0.20
 boto3==1.35.99
 anthropic==0.40.0
+Pillow==11.1.0

--- a/services/api/tests/test_story_card.py
+++ b/services/api/tests/test_story_card.py
@@ -1,0 +1,105 @@
+"""Tests for GET /outfits/{outfit_id}/story-card."""
+
+import io
+import uuid
+
+REGISTER_URL = "/auth/register"
+CREATE_OUTFIT_URL = "/outfits"
+STORY_CARD_URL = "/outfits/{outfit_id}/story-card"
+
+USER_A = {"username": "usera", "email": "a@example.com", "password": "password123"}
+
+
+def _register(client, payload):
+    res = client.post(REGISTER_URL, json=payload)
+    assert res.status_code == 201
+    return res.json()
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _post_outfit(client, token, caption="test outfit"):
+    fake_image = io.BytesIO(b"fake-image-data")
+    return client.post(
+        CREATE_OUTFIT_URL,
+        headers=_auth(token),
+        files={"image": ("test.jpg", fake_image, "image/jpeg")},
+        data={"metadata": f'{{"caption": "{caption}"}}'},
+    )
+
+
+def _fake_fetch(url: str) -> bytes:
+    """Returns a tiny but valid JPEG so Pillow can open it."""
+    # 1×1 white JPEG
+    img_buf = io.BytesIO()
+    from PIL import Image
+    Image.new("RGB", (1, 1), (255, 255, 255)).save(img_buf, format="JPEG")
+    return img_buf.getvalue()
+
+
+class TestStoryCard:
+    def test_returns_png_for_existing_outfit(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
+        monkeypatch.setattr("app.routers.outfits.run_vibe_check", lambda **kw: ("Cool fit!", "casual"))
+        monkeypatch.setattr("app.routers.outfits.fetch_image", _fake_fetch)
+
+        a = _register(client, USER_A)
+        outfit_res = _post_outfit(client, a["access_token"], "brunch fit")
+        outfit_id = outfit_res.json()["id"]
+
+        res = client.get(STORY_CARD_URL.format(outfit_id=outfit_id))
+        assert res.status_code == 200
+        assert res.headers["content-type"] == "image/png"
+        # PNG files start with the PNG signature bytes
+        assert res.content[:4] == b"\x89PNG"
+
+    def test_no_auth_required(self, client, monkeypatch):
+        """Story card endpoint is public — no token needed."""
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
+        monkeypatch.setattr("app.routers.outfits.run_vibe_check", lambda **kw: (None, None))
+        monkeypatch.setattr("app.routers.outfits.fetch_image", _fake_fetch)
+
+        a = _register(client, USER_A)
+        outfit_res = _post_outfit(client, a["access_token"])
+        outfit_id = outfit_res.json()["id"]
+
+        # No auth header
+        res = client.get(STORY_CARD_URL.format(outfit_id=outfit_id))
+        assert res.status_code == 200
+
+    def test_unknown_outfit_returns_404(self, client):
+        res = client.get(STORY_CARD_URL.format(outfit_id=str(uuid.uuid4())))
+        assert res.status_code == 404
+
+    def test_invalid_uuid_returns_404(self, client):
+        res = client.get(STORY_CARD_URL.format(outfit_id="not-a-uuid"))
+        assert res.status_code == 404
+
+    def test_card_still_generated_when_image_fetch_fails(self, client, monkeypatch):
+        """If the S3 image can't be fetched, card is still returned (dark bg)."""
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
+        monkeypatch.setattr("app.routers.outfits.run_vibe_check", lambda **kw: ("Great fit!", "streetwear"))
+        monkeypatch.setattr("app.routers.outfits.fetch_image", lambda url: (_ for _ in ()).throw(Exception("network error")))
+
+        a = _register(client, USER_A)
+        outfit_res = _post_outfit(client, a["access_token"], "risky fit")
+        outfit_id = outfit_res.json()["id"]
+
+        res = client.get(STORY_CARD_URL.format(outfit_id=outfit_id))
+        assert res.status_code == 200
+        assert res.content[:4] == b"\x89PNG"
+
+    def test_content_disposition_header(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
+        monkeypatch.setattr("app.routers.outfits.run_vibe_check", lambda **kw: (None, None))
+        monkeypatch.setattr("app.routers.outfits.fetch_image", _fake_fetch)
+
+        a = _register(client, USER_A)
+        outfit_res = _post_outfit(client, a["access_token"])
+        outfit_id = outfit_res.json()["id"]
+
+        res = client.get(STORY_CARD_URL.format(outfit_id=outfit_id))
+        assert "content-disposition" in res.headers
+        assert "ootd-" in res.headers["content-disposition"]


### PR DESCRIPTION
- New service app/services/story_card.py — generates a 1080×1920 PNG story card (Instagram story format) using Pillow
- GET /outfits/{outfit_id}/story-card — no auth required, publicly shareable
- Card layout: outfit photo (cover-fit, top 65%) → gradient fade → dark panel with tone badge, vibe check text, @username, caption, date, OOTD branding
- 10 tone badge colours matching vibe check tones (casual, streetwear, etc.)
- Best-effort image fetch: if S3 URL unreachable, card renders with dark bg
- 404 on unknown outfit or invalid UUID
- Added Pillow==11.1.0 to requirements.txt
- Added fonts-dejavu-core to Dockerfile (required for TrueType rendering)
- 62/62 tests passing (6 new story card tests)