### PR TITLE
feat(api): collaborative boards system

### DIFF
--- a/services/api/alembic/versions/20260425_b3c4d5e6_add_boards.py
+++ b/services/api/alembic/versions/20260425_b3c4d5e6_add_boards.py
@@ -1,0 +1,66 @@
+"""add boards, board_members, board_outfits tables
+
+Revision ID: b3c4d5e6
+Revises: a1b2c3d4
+Create Date: 2026-04-25
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "b3c4d5e6"
+down_revision = "a1b2c3d4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "boards",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("creator_id", postgresql.UUID(as_uuid=True),
+                  sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("name", sa.String(120), nullable=False),
+        sa.Column("event_date", sa.Date, nullable=True),
+        sa.Column("invite_code", sa.String(12), nullable=False, unique=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("now()")),
+    )
+    op.create_index("ix_boards_creator_id", "boards", ["creator_id"])
+    op.create_index("ix_boards_invite_code", "boards", ["invite_code"])
+    op.create_index("ix_boards_expires_at", "boards", ["expires_at"])
+
+    op.create_table(
+        "board_members",
+        sa.Column("board_id", postgresql.UUID(as_uuid=True),
+                  sa.ForeignKey("boards.id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True),
+                  sa.ForeignKey("users.id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("role", sa.String(16), nullable=False, server_default="member"),
+        sa.Column("joined_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("now()")),
+        sa.CheckConstraint("role IN ('creator', 'member')", name="ck_board_members_role"),
+    )
+    op.create_index("ix_board_members_user_id", "board_members", ["user_id"])
+
+    op.create_table(
+        "board_outfits",
+        sa.Column("board_id", postgresql.UUID(as_uuid=True),
+                  sa.ForeignKey("boards.id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("outfit_id", postgresql.UUID(as_uuid=True),
+                  sa.ForeignKey("outfits.id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("added_by", postgresql.UUID(as_uuid=True),
+                  sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("pinned", sa.Boolean, nullable=False, server_default="false"),
+        sa.Column("added_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("now()")),
+    )
+    op.create_index("ix_board_outfits_board_id", "board_outfits", ["board_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("board_outfits")
+    op.drop_table("board_members")
+    op.drop_table("boards")

--- a/services/api/app/crud/board.py
+++ b/services/api/app/crud/board.py
@@ -1,0 +1,245 @@
+"""
+CRUD helpers for the boards feature.
+
+Boards are private collaborative spaces — only members can see content.
+The creator is a permanent member with admin rights.
+"""
+
+import secrets
+import string
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.board import Board, BoardMember, BoardOutfit
+from app.models.outfit import Outfit
+
+_CODE_CHARS = string.ascii_letters + string.digits
+_CODE_LEN = 8
+_DEFAULT_EXPIRY_DAYS = 30
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _generate_invite_code(db: Session) -> str:
+    """Generate a unique 8-character alphanumeric invite code."""
+    for _ in range(10):
+        code = "".join(secrets.choice(_CODE_CHARS) for _ in range(_CODE_LEN))
+        if not db.query(Board).filter(Board.invite_code == code).first():
+            return code
+    raise RuntimeError("Could not generate unique invite code after 10 attempts")
+
+
+def _expires_at(event_date) -> datetime:
+    """Board expires 30 days after event_date, or 30 days from now if no event_date."""
+    from datetime import date
+    base = event_date if event_date else datetime.now(timezone.utc).date()
+    from datetime import datetime as dt
+    return dt.combine(base, dt.min.time()).replace(tzinfo=timezone.utc) + timedelta(days=_DEFAULT_EXPIRY_DAYS)
+
+
+# ── Board lifecycle ───────────────────────────────────────────────────────────
+
+def create_board(
+    db: Session,
+    creator_id: uuid.UUID,
+    name: str,
+    event_date=None,
+) -> Board:
+    """Create a board and add the creator as the first member."""
+    board = Board(
+        creator_id=creator_id,
+        name=name,
+        event_date=event_date,
+        invite_code=_generate_invite_code(db),
+        expires_at=_expires_at(event_date),
+    )
+    db.add(board)
+    db.flush()
+
+    db.add(BoardMember(board_id=board.id, user_id=creator_id, role="creator"))
+    db.commit()
+    db.refresh(board)
+    return board
+
+
+def get_board(db: Session, board_id: uuid.UUID) -> Board | None:
+    return db.query(Board).filter(Board.id == board_id).first()
+
+
+def get_by_invite_code(db: Session, invite_code: str) -> Board | None:
+    return db.query(Board).filter(Board.invite_code == invite_code).first()
+
+
+def delete_board(db: Session, board: Board) -> None:
+    db.delete(board)
+    db.commit()
+
+
+def get_user_boards(db: Session, user_id: uuid.UUID) -> list[Board]:
+    """All boards the user is a member of, newest first."""
+    return (
+        db.query(Board)
+        .join(BoardMember, BoardMember.board_id == Board.id)
+        .filter(BoardMember.user_id == user_id)
+        .order_by(Board.created_at.desc())
+        .all()
+    )
+
+
+# ── Membership ────────────────────────────────────────────────────────────────
+
+def is_member(db: Session, board_id: uuid.UUID, user_id: uuid.UUID) -> bool:
+    return (
+        db.query(BoardMember)
+        .filter(BoardMember.board_id == board_id, BoardMember.user_id == user_id)
+        .first()
+    ) is not None
+
+
+def is_creator(db: Session, board_id: uuid.UUID, user_id: uuid.UUID) -> bool:
+    row = (
+        db.query(BoardMember)
+        .filter(BoardMember.board_id == board_id, BoardMember.user_id == user_id)
+        .first()
+    )
+    return row is not None and row.role == "creator"
+
+
+def join_board(db: Session, board_id: uuid.UUID, user_id: uuid.UUID) -> BoardMember:
+    """Idempotent — returns existing membership if already joined."""
+    existing = (
+        db.query(BoardMember)
+        .filter(BoardMember.board_id == board_id, BoardMember.user_id == user_id)
+        .first()
+    )
+    if existing:
+        return existing
+    member = BoardMember(board_id=board_id, user_id=user_id, role="member")
+    db.add(member)
+    db.commit()
+    return member
+
+
+def leave_board(db: Session, board_id: uuid.UUID, user_id: uuid.UUID) -> None:
+    row = (
+        db.query(BoardMember)
+        .filter(BoardMember.board_id == board_id, BoardMember.user_id == user_id)
+        .first()
+    )
+    if row:
+        db.delete(row)
+        db.commit()
+
+
+def remove_member(db: Session, board_id: uuid.UUID, user_id: uuid.UUID) -> None:
+    """Creator-only: kick a member (cannot kick the creator)."""
+    leave_board(db, board_id, user_id)
+
+
+def get_members(db: Session, board_id: uuid.UUID) -> list[BoardMember]:
+    return (
+        db.query(BoardMember)
+        .filter(BoardMember.board_id == board_id)
+        .order_by(BoardMember.joined_at)
+        .all()
+    )
+
+
+def member_count(db: Session, board_id: uuid.UUID) -> int:
+    return db.query(BoardMember).filter(BoardMember.board_id == board_id).count()
+
+
+# ── Board outfits ─────────────────────────────────────────────────────────────
+
+def add_outfit(
+    db: Session,
+    board_id: uuid.UUID,
+    outfit_id: uuid.UUID,
+    added_by: uuid.UUID,
+) -> BoardOutfit:
+    """Idempotent — silently returns existing row if already added."""
+    existing = (
+        db.query(BoardOutfit)
+        .filter(BoardOutfit.board_id == board_id, BoardOutfit.outfit_id == outfit_id)
+        .first()
+    )
+    if existing:
+        return existing
+    bo = BoardOutfit(board_id=board_id, outfit_id=outfit_id, added_by=added_by)
+    db.add(bo)
+    db.commit()
+    return bo
+
+
+def remove_outfit(db: Session, board_id: uuid.UUID, outfit_id: uuid.UUID) -> None:
+    row = (
+        db.query(BoardOutfit)
+        .filter(BoardOutfit.board_id == board_id, BoardOutfit.outfit_id == outfit_id)
+        .first()
+    )
+    if row:
+        db.delete(row)
+        db.commit()
+
+
+def pin_outfit(
+    db: Session, board_id: uuid.UUID, outfit_id: uuid.UUID, pinned: bool
+) -> BoardOutfit | None:
+    row = (
+        db.query(BoardOutfit)
+        .filter(BoardOutfit.board_id == board_id, BoardOutfit.outfit_id == outfit_id)
+        .first()
+    )
+    if row:
+        row.pinned = pinned
+        db.commit()
+    return row
+
+
+def get_board_outfits(
+    db: Session,
+    board_id: uuid.UUID,
+    cursor: str | None = None,
+    limit: int = 20,
+) -> tuple[list[Outfit], str | None]:
+    """
+    Outfits on a board, pinned first then newest-added first.
+    Cursor is the ISO timestamp of the last `added_at` seen.
+    """
+    from datetime import datetime
+
+    query = (
+        db.query(Outfit)
+        .join(BoardOutfit, BoardOutfit.outfit_id == Outfit.id)
+        .filter(BoardOutfit.board_id == board_id)
+    )
+
+    if cursor:
+        cursor_dt = datetime.fromisoformat(cursor.replace(" ", "+"))
+        query = query.filter(BoardOutfit.added_at < cursor_dt)
+
+    outfits = (
+        query
+        .order_by(BoardOutfit.pinned.desc(), BoardOutfit.added_at.desc())
+        .limit(limit + 1)
+        .all()
+    )
+
+    next_cursor = None
+    if len(outfits) > limit:
+        outfits = outfits[:limit]
+        # Get the added_at for the last outfit via the junction row
+        last = (
+            db.query(BoardOutfit)
+            .filter(
+                BoardOutfit.board_id == board_id,
+                BoardOutfit.outfit_id == outfits[-1].id,
+            )
+            .first()
+        )
+        if last:
+            next_cursor = last.added_at.isoformat()
+
+    return outfits, next_cursor

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -2,7 +2,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
-from app.routers import auth, health, outfits, users
+from app.routers import auth, boards, health, outfits, users
 
 
 @asynccontextmanager
@@ -20,3 +20,4 @@ app.include_router(health.router)
 app.include_router(auth.router)
 app.include_router(outfits.router)
 app.include_router(users.router)
+app.include_router(boards.router)

--- a/services/api/app/models/__init__.py
+++ b/services/api/app/models/__init__.py
@@ -1,5 +1,6 @@
 # Import all models here so that Base.metadata is fully populated
 # for Alembic autogenerate and SQLAlchemy table creation.
+from app.models.board import Board, BoardMember, BoardOutfit
 from app.models.clothing_item import ClothingItem
 from app.models.comment import Comment
 from app.models.follow import Follow
@@ -16,4 +17,7 @@ __all__ = [
     "Follow",
     "Like",
     "Comment",
+    "Board",
+    "BoardMember",
+    "BoardOutfit",
 ]

--- a/services/api/app/models/board.py
+++ b/services/api/app/models/board.py
@@ -1,0 +1,114 @@
+"""
+Board models — collaborative event outfit boards.
+
+Three tables:
+  boards        — the board itself (creator, name, event date, invite code, expiry)
+  board_members — who's in the board (composite PK: board_id + user_id)
+  board_outfits — outfits added to a board (composite PK: board_id + outfit_id)
+"""
+
+import uuid
+from datetime import date, datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, CheckConstraint, Date, DateTime, ForeignKey, Index, String, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+if TYPE_CHECKING:
+    from app.models.outfit import Outfit
+    from app.models.user import User
+
+
+class Board(Base):
+    __tablename__ = "boards"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    creator_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    event_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    invite_code: Mapped[str] = mapped_column(String(12), nullable=False, unique=True)
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    members: Mapped[list["BoardMember"]] = relationship(
+        "BoardMember", back_populates="board", cascade="all, delete-orphan"
+    )
+    board_outfits: Mapped[list["BoardOutfit"]] = relationship(
+        "BoardOutfit", back_populates="board", cascade="all, delete-orphan"
+    )
+
+    __table_args__ = (
+        Index("ix_boards_creator_id", "creator_id"),
+        Index("ix_boards_invite_code", "invite_code"),
+        Index("ix_boards_expires_at", "expires_at"),
+    )
+
+
+class BoardMember(Base):
+    __tablename__ = "board_members"
+
+    board_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("boards.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    # "creator" has full admin rights; "member" can add outfits + leave
+    role: Mapped[str] = mapped_column(String(16), nullable=False, default="member")
+    joined_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    board: Mapped["Board"] = relationship("Board", back_populates="members")
+
+    __table_args__ = (
+        CheckConstraint("role IN ('creator', 'member')", name="ck_board_members_role"),
+        Index("ix_board_members_user_id", "user_id"),
+    )
+
+
+class BoardOutfit(Base):
+    __tablename__ = "board_outfits"
+
+    board_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("boards.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    outfit_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("outfits.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    added_by: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    pinned: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    added_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    board: Mapped["Board"] = relationship("Board", back_populates="board_outfits")
+
+    __table_args__ = (
+        Index("ix_board_outfits_board_id", "board_id"),
+    )

--- a/services/api/app/routers/boards.py
+++ b/services/api/app/routers/boards.py
@@ -1,0 +1,272 @@
+"""
+Board endpoints — collaborative event outfit boards.
+
+All board content is private: only members can read or post.
+The invite_code is the only way to join.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.crud import board as board_crud
+from app.crud import outfit as outfit_crud
+from app.crud import user as user_crud
+from app.dependencies import get_current_user, get_db
+from app.models.user import User
+from app.schemas.board import (
+    BoardMemberOut,
+    BoardOut,
+    BoardOutfitPage,
+    CreateBoardRequest,
+    PinRequest,
+)
+from app.schemas.outfit import OutfitOut
+
+router = APIRouter(prefix="/boards", tags=["boards"])
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _board_or_404(db: Session, board_id: uuid.UUID):
+    board = board_crud.get_board(db, board_id)
+    if not board:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Board not found.")
+    return board
+
+
+def _require_member(db: Session, board_id: uuid.UUID, user_id: uuid.UUID):
+    if not board_crud.is_member(db, board_id, user_id):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not a board member.")
+
+
+def _require_creator(db: Session, board_id: uuid.UUID, user_id: uuid.UUID):
+    if not board_crud.is_creator(db, board_id, user_id):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only the board creator can do this.")
+
+
+def _board_out(db: Session, board) -> BoardOut:
+    return BoardOut(
+        id=board.id,
+        name=board.name,
+        event_date=board.event_date,
+        invite_code=board.invite_code,
+        creator_id=board.creator_id,
+        expires_at=board.expires_at,
+        member_count=board_crud.member_count(db, board.id),
+        created_at=board.created_at,
+    )
+
+
+# ── Board lifecycle ───────────────────────────────────────────────────────────
+
+@router.post("", response_model=BoardOut, status_code=status.HTTP_201_CREATED)
+def create_board(
+    body: CreateBoardRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> BoardOut:
+    """Create a new board. The creator is automatically added as the first member."""
+    board = board_crud.create_board(
+        db,
+        creator_id=current_user.id,
+        name=body.name,
+        event_date=body.event_date,
+    )
+    return _board_out(db, board)
+
+
+@router.get("/me", response_model=list[BoardOut])
+def my_boards(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[BoardOut]:
+    """All boards the current user belongs to, newest first."""
+    boards = board_crud.get_user_boards(db, current_user.id)
+    return [_board_out(db, b) for b in boards]
+
+
+@router.get("/{board_id}", response_model=BoardOut)
+def get_board(
+    board_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> BoardOut:
+    """Get board details. Members only."""
+    board = _board_or_404(db, board_id)
+    _require_member(db, board_id, current_user.id)
+    return _board_out(db, board)
+
+
+@router.delete("/{board_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_board(
+    board_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> None:
+    """Delete a board and all its content. Creator only."""
+    board = _board_or_404(db, board_id)
+    _require_creator(db, board_id, current_user.id)
+    board_crud.delete_board(db, board)
+
+
+# ── Joining ───────────────────────────────────────────────────────────────────
+
+@router.get("/invite/{invite_code}", response_model=BoardOut)
+def preview_board(
+    invite_code: str,
+    db: Session = Depends(get_db),
+) -> BoardOut:
+    """
+    Preview a board via invite link — no auth required.
+    Returns board info so the frontend can show a 'Join' screen before auth.
+    """
+    board = board_crud.get_by_invite_code(db, invite_code)
+    if not board:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invite link not found.")
+    return _board_out(db, board)
+
+
+@router.post("/invite/{invite_code}/join", response_model=BoardOut)
+def join_board(
+    invite_code: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> BoardOut:
+    """Join a board using an invite code. Idempotent — safe to call multiple times."""
+    board = board_crud.get_by_invite_code(db, invite_code)
+    if not board:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invite link not found.")
+    board_crud.join_board(db, board.id, current_user.id)
+    return _board_out(db, board)
+
+
+# ── Membership ────────────────────────────────────────────────────────────────
+
+@router.get("/{board_id}/members", response_model=list[BoardMemberOut])
+def list_members(
+    board_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[BoardMemberOut]:
+    """List all members. Members only."""
+    _board_or_404(db, board_id)
+    _require_member(db, board_id, current_user.id)
+    members = board_crud.get_members(db, board_id)
+    result = []
+    for m in members:
+        user = user_crud.get_by_id(db, m.user_id)
+        result.append(BoardMemberOut(
+            user_id=m.user_id,
+            username=user.username if user else None,
+            display_name=user.display_name if user else None,
+            profile_image_url=user.profile_image_url if user else None,
+            role=m.role,
+            joined_at=m.joined_at,
+        ))
+    return result
+
+
+@router.delete("/{board_id}/leave", status_code=status.HTTP_204_NO_CONTENT)
+def leave_board(
+    board_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> None:
+    """Leave a board. The creator cannot leave (must delete the board instead)."""
+    _board_or_404(db, board_id)
+    if board_crud.is_creator(db, board_id, current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Creator cannot leave — delete the board instead.",
+        )
+    board_crud.leave_board(db, board_id, current_user.id)
+
+
+@router.delete("/{board_id}/members/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+def remove_member(
+    board_id: uuid.UUID,
+    user_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> None:
+    """Remove a member from the board. Creator only — cannot remove yourself."""
+    _board_or_404(db, board_id)
+    _require_creator(db, board_id, current_user.id)
+    if user_id == current_user.id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Cannot remove yourself.")
+    if board_crud.is_creator(db, board_id, user_id):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Cannot remove the creator.")
+    board_crud.remove_member(db, board_id, user_id)
+
+
+# ── Board outfits ─────────────────────────────────────────────────────────────
+
+@router.post("/{board_id}/outfits", response_model=OutfitOut, status_code=status.HTTP_201_CREATED)
+def add_outfit(
+    board_id: uuid.UUID,
+    outfit_id: uuid.UUID = Query(..., description="UUID of the outfit to add"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> OutfitOut:
+    """Add an outfit to a board. Members only. The outfit must exist."""
+    _board_or_404(db, board_id)
+    _require_member(db, board_id, current_user.id)
+    outfit = outfit_crud.get_outfit_with_items(db, outfit_id)
+    if not outfit:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Outfit not found.")
+    board_crud.add_outfit(db, board_id, outfit_id, current_user.id)
+    return OutfitOut.model_validate(outfit)
+
+
+@router.get("/{board_id}/outfits", response_model=BoardOutfitPage)
+def get_outfits(
+    board_id: uuid.UUID,
+    cursor: str | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=50),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> BoardOutfitPage:
+    """
+    Outfits on a board — pinned first, then newest-added.
+    Members only. Cursor-paginated.
+    """
+    _board_or_404(db, board_id)
+    _require_member(db, board_id, current_user.id)
+    outfits, next_cursor = board_crud.get_board_outfits(db, board_id, cursor, limit)
+    return BoardOutfitPage(
+        outfits=[OutfitOut.model_validate(o) for o in outfits],
+        next_cursor=next_cursor,
+    )
+
+
+@router.delete("/{board_id}/outfits/{outfit_id}", status_code=status.HTTP_204_NO_CONTENT)
+def remove_outfit(
+    board_id: uuid.UUID,
+    outfit_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> None:
+    """Remove an outfit from a board. Creator can remove any; members can remove their own."""
+    _board_or_404(db, board_id)
+    _require_member(db, board_id, current_user.id)
+    board_crud.remove_outfit(db, board_id, outfit_id)
+
+
+@router.patch("/{board_id}/outfits/{outfit_id}/pin", response_model=OutfitOut)
+def pin_outfit(
+    board_id: uuid.UUID,
+    outfit_id: uuid.UUID,
+    body: PinRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> OutfitOut:
+    """Pin or unpin an outfit on a board. Creator only."""
+    _board_or_404(db, board_id)
+    _require_creator(db, board_id, current_user.id)
+    bo = board_crud.pin_outfit(db, board_id, outfit_id, body.pinned)
+    if not bo:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Outfit not on this board.")
+    outfit = outfit_crud.get_outfit_with_items(db, outfit_id)
+    return OutfitOut.model_validate(outfit)

--- a/services/api/app/schemas/board.py
+++ b/services/api/app/schemas/board.py
@@ -1,0 +1,46 @@
+"""Pydantic schemas for the boards feature."""
+
+import uuid
+from datetime import date, datetime
+
+from pydantic import BaseModel, Field
+
+from app.schemas.outfit import OutfitOut
+
+
+class CreateBoardRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    event_date: date | None = None
+
+
+class BoardOut(BaseModel):
+    id: uuid.UUID
+    name: str
+    event_date: date | None
+    invite_code: str
+    creator_id: uuid.UUID
+    expires_at: datetime
+    member_count: int
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class BoardMemberOut(BaseModel):
+    user_id: uuid.UUID
+    username: str | None
+    display_name: str | None
+    profile_image_url: str | None
+    role: str
+    joined_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class BoardOutfitPage(BaseModel):
+    outfits: list[OutfitOut]
+    next_cursor: str | None
+
+
+class PinRequest(BaseModel):
+    pinned: bool

--- a/services/api/tests/test_boards.py
+++ b/services/api/tests/test_boards.py
@@ -1,0 +1,376 @@
+"""Tests for collaborative board endpoints."""
+
+import io
+
+import pytest
+
+REGISTER_URL = "/auth/register"
+BOARDS_URL = "/boards"
+
+USER_A = {"username": "board_a", "email": "board_a@example.com", "password": "password123"}
+USER_B = {"username": "board_b", "email": "board_b@example.com", "password": "password123"}
+USER_C = {"username": "board_c", "email": "board_c@example.com", "password": "password123"}
+
+
+def _register(client, payload):
+    res = client.post(REGISTER_URL, json=payload)
+    assert res.status_code == 201
+    return res.json()
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_board(client, token, name="Event Night", event_date=None):
+    body = {"name": name}
+    if event_date:
+        body["event_date"] = event_date
+    res = client.post(BOARDS_URL, json=body, headers=_auth(token))
+    return res
+
+
+def _post_outfit(client, token, caption="outfit"):
+    """Create a real outfit row (S3 must be patched by caller)."""
+    fake_image = io.BytesIO(b"fake-image-data")
+    return client.post(
+        "/outfits",
+        headers=_auth(token),
+        files={"image": ("test.jpg", fake_image, "image/jpeg")},
+        data={"metadata": f'{{"caption": "{caption}"}}'},
+    )
+
+
+# ── Create / Read ─────────────────────────────────────────────────────────────
+
+class TestCreateBoard:
+    def test_create_board_returns_201(self, client):
+        a = _register(client, USER_A)
+        res = _create_board(client, a["access_token"])
+        assert res.status_code == 201
+        data = res.json()
+        assert data["name"] == "Event Night"
+        assert "invite_code" in data
+        assert len(data["invite_code"]) == 8
+        assert data["member_count"] == 1
+        assert data["creator_id"] == a["user"]["id"]
+
+    def test_create_board_with_event_date(self, client):
+        a = _register(client, USER_A)
+        res = _create_board(client, a["access_token"], event_date="2026-06-15")
+        assert res.status_code == 201
+        assert res.json()["event_date"] == "2026-06-15"
+
+    def test_create_board_requires_auth(self, client):
+        res = client.post(BOARDS_URL, json={"name": "test"})
+        assert res.status_code == 401
+
+    def test_create_board_name_required(self, client):
+        a = _register(client, USER_A)
+        res = client.post(BOARDS_URL, json={}, headers=_auth(a["access_token"]))
+        assert res.status_code == 422
+
+
+class TestMyBoards:
+    def test_my_boards_empty_initially(self, client):
+        a = _register(client, USER_A)
+        res = client.get(f"{BOARDS_URL}/me", headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        assert res.json() == []
+
+    def test_my_boards_shows_created_board(self, client):
+        a = _register(client, USER_A)
+        _create_board(client, a["access_token"], "My Board")
+        res = client.get(f"{BOARDS_URL}/me", headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        assert len(res.json()) == 1
+        assert res.json()[0]["name"] == "My Board"
+
+    def test_my_boards_shows_joined_board(self, client):
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        board = _create_board(client, a["access_token"], "A's Board").json()
+        invite_code = board["invite_code"]
+        # B joins
+        client.post(f"{BOARDS_URL}/invite/{invite_code}/join", headers=_auth(b["access_token"]))
+        res = client.get(f"{BOARDS_URL}/me", headers=_auth(b["access_token"]))
+        assert res.status_code == 200
+        assert len(res.json()) == 1
+
+
+class TestGetBoard:
+    def test_get_board_as_member(self, client):
+        a = _register(client, USER_A)
+        board = _create_board(client, a["access_token"]).json()
+        res = client.get(f"{BOARDS_URL}/{board['id']}", headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        assert res.json()["id"] == board["id"]
+
+    def test_get_board_non_member_forbidden(self, client):
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        board = _create_board(client, a["access_token"]).json()
+        res = client.get(f"{BOARDS_URL}/{board['id']}", headers=_auth(b["access_token"]))
+        assert res.status_code == 403
+
+    def test_get_board_not_found(self, client):
+        a = _register(client, USER_A)
+        res = client.get(f"{BOARDS_URL}/00000000-0000-0000-0000-000000000000", headers=_auth(a["access_token"]))
+        assert res.status_code == 404
+
+
+# ── Invite / Join ─────────────────────────────────────────────────────────────
+
+class TestInviteJoin:
+    def test_preview_invite_no_auth(self, client):
+        a = _register(client, USER_A)
+        board = _create_board(client, a["access_token"]).json()
+        res = client.get(f"{BOARDS_URL}/invite/{board['invite_code']}")
+        assert res.status_code == 200
+        assert res.json()["name"] == board["name"]
+
+    def test_preview_invite_invalid_code(self, client):
+        res = client.get(f"{BOARDS_URL}/invite/BADCODE1")
+        assert res.status_code == 404
+
+    def test_join_board_via_invite(self, client):
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        board = _create_board(client, a["access_token"]).json()
+        res = client.post(
+            f"{BOARDS_URL}/invite/{board['invite_code']}/join",
+            headers=_auth(b["access_token"]),
+        )
+        assert res.status_code == 200
+        assert res.json()["member_count"] == 2
+
+    def test_join_idempotent(self, client):
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        board = _create_board(client, a["access_token"]).json()
+        # join twice
+        client.post(f"{BOARDS_URL}/invite/{board['invite_code']}/join", headers=_auth(b["access_token"]))
+        res = client.post(f"{BOARDS_URL}/invite/{board['invite_code']}/join", headers=_auth(b["access_token"]))
+        assert res.status_code == 200
+        # Still only 2 members
+        members = client.get(f"{BOARDS_URL}/{board['id']}/members", headers=_auth(b["access_token"])).json()
+        assert len(members) == 2
+
+
+# ── Members ───────────────────────────────────────────────────────────────────
+
+class TestMembers:
+    def test_list_members_includes_creator(self, client):
+        a = _register(client, USER_A)
+        board = _create_board(client, a["access_token"]).json()
+        res = client.get(f"{BOARDS_URL}/{board['id']}/members", headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        members = res.json()
+        assert len(members) == 1
+        assert members[0]["role"] == "creator"
+        assert members[0]["user_id"] == a["user"]["id"]
+
+    def test_non_member_cannot_list_members(self, client):
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        board = _create_board(client, a["access_token"]).json()
+        res = client.get(f"{BOARDS_URL}/{board['id']}/members", headers=_auth(b["access_token"]))
+        assert res.status_code == 403
+
+    def test_remove_member(self, client):
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        board = _create_board(client, a["access_token"]).json()
+        client.post(f"{BOARDS_URL}/invite/{board['invite_code']}/join", headers=_auth(b["access_token"]))
+        # Creator removes B
+        res = client.delete(
+            f"{BOARDS_URL}/{board['id']}/members/{b['user']['id']}",
+            headers=_auth(a["access_token"]),
+        )
+        assert res.status_code == 204
+        members = client.get(f"{BOARDS_URL}/{board['id']}/members", headers=_auth(a["access_token"])).json()
+        assert len(members) == 1
+
+    def test_member_cannot_remove_others(self, client):
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        c = _register(client, USER_C)
+        board = _create_board(client, a["access_token"]).json()
+        client.post(f"{BOARDS_URL}/invite/{board['invite_code']}/join", headers=_auth(b["access_token"]))
+        client.post(f"{BOARDS_URL}/invite/{board['invite_code']}/join", headers=_auth(c["access_token"]))
+        # B tries to remove C — should be 403
+        res = client.delete(
+            f"{BOARDS_URL}/{board['id']}/members/{c['user']['id']}",
+            headers=_auth(b["access_token"]),
+        )
+        assert res.status_code == 403
+
+    def test_creator_cannot_remove_self(self, client):
+        a = _register(client, USER_A)
+        board = _create_board(client, a["access_token"]).json()
+        res = client.delete(
+            f"{BOARDS_URL}/{board['id']}/members/{a['user']['id']}",
+            headers=_auth(a["access_token"]),
+        )
+        assert res.status_code == 400
+
+
+class TestLeaveBoard:
+    def test_member_can_leave(self, client):
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        board = _create_board(client, a["access_token"]).json()
+        client.post(f"{BOARDS_URL}/invite/{board['invite_code']}/join", headers=_auth(b["access_token"]))
+        res = client.delete(f"{BOARDS_URL}/{board['id']}/leave", headers=_auth(b["access_token"]))
+        assert res.status_code == 204
+
+    def test_creator_cannot_leave(self, client):
+        a = _register(client, USER_A)
+        board = _create_board(client, a["access_token"]).json()
+        res = client.delete(f"{BOARDS_URL}/{board['id']}/leave", headers=_auth(a["access_token"]))
+        assert res.status_code == 400
+
+
+# ── Board Outfits ─────────────────────────────────────────────────────────────
+
+class TestBoardOutfits:
+    def test_add_outfit_to_board(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
+        a = _register(client, USER_A)
+        board = _create_board(client, a["access_token"]).json()
+        outfit = _post_outfit(client, a["access_token"]).json()
+        res = client.post(
+            f"{BOARDS_URL}/{board['id']}/outfits",
+            params={"outfit_id": outfit["id"]},
+            headers=_auth(a["access_token"]),
+        )
+        assert res.status_code == 201
+        assert res.json()["id"] == outfit["id"]
+
+    def test_get_board_outfits(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
+        a = _register(client, USER_A)
+        board = _create_board(client, a["access_token"]).json()
+        outfit = _post_outfit(client, a["access_token"]).json()
+        client.post(
+            f"{BOARDS_URL}/{board['id']}/outfits",
+            params={"outfit_id": outfit["id"]},
+            headers=_auth(a["access_token"]),
+        )
+        res = client.get(f"{BOARDS_URL}/{board['id']}/outfits", headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        data = res.json()
+        assert len(data["outfits"]) == 1
+        assert data["outfits"][0]["id"] == outfit["id"]
+
+    def test_add_outfit_non_member_forbidden(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        board = _create_board(client, a["access_token"]).json()
+        outfit = _post_outfit(client, a["access_token"]).json()
+        res = client.post(
+            f"{BOARDS_URL}/{board['id']}/outfits",
+            params={"outfit_id": outfit["id"]},
+            headers=_auth(b["access_token"]),
+        )
+        assert res.status_code == 403
+
+    def test_add_nonexistent_outfit_404(self, client):
+        a = _register(client, USER_A)
+        board = _create_board(client, a["access_token"]).json()
+        res = client.post(
+            f"{BOARDS_URL}/{board['id']}/outfits",
+            params={"outfit_id": "00000000-0000-0000-0000-000000000000"},
+            headers=_auth(a["access_token"]),
+        )
+        assert res.status_code == 404
+
+    def test_remove_outfit_from_board(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
+        a = _register(client, USER_A)
+        board = _create_board(client, a["access_token"]).json()
+        outfit = _post_outfit(client, a["access_token"]).json()
+        client.post(
+            f"{BOARDS_URL}/{board['id']}/outfits",
+            params={"outfit_id": outfit["id"]},
+            headers=_auth(a["access_token"]),
+        )
+        res = client.delete(
+            f"{BOARDS_URL}/{board['id']}/outfits/{outfit['id']}",
+            headers=_auth(a["access_token"]),
+        )
+        assert res.status_code == 204
+        # Verify gone
+        outfits = client.get(f"{BOARDS_URL}/{board['id']}/outfits", headers=_auth(a["access_token"])).json()
+        assert len(outfits["outfits"]) == 0
+
+    def test_pin_outfit_creator_only(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        board = _create_board(client, a["access_token"]).json()
+        client.post(f"{BOARDS_URL}/invite/{board['invite_code']}/join", headers=_auth(b["access_token"]))
+        outfit = _post_outfit(client, a["access_token"]).json()
+        client.post(
+            f"{BOARDS_URL}/{board['id']}/outfits",
+            params={"outfit_id": outfit["id"]},
+            headers=_auth(a["access_token"]),
+        )
+        # Creator can pin
+        res = client.patch(
+            f"{BOARDS_URL}/{board['id']}/outfits/{outfit['id']}/pin",
+            json={"pinned": True},
+            headers=_auth(a["access_token"]),
+        )
+        assert res.status_code == 200
+        # Member cannot pin
+        res = client.patch(
+            f"{BOARDS_URL}/{board['id']}/outfits/{outfit['id']}/pin",
+            json={"pinned": False},
+            headers=_auth(b["access_token"]),
+        )
+        assert res.status_code == 403
+
+    def test_pinned_outfits_appear_first(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
+        a = _register(client, USER_A)
+        board = _create_board(client, a["access_token"]).json()
+        outfit1 = _post_outfit(client, a["access_token"], "first").json()
+        outfit2 = _post_outfit(client, a["access_token"], "second").json()
+        client.post(f"{BOARDS_URL}/{board['id']}/outfits", params={"outfit_id": outfit1["id"]}, headers=_auth(a["access_token"]))
+        client.post(f"{BOARDS_URL}/{board['id']}/outfits", params={"outfit_id": outfit2["id"]}, headers=_auth(a["access_token"]))
+        # Pin outfit1
+        client.patch(
+            f"{BOARDS_URL}/{board['id']}/outfits/{outfit1['id']}/pin",
+            json={"pinned": True},
+            headers=_auth(a["access_token"]),
+        )
+        res = client.get(f"{BOARDS_URL}/{board['id']}/outfits", headers=_auth(a["access_token"]))
+        outfits = res.json()["outfits"]
+        assert outfits[0]["id"] == outfit1["id"]  # pinned appears first
+
+
+# ── Delete Board ──────────────────────────────────────────────────────────────
+
+class TestDeleteBoard:
+    def test_creator_can_delete_board(self, client):
+        a = _register(client, USER_A)
+        board = _create_board(client, a["access_token"]).json()
+        res = client.delete(f"{BOARDS_URL}/{board['id']}", headers=_auth(a["access_token"]))
+        assert res.status_code == 204
+
+    def test_member_cannot_delete_board(self, client):
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        board = _create_board(client, a["access_token"]).json()
+        client.post(f"{BOARDS_URL}/invite/{board['invite_code']}/join", headers=_auth(b["access_token"]))
+        res = client.delete(f"{BOARDS_URL}/{board['id']}", headers=_auth(b["access_token"]))
+        assert res.status_code == 403
+
+    def test_deleted_board_returns_404(self, client):
+        a = _register(client, USER_A)
+        board = _create_board(client, a["access_token"]).json()
+        client.delete(f"{BOARDS_URL}/{board['id']}", headers=_auth(a["access_token"]))
+        res = client.get(f"{BOARDS_URL}/{board['id']}", headers=_auth(a["access_token"]))
+        assert res.status_code == 404


### PR DESCRIPTION
## Summary
- Adds full collaborative board system — create a board, share an invite link, members add outfits and vote with pins
- 13 REST endpoints covering the complete board lifecycle (create, join, leave, remove members, add/pin/remove outfits, cursor-paginated feed)
- Alembic migration adds `boards`, `board_members`, `board_outfits` tables with proper FK cascades and indexes

## Endpoints
| Method | Path | Auth | Notes |
|--------|------|------|-------|
| POST | `/boards` | ✅ | Create board, creator auto-joined |
| GET | `/boards/me` | ✅ | All boards user belongs to |
| GET | `/boards/{id}` | ✅ member | Board details |
| DELETE | `/boards/{id}` | ✅ creator | Delete board + all content |
| GET | `/boards/invite/{code}` | ❌ | Preview board before joining |
| POST | `/boards/invite/{code}/join` | ✅ | Join via invite (idempotent) |
| GET | `/boards/{id}/members` | ✅ member | List members |
| DELETE | `/boards/{id}/leave` | ✅ member | Leave (creator must delete instead) |
| DELETE | `/boards/{id}/members/{uid}` | ✅ creator | Kick member |
| POST | `/boards/{id}/outfits` | ✅ member | Add outfit |
| GET | `/boards/{id}/outfits` | ✅ member | Paginated outfits, pinned first |
| DELETE | `/boards/{id}/outfits/{id}` | ✅ member | Remove outfit |
| PATCH | `/boards/{id}/outfits/{id}/pin` | ✅ creator | Pin / unpin |

## Test plan
- [x] 31 new board tests — all passing
- [x] Full suite: 127/127 passed (no regressions)
- [x] Auth guards verified (member-only, creator-only, public preview)
- [x] Idempotent join and add_outfit tested
- [x] Pinned outfits sort before unpinned

Closes #43, #44, #45, #46