### PR TITLE
feat(api): likes and comments endpoints

### DIFF
--- a/services/api/app/crud/social.py
+++ b/services/api/app/crud/social.py
@@ -1,0 +1,107 @@
+"""
+CRUD helpers for likes and comments.
+
+Likes  — composite PK (user_id, outfit_id), idempotent toggle.
+Comments — full CRUD; only the author or the outfit owner may delete.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.comment import Comment
+from app.models.like import Like
+
+
+# ── Likes ─────────────────────────────────────────────────────────────────────
+
+def like_outfit(db: Session, user_id: uuid.UUID, outfit_id: uuid.UUID) -> None:
+    """Idempotent — does nothing if the user already liked this outfit."""
+    exists = (
+        db.query(Like)
+        .filter(Like.user_id == user_id, Like.outfit_id == outfit_id)
+        .first()
+    )
+    if not exists:
+        db.add(Like(user_id=user_id, outfit_id=outfit_id))
+        db.commit()
+
+
+def unlike_outfit(db: Session, user_id: uuid.UUID, outfit_id: uuid.UUID) -> None:
+    """Idempotent — does nothing if the user never liked this outfit."""
+    row = (
+        db.query(Like)
+        .filter(Like.user_id == user_id, Like.outfit_id == outfit_id)
+        .first()
+    )
+    if row:
+        db.delete(row)
+        db.commit()
+
+
+def get_like_count(db: Session, outfit_id: uuid.UUID) -> int:
+    return db.query(Like).filter(Like.outfit_id == outfit_id).count()
+
+
+def is_liked_by(db: Session, outfit_id: uuid.UUID, user_id: uuid.UUID) -> bool:
+    return (
+        db.query(Like)
+        .filter(Like.outfit_id == outfit_id, Like.user_id == user_id)
+        .first()
+    ) is not None
+
+
+# ── Comments ──────────────────────────────────────────────────────────────────
+
+def create_comment(
+    db: Session,
+    outfit_id: uuid.UUID,
+    user_id: uuid.UUID,
+    body: str,
+) -> Comment:
+    comment = Comment(outfit_id=outfit_id, user_id=user_id, body=body)
+    db.add(comment)
+    db.commit()
+    db.refresh(comment)
+    return comment
+
+
+def get_comment(db: Session, comment_id: uuid.UUID) -> Comment | None:
+    return db.query(Comment).filter(Comment.id == comment_id).first()
+
+
+def get_outfit_comments(
+    db: Session,
+    outfit_id: uuid.UUID,
+    cursor: str | None = None,
+    limit: int = 20,
+) -> tuple[list[Comment], str | None]:
+    """Oldest-first (conversation order). Cursor is the ISO created_at of the last seen comment."""
+    query = db.query(Comment).filter(Comment.outfit_id == outfit_id)
+
+    if cursor:
+        cursor_dt = datetime.fromisoformat(cursor.replace(" ", "+"))
+        query = query.filter(Comment.created_at > cursor_dt)
+
+    comments = query.order_by(Comment.created_at.asc()).limit(limit + 1).all()
+
+    next_cursor = None
+    if len(comments) > limit:
+        comments = comments[:limit]
+        next_cursor = comments[-1].created_at.isoformat()
+
+    return comments, next_cursor
+
+
+def update_comment(db: Session, comment: Comment, body: str) -> Comment:
+    comment.body = body
+    comment.updated_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(comment)
+    return comment
+
+
+def delete_comment(db: Session, comment: Comment) -> None:
+    db.delete(comment)
+    db.commit()

--- a/services/api/app/dependencies.py
+++ b/services/api/app/dependencies.py
@@ -74,3 +74,24 @@ def get_current_user(
         )
 
     return user
+
+
+def get_optional_user(
+    authorization: str | None = Header(default=None),
+    db: Session = Depends(get_db),
+) -> User | None:
+    """
+    Like get_current_user but returns None instead of 401 when no token is provided.
+    Use on endpoints that are public but have auth-aware behaviour (e.g. liked_by_me).
+    """
+    if not authorization or not authorization.startswith("Bearer "):
+        return None
+    try:
+        token = authorization.removeprefix("Bearer ")
+        payload = decode_access_token(token)
+        user_id: str | None = payload.get("sub")
+        if not user_id:
+            return None
+        return user_crud.get_by_id(db, uuid.UUID(user_id))
+    except (JWTError, ExpiredSignatureError):
+        return None

--- a/services/api/app/routers/outfits.py
+++ b/services/api/app/routers/outfits.py
@@ -4,12 +4,23 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Upload
 from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
+import uuid
+
 from app.crud import follow as follow_crud
 from app.crud import outfit as outfit_crud
+from app.crud import social as social_crud
 from app.crud import user as user_crud
-from app.dependencies import get_current_user, get_db
+from app.dependencies import get_current_user, get_db, get_optional_user
 from app.models.user import User
 from app.schemas.outfit import OutfitDetailOut, OutfitMetadata, OutfitOGOut, OutfitOut, OutfitOwner, VaultPage
+from app.schemas.social import (
+    CommentOut,
+    CommentPage,
+    CommentAuthor,
+    CreateCommentRequest,
+    LikeStatus,
+    UpdateCommentRequest,
+)
 from app.services.storage import InvalidImageError, StorageError, upload_image
 from app.services.story_card import fetch_image, generate_story_card
 from app.services.vibe_check import run_vibe_check
@@ -215,6 +226,153 @@ def get_outfit(
         **OutfitOut.model_validate(outfit).model_dump(),
         owner=owner_out,
     )
+
+
+# ── Likes ─────────────────────────────────────────────────────────────────────
+
+def _outfit_or_404(db: Session, outfit_id_str: str):
+    try:
+        oid = uuid.UUID(outfit_id_str)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Outfit not found.")
+    outfit = outfit_crud.get_outfit_with_items(db, oid)
+    if not outfit:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Outfit not found.")
+    return outfit
+
+
+def _comment_author(db: Session, user_id: uuid.UUID) -> CommentAuthor:
+    u = user_crud.get_by_id(db, user_id)
+    return CommentAuthor(
+        id=u.id if u else user_id,
+        username=u.username if u else None,
+        display_name=u.display_name if u else None,
+        profile_image_url=u.profile_image_url if u else None,
+    )
+
+
+def _comment_out(db: Session, comment) -> CommentOut:
+    return CommentOut(
+        id=comment.id,
+        outfit_id=comment.outfit_id,
+        user_id=comment.user_id,
+        body=comment.body,
+        created_at=comment.created_at,
+        updated_at=comment.updated_at,
+        author=_comment_author(db, comment.user_id),
+    )
+
+
+@router.get("/{outfit_id}/likes", response_model=LikeStatus)
+def get_likes(
+    outfit_id: str,
+    db: Session = Depends(get_db),
+    current_user: User | None = Depends(get_optional_user),
+) -> LikeStatus:
+    """Like count + whether the current user liked this outfit. Auth optional."""
+    outfit = _outfit_or_404(db, outfit_id)
+    like_count = social_crud.get_like_count(db, outfit.id)
+    liked = social_crud.is_liked_by(db, outfit.id, current_user.id) if current_user else False
+    return LikeStatus(like_count=like_count, liked=liked)
+
+
+@router.post("/{outfit_id}/likes", response_model=LikeStatus, status_code=status.HTTP_200_OK)
+def like_outfit(
+    outfit_id: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> LikeStatus:
+    """Like an outfit. Idempotent — safe to call multiple times."""
+    outfit = _outfit_or_404(db, outfit_id)
+    social_crud.like_outfit(db, current_user.id, outfit.id)
+    return LikeStatus(
+        like_count=social_crud.get_like_count(db, outfit.id),
+        liked=True,
+    )
+
+
+@router.delete("/{outfit_id}/likes", response_model=LikeStatus)
+def unlike_outfit(
+    outfit_id: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> LikeStatus:
+    """Unlike an outfit. Idempotent."""
+    outfit = _outfit_or_404(db, outfit_id)
+    social_crud.unlike_outfit(db, current_user.id, outfit.id)
+    return LikeStatus(
+        like_count=social_crud.get_like_count(db, outfit.id),
+        liked=False,
+    )
+
+
+# ── Comments ──────────────────────────────────────────────────────────────────
+
+@router.get("/{outfit_id}/comments", response_model=CommentPage)
+def list_comments(
+    outfit_id: str,
+    cursor: str | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=50),
+    db: Session = Depends(get_db),
+) -> CommentPage:
+    """List comments on an outfit, oldest first. No auth required."""
+    outfit = _outfit_or_404(db, outfit_id)
+    comments, next_cursor = social_crud.get_outfit_comments(db, outfit.id, cursor, limit)
+    return CommentPage(
+        comments=[_comment_out(db, c) for c in comments],
+        next_cursor=next_cursor,
+    )
+
+
+@router.post("/{outfit_id}/comments", response_model=CommentOut, status_code=status.HTTP_201_CREATED)
+def create_comment(
+    outfit_id: str,
+    body: CreateCommentRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> CommentOut:
+    """Post a comment on an outfit. Auth required."""
+    outfit = _outfit_or_404(db, outfit_id)
+    comment = social_crud.create_comment(db, outfit.id, current_user.id, body.body)
+    return _comment_out(db, comment)
+
+
+@router.patch("/{outfit_id}/comments/{comment_id}", response_model=CommentOut)
+def update_comment(
+    outfit_id: str,
+    comment_id: uuid.UUID,
+    body: UpdateCommentRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> CommentOut:
+    """Edit your own comment."""
+    _outfit_or_404(db, outfit_id)
+    comment = social_crud.get_comment(db, comment_id)
+    if not comment:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Comment not found.")
+    if comment.user_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Cannot edit someone else's comment.")
+    updated = social_crud.update_comment(db, comment, body.body)
+    return _comment_out(db, updated)
+
+
+@router.delete("/{outfit_id}/comments/{comment_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_comment(
+    outfit_id: str,
+    comment_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> None:
+    """Delete a comment. Author or outfit owner can delete."""
+    outfit = _outfit_or_404(db, outfit_id)
+    comment = social_crud.get_comment(db, comment_id)
+    if not comment:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Comment not found.")
+    is_author = comment.user_id == current_user.id
+    is_outfit_owner = outfit.user_id == current_user.id
+    if not is_author and not is_outfit_owner:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Cannot delete this comment.")
+    social_crud.delete_comment(db, comment)
 
 
 @router.get("/user/{username}", response_model=VaultPage)

--- a/services/api/app/schemas/social.py
+++ b/services/api/app/schemas/social.py
@@ -1,0 +1,50 @@
+"""Pydantic schemas for likes and comments."""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+# ── Likes ─────────────────────────────────────────────────────────────────────
+
+class LikeStatus(BaseModel):
+    """Returned by like/unlike/get-like-status endpoints."""
+    like_count: int
+    liked: bool
+
+
+# ── Comments ──────────────────────────────────────────────────────────────────
+
+class CommentAuthor(BaseModel):
+    id: uuid.UUID
+    username: str | None
+    display_name: str | None
+    profile_image_url: str | None
+
+    model_config = {"from_attributes": True}
+
+
+class CommentOut(BaseModel):
+    id: uuid.UUID
+    outfit_id: uuid.UUID
+    user_id: uuid.UUID
+    body: str
+    created_at: datetime
+    updated_at: datetime
+    author: CommentAuthor
+
+    model_config = {"from_attributes": True}
+
+
+class CommentPage(BaseModel):
+    comments: list[CommentOut]
+    next_cursor: str | None
+
+
+class CreateCommentRequest(BaseModel):
+    body: str = Field(..., min_length=1, max_length=500)
+
+
+class UpdateCommentRequest(BaseModel):
+    body: str = Field(..., min_length=1, max_length=500)

--- a/services/api/tests/test_social.py
+++ b/services/api/tests/test_social.py
@@ -1,0 +1,322 @@
+"""Tests for likes and comments endpoints (#55)."""
+
+import io
+
+REGISTER_URL = "/auth/register"
+
+USER_A = {"username": "social_a", "email": "social_a@example.com", "password": "password123"}
+USER_B = {"username": "social_b", "email": "social_b@example.com", "password": "password123"}
+USER_C = {"username": "social_c", "email": "social_c@example.com", "password": "password123"}
+
+
+def _register(client, payload):
+    res = client.post(REGISTER_URL, json=payload)
+    assert res.status_code == 201
+    return res.json()
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _post_outfit(client, token, caption="my fit"):
+    fake_image = io.BytesIO(b"fake-image-data")
+    res = client.post(
+        "/outfits",
+        headers=_auth(token),
+        files={"image": ("test.jpg", fake_image, "image/jpeg")},
+        data={"metadata": f'{{"caption": "{caption}"}}'},
+    )
+    assert res.status_code == 201
+    return res.json()
+
+
+# ── Likes ─────────────────────────────────────────────────────────────────────
+
+class TestLikes:
+    def test_get_likes_no_auth(self, client, monkeypatch):
+        """Like count is public — no auth needed."""
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"])
+        res = client.get(f"/outfits/{outfit['id']}/likes")
+        assert res.status_code == 200
+        assert res.json()["like_count"] == 0
+        assert res.json()["liked"] is False
+
+    def test_like_outfit(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        outfit = _post_outfit(client, a["access_token"])
+        res = client.post(f"/outfits/{outfit['id']}/likes", headers=_auth(b["access_token"]))
+        assert res.status_code == 200
+        assert res.json()["like_count"] == 1
+        assert res.json()["liked"] is True
+
+    def test_like_idempotent(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"])
+        client.post(f"/outfits/{outfit['id']}/likes", headers=_auth(a["access_token"]))
+        client.post(f"/outfits/{outfit['id']}/likes", headers=_auth(a["access_token"]))
+        res = client.get(f"/outfits/{outfit['id']}/likes")
+        assert res.json()["like_count"] == 1  # not 2
+
+    def test_unlike_outfit(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        outfit = _post_outfit(client, a["access_token"])
+        client.post(f"/outfits/{outfit['id']}/likes", headers=_auth(b["access_token"]))
+        res = client.delete(f"/outfits/{outfit['id']}/likes", headers=_auth(b["access_token"]))
+        assert res.status_code == 200
+        assert res.json()["like_count"] == 0
+        assert res.json()["liked"] is False
+
+    def test_unlike_idempotent(self, client, monkeypatch):
+        """Unliking an outfit you never liked is fine — no error."""
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"])
+        res = client.delete(f"/outfits/{outfit['id']}/likes", headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        assert res.json()["like_count"] == 0
+
+    def test_liked_by_me_true_when_authed(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        outfit = _post_outfit(client, a["access_token"])
+        client.post(f"/outfits/{outfit['id']}/likes", headers=_auth(b["access_token"]))
+        res = client.get(f"/outfits/{outfit['id']}/likes", headers=_auth(b["access_token"]))
+        assert res.json()["liked"] is True
+
+    def test_liked_by_me_false_for_different_user(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        c = _register(client, USER_C)
+        outfit = _post_outfit(client, a["access_token"])
+        client.post(f"/outfits/{outfit['id']}/likes", headers=_auth(b["access_token"]))
+        res = client.get(f"/outfits/{outfit['id']}/likes", headers=_auth(c["access_token"]))
+        assert res.json()["liked"] is False
+
+    def test_multiple_users_like(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        c = _register(client, USER_C)
+        outfit = _post_outfit(client, a["access_token"])
+        client.post(f"/outfits/{outfit['id']}/likes", headers=_auth(b["access_token"]))
+        client.post(f"/outfits/{outfit['id']}/likes", headers=_auth(c["access_token"]))
+        res = client.get(f"/outfits/{outfit['id']}/likes")
+        assert res.json()["like_count"] == 2
+
+    def test_like_requires_auth(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"])
+        res = client.post(f"/outfits/{outfit['id']}/likes")
+        assert res.status_code == 401
+
+    def test_like_404_on_missing_outfit(self, client):
+        a = _register(client, USER_A)
+        res = client.post("/outfits/00000000-0000-0000-0000-000000000000/likes", headers=_auth(a["access_token"]))
+        assert res.status_code == 404
+
+
+# ── Comments ──────────────────────────────────────────────────────────────────
+
+class TestComments:
+    def test_list_comments_empty(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"])
+        res = client.get(f"/outfits/{outfit['id']}/comments")
+        assert res.status_code == 200
+        assert res.json()["comments"] == []
+        assert res.json()["next_cursor"] is None
+
+    def test_list_comments_no_auth(self, client, monkeypatch):
+        """Comments are public."""
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"])
+        client.post(f"/outfits/{outfit['id']}/comments", json={"body": "nice fit!"}, headers=_auth(a["access_token"]))
+        res = client.get(f"/outfits/{outfit['id']}/comments")
+        assert res.status_code == 200
+        assert len(res.json()["comments"]) == 1
+
+    def test_create_comment(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        outfit = _post_outfit(client, a["access_token"])
+        res = client.post(
+            f"/outfits/{outfit['id']}/comments",
+            json={"body": "love the vibe!"},
+            headers=_auth(b["access_token"]),
+        )
+        assert res.status_code == 201
+        data = res.json()
+        assert data["body"] == "love the vibe!"
+        assert data["user_id"] == b["user"]["id"]
+
+    def test_comment_includes_author(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"])
+        res = client.post(
+            f"/outfits/{outfit['id']}/comments",
+            json={"body": "fire!"},
+            headers=_auth(a["access_token"]),
+        )
+        data = res.json()
+        assert "author" in data
+        assert data["author"]["username"] == USER_A["username"]
+        assert data["author"]["id"] == a["user"]["id"]
+
+    def test_create_comment_requires_auth(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"])
+        res = client.post(f"/outfits/{outfit['id']}/comments", json={"body": "hi"})
+        assert res.status_code == 401
+
+    def test_comment_body_required(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"])
+        res = client.post(f"/outfits/{outfit['id']}/comments", json={}, headers=_auth(a["access_token"]))
+        assert res.status_code == 422
+
+    def test_comment_body_max_length(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"])
+        res = client.post(
+            f"/outfits/{outfit['id']}/comments",
+            json={"body": "x" * 501},
+            headers=_auth(a["access_token"]),
+        )
+        assert res.status_code == 422
+
+    def test_edit_own_comment(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"])
+        comment = client.post(
+            f"/outfits/{outfit['id']}/comments",
+            json={"body": "original"},
+            headers=_auth(a["access_token"]),
+        ).json()
+        res = client.patch(
+            f"/outfits/{outfit['id']}/comments/{comment['id']}",
+            json={"body": "edited"},
+            headers=_auth(a["access_token"]),
+        )
+        assert res.status_code == 200
+        assert res.json()["body"] == "edited"
+
+    def test_cannot_edit_others_comment(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        outfit = _post_outfit(client, a["access_token"])
+        comment = client.post(
+            f"/outfits/{outfit['id']}/comments",
+            json={"body": "a's comment"},
+            headers=_auth(a["access_token"]),
+        ).json()
+        res = client.patch(
+            f"/outfits/{outfit['id']}/comments/{comment['id']}",
+            json={"body": "b editing a"},
+            headers=_auth(b["access_token"]),
+        )
+        assert res.status_code == 403
+
+    def test_author_can_delete_own_comment(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        outfit = _post_outfit(client, a["access_token"])
+        comment = client.post(
+            f"/outfits/{outfit['id']}/comments",
+            json={"body": "b's comment"},
+            headers=_auth(b["access_token"]),
+        ).json()
+        res = client.delete(
+            f"/outfits/{outfit['id']}/comments/{comment['id']}",
+            headers=_auth(b["access_token"]),
+        )
+        assert res.status_code == 204
+
+    def test_outfit_owner_can_delete_any_comment(self, client, monkeypatch):
+        """Outfit owner can moderate — delete anyone's comments."""
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        outfit = _post_outfit(client, a["access_token"])
+        comment = client.post(
+            f"/outfits/{outfit['id']}/comments",
+            json={"body": "b's comment"},
+            headers=_auth(b["access_token"]),
+        ).json()
+        # A (outfit owner) deletes B's comment
+        res = client.delete(
+            f"/outfits/{outfit['id']}/comments/{comment['id']}",
+            headers=_auth(a["access_token"]),
+        )
+        assert res.status_code == 204
+
+    def test_third_party_cannot_delete_comment(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        c = _register(client, USER_C)
+        outfit = _post_outfit(client, a["access_token"])
+        comment = client.post(
+            f"/outfits/{outfit['id']}/comments",
+            json={"body": "b's comment"},
+            headers=_auth(b["access_token"]),
+        ).json()
+        res = client.delete(
+            f"/outfits/{outfit['id']}/comments/{comment['id']}",
+            headers=_auth(c["access_token"]),
+        )
+        assert res.status_code == 403
+
+    def test_comments_oldest_first(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"])
+        client.post(f"/outfits/{outfit['id']}/comments", json={"body": "first"}, headers=_auth(a["access_token"]))
+        client.post(f"/outfits/{outfit['id']}/comments", json={"body": "second"}, headers=_auth(a["access_token"]))
+        res = client.get(f"/outfits/{outfit['id']}/comments")
+        comments = res.json()["comments"]
+        assert len(comments) == 2
+        assert comments[0]["body"] == "first"
+        assert comments[1]["body"] == "second"
+
+    def test_delete_removes_from_list(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"])
+        comment = client.post(
+            f"/outfits/{outfit['id']}/comments",
+            json={"body": "delete me"},
+            headers=_auth(a["access_token"]),
+        ).json()
+        client.delete(f"/outfits/{outfit['id']}/comments/{comment['id']}", headers=_auth(a["access_token"]))
+        res = client.get(f"/outfits/{outfit['id']}/comments")
+        assert len(res.json()["comments"]) == 0
+
+    def test_comment_404_on_missing_outfit(self, client):
+        a = _register(client, USER_A)
+        res = client.post(
+            "/outfits/00000000-0000-0000-0000-000000000000/comments",
+            json={"body": "hello"},
+            headers=_auth(a["access_token"]),
+        )
+        assert res.status_code == 404


### PR DESCRIPTION
## Summary
- Full likes + comments system — the last major social layer Tomi needs to build the interactive feed
- Comments embed author info so the UI never needs a second request to show avatars/names
- Outfit owners can moderate their own comment sections (delete any comment)

## Endpoints

### Likes
| Method | Path | Auth | Notes |
|--------|------|------|-------|
| GET | `/outfits/{id}/likes` | optional | Count + `liked_by_me` flag |
| POST | `/outfits/{id}/likes` | ✅ | Like (idempotent) |
| DELETE | `/outfits/{id}/likes` | ✅ | Unlike (idempotent) |

**Response:** `{ "like_count": 12, "liked": true }`

### Comments
| Method | Path | Auth | Notes |
|--------|------|------|-------|
| GET | `/outfits/{id}/comments` | ❌ | Oldest-first, cursor-paginated |
| POST | `/outfits/{id}/comments` | ✅ | Create (max 500 chars) |
| PATCH | `/outfits/{id}/comments/{cid}` | ✅ | Edit own only |
| DELETE | `/outfits/{id}/comments/{cid}` | ✅ | Author or outfit owner |

**CommentOut includes:**
```json
{
  "id": "...", "body": "fire outfit!", "created_at": "...",
  "author": { "id": "...", "username": "tomi", "display_name": "Tomi", "profile_image_url": "..." }
}
```

## Also added
- `get_optional_user` dependency — resolves to `User | None`, used for auth-aware public endpoints (like count with `liked_by_me`)

## Test plan
- [x] 25 new tests — all passing
- [x] Full suite: 167/167 passed, no regressions
- [x] Like idempotency (double-like stays count=1)
- [x] Unlike idempotency (unliking what you never liked = 200, count=0)
- [x] `liked_by_me` correct per-user
- [x] Comment ordering (oldest first)
- [x] Moderation: outfit owner can delete any comment, third-party gets 403

Closes #55