### PR TITLE
feat(api): edit profile, avatar upload, user search, suggested users

### DIFF
--- a/services/api/app/crud/user.py
+++ b/services/api/app/crud/user.py
@@ -1,8 +1,11 @@
 import uuid
 
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
 
 from app.models.user import User
+
+_UNSET = object()  # sentinel for "caller did not pass this field"
 
 
 def get_by_email(db: Session, email: str) -> User | None:
@@ -27,3 +30,107 @@ def create_user(db: Session, username: str, email: str, password_hash: str) -> U
     db.commit()
     db.refresh(user)
     return user
+
+
+def update_profile(
+    db: Session,
+    user: User,
+    display_name: object = _UNSET,
+    bio: object = _UNSET,
+    username: object = _UNSET,
+) -> User:
+    """
+    Partial update — only fields explicitly passed are written.
+    Caller is responsible for checking username uniqueness before calling.
+    """
+    if display_name is not _UNSET:
+        user.display_name = display_name  # type: ignore[assignment]
+    if bio is not _UNSET:
+        user.bio = bio  # type: ignore[assignment]
+    if username is not _UNSET:
+        user.username = username  # type: ignore[assignment]
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def set_avatar(db: Session, user: User, url: str) -> User:
+    """Store the S3 URL for the user's profile photo."""
+    user.profile_image_url = url
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def search(db: Session, q: str, limit: int = 20) -> list[User]:
+    """Case-insensitive substring search on username and display_name."""
+    term = f"%{q.lower()}%"
+    return (
+        db.query(User)
+        .filter(
+            or_(
+                func.lower(User.username).like(term),
+                func.lower(User.display_name).like(term),
+            )
+        )
+        .order_by(User.username)
+        .limit(limit)
+        .all()
+    )
+
+
+def suggested(
+    db: Session,
+    current_user_id: uuid.UUID,
+    limit: int = 10,
+) -> list[User]:
+    """
+    Suggested users to follow.
+    Strategy: friends-of-friends first, padded with most-followed globally.
+    Excludes the current user and anyone already followed.
+    """
+    from app.models.follow import Follow
+
+    # IDs the current user already follows
+    already_following_sq = (
+        db.query(Follow.following_id)
+        .filter(Follow.follower_id == current_user_id)
+        .subquery()
+    )
+
+    # Friends of friends
+    fof_sq = (
+        db.query(Follow.following_id)
+        .filter(Follow.follower_id.in_(already_following_sq.select()))
+        .filter(Follow.following_id != current_user_id)
+        .filter(Follow.following_id.notin_(already_following_sq.select()))
+        .subquery()
+    )
+
+    candidates = (
+        db.query(User)
+        .filter(User.id.in_(fof_sq.select()))
+        .limit(limit)
+        .all()
+    )
+
+    # Pad with globally popular users if not enough
+    if len(candidates) < limit:
+        exclude_ids = (
+            {u.id for u in candidates}
+            | {current_user_id}
+            | {row[0] for row in db.query(Follow.following_id)
+               .filter(Follow.follower_id == current_user_id).all()}
+        )
+        popular = (
+            db.query(User)
+            .filter(User.id.notin_(exclude_ids))
+            .outerjoin(Follow, Follow.following_id == User.id)
+            .group_by(User.id)
+            .order_by(func.count(Follow.follower_id).desc())
+            .limit(limit - len(candidates))
+            .all()
+        )
+        candidates += popular
+
+    return candidates

--- a/services/api/app/routers/users.py
+++ b/services/api/app/routers/users.py
@@ -1,6 +1,6 @@
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
 from sqlalchemy.orm import Session
 
 from app.crud import follow as follow_crud
@@ -9,10 +9,87 @@ from app.crud import wrapped as wrapped_crud
 from app.dependencies import get_current_user, get_db
 from app.models.user import User
 from app.schemas.outfit import OutfitOut
-from app.schemas.user import FollowResponse, PublicProfile
+from app.schemas.user import FollowResponse, PublicProfile, SearchResult, UpdateProfileRequest
 from app.schemas.wrapped import WrappedStats
+from app.services.storage import InvalidImageError, StorageError, upload_image
 
 router = APIRouter(prefix="/users", tags=["users"])
+
+
+# ── /me routes (must come before /{username} to avoid capture) ───────────────
+
+@router.patch("/me", response_model=PublicProfile)
+def update_profile(
+    body: UpdateProfileRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> PublicProfile:
+    """
+    Partial profile update — only fields included in the request body are changed.
+    Omit a field entirely to leave it unchanged.
+    """
+    # Check username uniqueness if caller wants to change it
+    if body.username is not None and body.username != current_user.username:
+        if user_crud.get_by_username(db, body.username):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Username already taken.",
+            )
+
+    from app.crud.user import _UNSET
+    user = user_crud.update_profile(
+        db,
+        current_user,
+        display_name=body.display_name if body.display_name is not None else _UNSET,
+        bio=body.bio if body.bio is not None else _UNSET,
+        username=body.username if body.username is not None else _UNSET,
+    )
+    return PublicProfile(
+        id=user.id,
+        username=user.username,
+        display_name=user.display_name,
+        bio=user.bio,
+        profile_image_url=user.profile_image_url,
+        follower_count=follow_crud.follower_count(db, user.id),
+        following_count=follow_crud.following_count(db, user.id),
+        created_at=user.created_at,
+    )
+
+
+@router.post("/me/avatar", response_model=PublicProfile)
+def upload_avatar(
+    image: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> PublicProfile:
+    """
+    Upload or replace the current user's profile photo.
+    Accepts JPEG, PNG, WebP, HEIC — max 10 MB.
+    """
+    try:
+        file_bytes = image.file.read()
+        url = upload_image(
+            file_bytes=file_bytes,
+            content_type=image.content_type or "",
+            user_id=current_user.id,
+            key_prefix="avatars",
+        )
+    except InvalidImageError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
+    except StorageError as exc:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc))
+
+    user = user_crud.set_avatar(db, current_user, url)
+    return PublicProfile(
+        id=user.id,
+        username=user.username,
+        display_name=user.display_name,
+        bio=user.bio,
+        profile_image_url=user.profile_image_url,
+        follower_count=follow_crud.follower_count(db, user.id),
+        following_count=follow_crud.following_count(db, user.id),
+        created_at=user.created_at,
+    )
 
 
 @router.get("/me/wrapped", response_model=WrappedStats)
@@ -21,13 +98,7 @@ def get_wrapped(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> WrappedStats:
-    """
-    Monthly Fits Wrapped — stats for the current user's outfits in a given month.
-
-    Returns totals, top colors/brands/category, vibe of the month, most active
-    day of the week, longest consecutive streak, and the standout outfit.
-    All fields gracefully degrade to None / [] when there is no data.
-    """
+    """Monthly Fits Wrapped — stats for the current user's outfits in a given month."""
     try:
         year_str, mon_str = month.split("-")
         year, mon = int(year_str), int(mon_str)
@@ -38,11 +109,58 @@ def get_wrapped(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="month must be in YYYY-MM format (e.g. 2026-04).",
         )
-
     stats = wrapped_crud.get_wrapped_stats(db, current_user.id, year, mon)
     top_outfit_out = OutfitOut.model_validate(stats["top_outfit"]) if stats["top_outfit"] else None
     return WrappedStats(**{**stats, "top_outfit": top_outfit_out})
 
+
+@router.get("/search", response_model=list[SearchResult])
+def search_users(
+    q: str = Query(..., min_length=1, max_length=50, description="Search term"),
+    limit: int = Query(default=20, ge=1, le=50),
+    db: Session = Depends(get_db),
+) -> list[SearchResult]:
+    """
+    Search users by username or display name. No auth required.
+    Returns up to `limit` results ordered alphabetically by username.
+    """
+    users = user_crud.search(db, q.strip(), limit)
+    return [
+        SearchResult(
+            id=u.id,
+            username=u.username,
+            display_name=u.display_name,
+            profile_image_url=u.profile_image_url,
+            follower_count=follow_crud.follower_count(db, u.id),
+        )
+        for u in users
+    ]
+
+
+@router.get("/suggested", response_model=list[SearchResult])
+def suggested_users(
+    limit: int = Query(default=10, ge=1, le=20),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[SearchResult]:
+    """
+    Suggested users to follow — friends of friends first, then most-followed globally.
+    Excludes users already followed and the current user.
+    """
+    users = user_crud.suggested(db, current_user.id, limit)
+    return [
+        SearchResult(
+            id=u.id,
+            username=u.username,
+            display_name=u.display_name,
+            profile_image_url=u.profile_image_url,
+            follower_count=follow_crud.follower_count(db, u.id),
+        )
+        for u in users
+    ]
+
+
+# ── /{username} and /{user_id} routes ────────────────────────────────────────
 
 @router.get("/{username}", response_model=PublicProfile)
 def get_profile(username: str, db: Session = Depends(get_db)) -> PublicProfile:

--- a/services/api/app/schemas/user.py
+++ b/services/api/app/schemas/user.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
 
 
 class PublicProfile(BaseModel):
@@ -20,3 +20,32 @@ class PublicProfile(BaseModel):
 class FollowResponse(BaseModel):
     following: bool
     follower_count: int
+
+
+class UpdateProfileRequest(BaseModel):
+    """All fields are optional — only provided fields are updated (PATCH semantics)."""
+
+    display_name: str | None = Field(default=None, max_length=64)
+    bio: str | None = Field(default=None, max_length=160)
+    username: str | None = Field(default=None, min_length=2, max_length=30)
+
+    @field_validator("username")
+    @classmethod
+    def username_format(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        if not v.replace("_", "").replace(".", "").isalnum():
+            raise ValueError("Username may only contain letters, numbers, underscores, and dots.")
+        return v.lower()
+
+
+class SearchResult(BaseModel):
+    """Slim profile returned by search and suggested-users endpoints."""
+
+    id: uuid.UUID
+    username: str | None
+    display_name: str | None
+    profile_image_url: str | None
+    follower_count: int
+
+    model_config = {"from_attributes": True}

--- a/services/api/app/services/storage.py
+++ b/services/api/app/services/storage.py
@@ -48,6 +48,7 @@ def upload_image(
     file_bytes: bytes,
     content_type: str,
     user_id: uuid.UUID,
+    key_prefix: str = "outfits",
 ) -> str:
     """
     Upload an image to S3 and return its public URL.
@@ -56,6 +57,7 @@ def upload_image(
         file_bytes:   Raw file content read from the multipart upload.
         content_type: MIME type declared by the client (e.g. "image/jpeg").
         user_id:      ID of the uploading user — used to namespace the S3 key.
+        key_prefix:   S3 key prefix folder (default "outfits", use "avatars" for profile photos).
 
     Returns:
         The public HTTPS URL of the uploaded object.
@@ -67,7 +69,7 @@ def upload_image(
     _validate(file_bytes, content_type)
 
     ext = _ALLOWED[content_type]
-    key = f"outfits/{user_id}/{uuid.uuid4()}.{ext}"
+    key = f"{key_prefix}/{user_id}/{uuid.uuid4()}.{ext}"
 
     try:
         client = _s3_client()

--- a/services/api/tests/test_profile.py
+++ b/services/api/tests/test_profile.py
@@ -1,0 +1,179 @@
+"""Tests for PATCH /users/me, POST /users/me/avatar, GET /users/search, GET /users/suggested."""
+
+import io
+
+REGISTER_URL = "/auth/register"
+UPDATE_PROFILE_URL = "/users/me"
+UPLOAD_AVATAR_URL = "/users/me/avatar"
+SEARCH_URL = "/users/search"
+SUGGESTED_URL = "/users/suggested"
+FOLLOW_URL = "/users/{user_id}/follow"
+
+USER_A = {"username": "usera", "email": "a@example.com", "password": "password123"}
+USER_B = {"username": "userb", "email": "b@example.com", "password": "password123"}
+USER_C = {"username": "userc", "email": "c@example.com", "password": "password123"}
+
+
+def _register(client, payload):
+    res = client.post(REGISTER_URL, json=payload)
+    assert res.status_code == 201
+    return res.json()
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── PATCH /users/me ───────────────────────────────────────────────────────────
+
+class TestUpdateProfile:
+    def test_update_display_name(self, client):
+        a = _register(client, USER_A)
+        res = client.patch(UPDATE_PROFILE_URL, json={"display_name": "Reagan B"}, headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        assert res.json()["display_name"] == "Reagan B"
+
+    def test_update_bio(self, client):
+        a = _register(client, USER_A)
+        res = client.patch(UPDATE_PROFILE_URL, json={"bio": "living in fits 🤍"}, headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        assert res.json()["bio"] == "living in fits 🤍"
+
+    def test_update_username(self, client):
+        a = _register(client, USER_A)
+        res = client.patch(UPDATE_PROFILE_URL, json={"username": "reagan_b"}, headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        assert res.json()["username"] == "reagan_b"
+
+    def test_partial_update_leaves_other_fields_unchanged(self, client):
+        a = _register(client, USER_A)
+        client.patch(UPDATE_PROFILE_URL, json={"bio": "first bio"}, headers=_auth(a["access_token"]))
+        res = client.patch(UPDATE_PROFILE_URL, json={"display_name": "New Name"}, headers=_auth(a["access_token"]))
+        assert res.json()["bio"] == "first bio"
+        assert res.json()["display_name"] == "New Name"
+
+    def test_duplicate_username_returns_409(self, client):
+        a = _register(client, USER_A)
+        _register(client, USER_B)
+        res = client.patch(UPDATE_PROFILE_URL, json={"username": "userb"}, headers=_auth(a["access_token"]))
+        assert res.status_code == 409
+
+    def test_invalid_username_format_returns_422(self, client):
+        a = _register(client, USER_A)
+        res = client.patch(UPDATE_PROFILE_URL, json={"username": "bad username!"}, headers=_auth(a["access_token"]))
+        assert res.status_code == 422
+
+    def test_requires_auth(self, client):
+        assert client.patch(UPDATE_PROFILE_URL, json={"bio": "test"}).status_code == 401
+
+    def test_bio_max_length(self, client):
+        a = _register(client, USER_A)
+        res = client.patch(UPDATE_PROFILE_URL, json={"bio": "x" * 161}, headers=_auth(a["access_token"]))
+        assert res.status_code == 422
+
+    def test_returns_follower_counts(self, client):
+        a = _register(client, USER_A)
+        res = client.patch(UPDATE_PROFILE_URL, json={"display_name": "Test"}, headers=_auth(a["access_token"]))
+        assert "follower_count" in res.json()
+        assert "following_count" in res.json()
+
+
+# ── POST /users/me/avatar ─────────────────────────────────────────────────────
+
+class TestUploadAvatar:
+    def test_avatar_sets_profile_image_url(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "app.routers.users.upload_image",
+            lambda **kw: "https://s3.example.com/avatars/test.jpg",
+        )
+        a = _register(client, USER_A)
+        fake = io.BytesIO(b"fake-image")
+        res = client.post(
+            UPLOAD_AVATAR_URL,
+            headers=_auth(a["access_token"]),
+            files={"image": ("avatar.jpg", fake, "image/jpeg")},
+        )
+        assert res.status_code == 200
+        assert res.json()["profile_image_url"] == "https://s3.example.com/avatars/test.jpg"
+
+    def test_avatar_requires_auth(self, client):
+        fake = io.BytesIO(b"fake-image")
+        res = client.post(UPLOAD_AVATAR_URL, files={"image": ("avatar.jpg", fake, "image/jpeg")})
+        assert res.status_code == 401
+
+
+# ── GET /users/search ─────────────────────────────────────────────────────────
+
+class TestSearchUsers:
+    def test_finds_by_username(self, client):
+        _register(client, USER_A)
+        res = client.get(SEARCH_URL, params={"q": "usera"})
+        assert res.status_code == 200
+        assert any(u["username"] == "usera" for u in res.json())
+
+    def test_finds_by_display_name(self, client):
+        a = _register(client, USER_A)
+        client.patch(UPDATE_PROFILE_URL, json={"display_name": "Reagan Bourne"}, headers=_auth(a["access_token"]))
+        res = client.get(SEARCH_URL, params={"q": "reagan"})
+        assert any(u["display_name"] == "Reagan Bourne" for u in res.json())
+
+    def test_case_insensitive(self, client):
+        _register(client, USER_A)
+        res = client.get(SEARCH_URL, params={"q": "USERA"})
+        assert any(u["username"] == "usera" for u in res.json())
+
+    def test_no_results_returns_empty_list(self, client):
+        _register(client, USER_A)
+        res = client.get(SEARCH_URL, params={"q": "zzznomatch"})
+        assert res.status_code == 200
+        assert res.json() == []
+
+    def test_no_auth_required(self, client):
+        _register(client, USER_A)
+        assert client.get(SEARCH_URL, params={"q": "user"}).status_code == 200
+
+    def test_returns_follower_count(self, client):
+        _register(client, USER_A)
+        res = client.get(SEARCH_URL, params={"q": "usera"})
+        assert "follower_count" in res.json()[0]
+
+    def test_empty_query_returns_422(self, client):
+        assert client.get(SEARCH_URL, params={"q": ""}).status_code == 422
+
+
+# ── GET /users/suggested ──────────────────────────────────────────────────────
+
+class TestSuggestedUsers:
+    def test_requires_auth(self, client):
+        assert client.get(SUGGESTED_URL).status_code == 401
+
+    def test_excludes_self(self, client):
+        a = _register(client, USER_A)
+        res = client.get(SUGGESTED_URL, headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        assert not any(u["username"] == "usera" for u in res.json())
+
+    def test_excludes_already_followed(self, client):
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        client.post(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=_auth(a["access_token"]))
+        res = client.get(SUGGESTED_URL, headers=_auth(a["access_token"]))
+        assert not any(u["username"] == "userb" for u in res.json())
+
+    def test_returns_users_when_population_exists(self, client):
+        a = _register(client, USER_A)
+        _register(client, USER_B)
+        _register(client, USER_C)
+        res = client.get(SUGGESTED_URL, headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        assert len(res.json()) >= 1
+
+    def test_friends_of_friends_appear(self, client):
+        """A follows B, B follows C — C should appear in A's suggestions."""
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        c = _register(client, USER_C)
+        client.post(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=_auth(a["access_token"]))
+        client.post(FOLLOW_URL.format(user_id=c["user"]["id"]), headers=_auth(b["access_token"]))
+        res = client.get(SUGGESTED_URL, headers=_auth(a["access_token"]))
+        assert any(u["username"] == "userc" for u in res.json())


### PR DESCRIPTION
- PATCH /users/me — partial profile update (display_name, bio, username). Sentinel pattern ensures omitted fields are never overwritten. 409 on duplicate username, 422 on invalid format or bio > 160 chars.
- POST /users/me/avatar — upload profile photo to S3 (avatars/ prefix). Reuses existing upload_image service with new key_prefix param.
- GET /users/search?q= — case-insensitive substring search on username and display_name, no auth required, returns SearchResult list.
- GET /users/suggested — friends-of-friends first, padded with most- followed globally. Excludes current user and already-followed users.
- New schemas: UpdateProfileRequest (validated PATCH body), SearchResult (slim profile for search + suggested responses).
- storage.upload_image now accepts key_prefix param (default 'outfits').
- Closes #76 (user search), #77 (suggested users)
- 96/96 tests passing (23 new profile tests)