### PR TITLE
feat(api): outfit detail, public page, and OG metadata endpoints

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -16,6 +16,9 @@ class Settings(BaseSettings):
     # Claude AI (vibe check)
     anthropic_api_key: str = ""
 
+    # Public frontend base URL — used for shareable links and OG tags
+    public_base_url: str = "https://ootd.app"
+
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
 

--- a/services/api/app/routers/outfits.py
+++ b/services/api/app/routers/outfits.py
@@ -9,7 +9,7 @@ from app.crud import outfit as outfit_crud
 from app.crud import user as user_crud
 from app.dependencies import get_current_user, get_db
 from app.models.user import User
-from app.schemas.outfit import OutfitMetadata, OutfitOut, VaultPage
+from app.schemas.outfit import OutfitDetailOut, OutfitMetadata, OutfitOGOut, OutfitOut, OutfitOwner, VaultPage
 from app.services.storage import InvalidImageError, StorageError, upload_image
 from app.services.story_card import fetch_image, generate_story_card
 from app.services.vibe_check import run_vibe_check
@@ -136,6 +136,84 @@ def story_card(
         content=png_bytes,
         media_type="image/png",
         headers={"Content-Disposition": f'inline; filename="ootd-{outfit_id[:8]}.png"'},
+    )
+
+
+@router.get("/{outfit_id}/og", response_model=OutfitOGOut)
+def outfit_og(
+    outfit_id: str,
+    db: Session = Depends(get_db),
+) -> OutfitOGOut:
+    """
+    Open Graph metadata for a shareable outfit link.
+    No auth required — designed to be read by link-preview crawlers and the frontend.
+
+    Tomi: use these fields to populate <meta property="og:..."> tags on the outfit page.
+    """
+    import uuid as _uuid
+    from app.config import settings
+
+    try:
+        oid = _uuid.UUID(outfit_id)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Outfit not found.")
+
+    outfit = outfit_crud.get_outfit_with_items(db, oid)
+    if not outfit:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Outfit not found.")
+
+    owner = user_crud.get_by_id(db, outfit.user_id)
+    username = owner.username if owner else None
+    display_name = owner.display_name if owner else None
+
+    handle = f"@{username}" if username else "someone"
+    name = display_name or username or "A user"
+
+    title = f"{name}'s outfit on OOTD"
+    description = outfit.caption or f"Check out {handle}'s latest fit on OOTD."
+    page_url = f"{settings.public_base_url}/outfits/{outfit_id}"
+
+    return OutfitOGOut(
+        title=title,
+        description=description,
+        image_url=outfit.image_url,
+        page_url=page_url,
+        site_name="OOTD",
+        twitter_card="summary_large_image",
+    )
+
+
+@router.get("/{outfit_id}", response_model=OutfitDetailOut)
+def get_outfit(
+    outfit_id: str,
+    db: Session = Depends(get_db),
+) -> OutfitDetailOut:
+    """
+    Full outfit detail with owner info — no auth required.
+    This is the primary endpoint for the outfit detail page and public sharing.
+    """
+    import uuid as _uuid
+
+    try:
+        oid = _uuid.UUID(outfit_id)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Outfit not found.")
+
+    outfit = outfit_crud.get_outfit_with_items(db, oid)
+    if not outfit:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Outfit not found.")
+
+    owner = user_crud.get_by_id(db, outfit.user_id)
+    owner_out = OutfitOwner(
+        id=owner.id if owner else outfit.user_id,
+        username=owner.username if owner else None,
+        display_name=owner.display_name if owner else None,
+        profile_image_url=owner.profile_image_url if owner else None,
+    )
+
+    return OutfitDetailOut(
+        **OutfitOut.model_validate(outfit).model_dump(),
+        owner=owner_out,
     )
 
 

--- a/services/api/app/schemas/outfit.py
+++ b/services/api/app/schemas/outfit.py
@@ -70,3 +70,27 @@ class OutfitOut(BaseModel):
 class VaultPage(BaseModel):
     outfits: list[OutfitOut]
     next_cursor: str | None
+
+
+class OutfitOwner(BaseModel):
+    id: uuid.UUID
+    username: str | None
+    display_name: str | None
+    profile_image_url: str | None
+
+    model_config = {"from_attributes": True}
+
+
+class OutfitDetailOut(OutfitOut):
+    """Full outfit detail with embedded owner info — used for the outfit detail page."""
+    owner: OutfitOwner
+
+
+class OutfitOGOut(BaseModel):
+    """Open Graph metadata for a shareable outfit link."""
+    title: str
+    description: str
+    image_url: str
+    page_url: str
+    site_name: str
+    twitter_card: str

--- a/services/api/tests/test_outfit_detail.py
+++ b/services/api/tests/test_outfit_detail.py
@@ -1,0 +1,175 @@
+"""Tests for outfit detail and OG metadata endpoints (#111, #74, #75)."""
+
+import io
+
+REGISTER_URL = "/auth/register"
+
+USER_A = {"username": "detail_a", "email": "detail_a@example.com", "password": "password123"}
+USER_B = {"username": "detail_b", "email": "detail_b@example.com", "password": "password123"}
+
+
+def _register(client, payload):
+    res = client.post(REGISTER_URL, json=payload)
+    assert res.status_code == 201
+    return res.json()
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _post_outfit(client, token, caption="test outfit"):
+    fake_image = io.BytesIO(b"fake-image-data")
+    return client.post(
+        "/outfits",
+        headers=_auth(token),
+        files={"image": ("test.jpg", fake_image, "image/jpeg")},
+        data={"metadata": f'{{"caption": "{caption}"}}'},
+    )
+
+
+# ── GET /outfits/{outfit_id} ──────────────────────────────────────────────────
+
+class TestOutfitDetail:
+    def test_get_outfit_no_auth(self, client, monkeypatch):
+        """Anyone can fetch an outfit detail — no auth required."""
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"], "my fit").json()
+
+        res = client.get(f"/outfits/{outfit['id']}")
+        assert res.status_code == 200
+
+    def test_outfit_detail_includes_all_fields(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"], "brunch fit").json()
+
+        res = client.get(f"/outfits/{outfit['id']}")
+        data = res.json()
+        assert data["id"] == outfit["id"]
+        assert data["caption"] == "brunch fit"
+        assert data["image_url"] == "https://s3.example.com/img.jpg"
+        assert "clothing_items" in data
+        assert "created_at" in data
+
+    def test_outfit_detail_includes_owner(self, client, monkeypatch):
+        """Response embeds owner profile — no extra request needed from Tomi."""
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"]).json()
+
+        res = client.get(f"/outfits/{outfit['id']}")
+        data = res.json()
+        assert "owner" in data
+        assert data["owner"]["id"] == a["user"]["id"]
+        assert data["owner"]["username"] == USER_A["username"]
+
+    def test_outfit_detail_404_on_missing(self, client):
+        res = client.get("/outfits/00000000-0000-0000-0000-000000000000")
+        assert res.status_code == 404
+
+    def test_outfit_detail_404_on_bad_uuid(self, client):
+        res = client.get("/outfits/not-a-uuid")
+        assert res.status_code == 404
+
+    def test_different_user_can_view_outfit(self, client, monkeypatch):
+        """Public endpoint — user B can view user A's outfit without following."""
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        outfit = _post_outfit(client, a["access_token"], "a's fit").json()
+
+        res = client.get(f"/outfits/{outfit['id']}", headers=_auth(b["access_token"]))
+        assert res.status_code == 200
+        assert res.json()["caption"] == "a's fit"
+
+
+# ── GET /outfits/{outfit_id}/og ───────────────────────────────────────────────
+
+class TestOutfitOG:
+    def test_og_no_auth(self, client, monkeypatch):
+        """OG endpoint is public — no auth required for crawlers."""
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"], "date night").json()
+
+        res = client.get(f"/outfits/{outfit['id']}/og")
+        assert res.status_code == 200
+
+    def test_og_has_required_fields(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"], "cozy sunday").json()
+
+        res = client.get(f"/outfits/{outfit['id']}/og")
+        data = res.json()
+        assert "title" in data
+        assert "description" in data
+        assert "image_url" in data
+        assert "page_url" in data
+        assert "site_name" in data
+        assert "twitter_card" in data
+
+    def test_og_description_uses_caption(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"], "casual friday").json()
+
+        res = client.get(f"/outfits/{outfit['id']}/og")
+        assert res.json()["description"] == "casual friday"
+
+    def test_og_title_includes_username(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"]).json()
+
+        res = client.get(f"/outfits/{outfit['id']}/og")
+        assert USER_A["username"] in res.json()["title"]
+
+    def test_og_image_url_is_outfit_image(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"]).json()
+
+        res = client.get(f"/outfits/{outfit['id']}/og")
+        assert res.json()["image_url"] == "https://s3.example.com/img.jpg"
+
+    def test_og_page_url_contains_outfit_id(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"]).json()
+
+        res = client.get(f"/outfits/{outfit['id']}/og")
+        assert outfit["id"] in res.json()["page_url"]
+
+    def test_og_site_name_and_twitter_card(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"]).json()
+
+        res = client.get(f"/outfits/{outfit['id']}/og")
+        data = res.json()
+        assert data["site_name"] == "OOTD"
+        assert data["twitter_card"] == "summary_large_image"
+
+    def test_og_404_on_missing_outfit(self, client):
+        res = client.get("/outfits/00000000-0000-0000-0000-000000000000/og")
+        assert res.status_code == 404
+
+    def test_og_fallback_description_when_no_caption(self, client, monkeypatch):
+        """If no caption, description falls back to a default string."""
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        # Post outfit with no caption
+        fake_image = io.BytesIO(b"fake-image-data")
+        outfit = client.post(
+            "/outfits",
+            headers=_auth(a["access_token"]),
+            files={"image": ("test.jpg", fake_image, "image/jpeg")},
+            data={"metadata": "{}"},
+        ).json()
+
+        res = client.get(f"/outfits/{outfit['id']}/og")
+        desc = res.json()["description"]
+        assert len(desc) > 0  # Some fallback text, not empty


### PR DESCRIPTION
## Summary
- Outfit detail page and public sharing are now fully unblocked for Tomi
- No auth required on either endpoint — crawlers and unauthenticated users can access them

## Endpoints

### `GET /outfits/{outfit_id}`
Full outfit detail with embedded owner info. No auth required.

**Response** (`OutfitDetailOut`):
```json
{
  "id": "...",
  "caption": "date night",
  "image_url": "https://...",
  "vibe_check_text": "...",
  "vibe_check_tone": "elevated",
  "clothing_items": [...],
  "owner": {
    "id": "...",
    "username": "reagan",
    "display_name": "Reagan",
    "profile_image_url": "https://..."
  },
  ...
}
```

### `GET /outfits/{outfit_id}/og`
Open Graph metadata for `<meta>` tags. No auth required — designed for link preview crawlers.

**Response** (`OutfitOGOut`):
```json
{
  "title": "Reagan's outfit on OOTD",
  "description": "date night",
  "image_url": "https://s3.amazonaws.com/...",
  "page_url": "https://ootd.app/outfits/abc123",
  "site_name": "OOTD",
  "twitter_card": "summary_large_image"
}
```

> Set `PUBLIC_BASE_URL` in `.env` to configure the canonical URL (defaults to `https://ootd.app`).

## Test plan
- [x] 15 new tests — all passing
- [x] Full suite: 142/142 passed, no regressions
- [x] Auth-free access verified
- [x] Owner embedded correctly in detail response
- [x] OG fallback description when no caption

Closes #74, #75, #111