### PR TITLE
feat(api): AI caption generator, vault search, and board expiry

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -19,6 +19,10 @@ class Settings(BaseSettings):
     # Public frontend base URL — used for shareable links and OG tags
     public_base_url: str = "https://ootd.app"
 
+    # Admin secret for internal maintenance endpoints (board cleanup, etc.)
+    # Set this to a long random string in production. Empty = endpoint disabled.
+    admin_secret: str = ""
+
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
 

--- a/services/api/app/crud/board.py
+++ b/services/api/app/crud/board.py
@@ -198,6 +198,26 @@ def pin_outfit(
     return row
 
 
+def is_expired(board) -> bool:
+    """Return True if the board's expiry has passed."""
+    return board.expires_at < datetime.now(timezone.utc)
+
+
+def delete_expired_boards(db: Session) -> int:
+    """Delete all boards past their expiry date. Returns count deleted."""
+    expired = (
+        db.query(Board)
+        .filter(Board.expires_at < datetime.now(timezone.utc))
+        .all()
+    )
+    count = len(expired)
+    for board in expired:
+        db.delete(board)
+    if count:
+        db.commit()
+    return count
+
+
 def get_board_outfits(
     db: Session,
     board_id: uuid.UUID,

--- a/services/api/app/crud/outfit.py
+++ b/services/api/app/crud/outfit.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import date, datetime, timezone
 
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from app.models.clothing_item import ClothingItem
@@ -81,6 +82,57 @@ def get_user_outfits(
         next_cursor = outfits[-1].created_at.isoformat()
 
     return outfits, next_cursor
+
+
+def search_user_outfits(
+    db: Session,
+    user_id: uuid.UUID,
+    q: str,
+    limit: int = 20,
+) -> list[Outfit]:
+    """
+    Full-text search within a user's own vault.
+    Matches against caption, event_name, and any clothing item's brand/category/color.
+    Returns newest-first, capped at limit.
+    """
+    term = f"%{q.lower()}%"
+    from sqlalchemy import func
+
+    # Outfits that match caption or event_name directly
+    direct_match = (
+        db.query(Outfit.id)
+        .filter(
+            Outfit.user_id == user_id,
+            or_(
+                func.lower(Outfit.caption).like(term),
+                func.lower(Outfit.event_name).like(term),
+            ),
+        )
+    )
+
+    # Outfits whose clothing items match brand/category/color
+    item_match = (
+        db.query(ClothingItem.outfit_id)
+        .join(Outfit, Outfit.id == ClothingItem.outfit_id)
+        .filter(
+            Outfit.user_id == user_id,
+            or_(
+                func.lower(ClothingItem.brand).like(term),
+                func.lower(ClothingItem.category).like(term),
+                func.lower(ClothingItem.color).like(term),
+            ),
+        )
+    )
+
+    all_ids = direct_match.union(item_match).subquery()
+
+    return (
+        db.query(Outfit)
+        .filter(Outfit.id.in_(all_ids.select()))
+        .order_by(Outfit.created_at.desc())
+        .limit(limit)
+        .all()
+    )
 
 
 def get_feed(

--- a/services/api/app/routers/boards.py
+++ b/services/api/app/routers/boards.py
@@ -10,6 +10,7 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
+from app.config import settings
 from app.crud import board as board_crud
 from app.crud import outfit as outfit_crud
 from app.crud import user as user_crud
@@ -33,6 +34,8 @@ def _board_or_404(db: Session, board_id: uuid.UUID):
     board = board_crud.get_board(db, board_id)
     if not board:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Board not found.")
+    if board_crud.is_expired(board):
+        raise HTTPException(status_code=status.HTTP_410_GONE, detail="This board has expired.")
     return board
 
 
@@ -270,3 +273,37 @@ def pin_outfit(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Outfit not on this board.")
     outfit = outfit_crud.get_outfit_with_items(db, outfit_id)
     return OutfitOut.model_validate(outfit)
+
+
+# ── Admin ─────────────────────────────────────────────────────────────────────
+
+from fastapi import Header as _Header
+from pydantic import BaseModel as _BM
+
+
+class CleanupResult(_BM):
+    deleted: int
+
+
+@router.post("/admin/cleanup", response_model=CleanupResult)
+def cleanup_expired_boards(
+    x_admin_secret: str | None = _Header(default=None),
+    db: Session = Depends(get_db),
+) -> CleanupResult:
+    """
+    Delete all boards whose expiry date has passed.
+    Protected by X-Admin-Secret header — set ADMIN_SECRET in your env.
+
+    Designed to be called by a cron job (e.g. GitHub Actions daily schedule,
+    Render cron, or AWS EventBridge). Returns the number of boards deleted.
+
+    Example cron (GitHub Actions):
+        curl -X POST https://api.ootd.app/boards/admin/cleanup \\
+             -H "X-Admin-Secret: $ADMIN_SECRET"
+    """
+    if not settings.admin_secret:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Admin endpoint not configured.")
+    if x_admin_secret != settings.admin_secret:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid admin secret.")
+    deleted = board_crud.delete_expired_boards(db)
+    return CleanupResult(deleted=deleted)

--- a/services/api/app/routers/outfits.py
+++ b/services/api/app/routers/outfits.py
@@ -12,7 +12,7 @@ from app.crud import social as social_crud
 from app.crud import user as user_crud
 from app.dependencies import get_current_user, get_db, get_optional_user
 from app.models.user import User
-from app.schemas.outfit import OutfitDetailOut, OutfitMetadata, OutfitOGOut, OutfitOut, OutfitOwner, VaultPage
+from app.schemas.outfit import CaptionSuggestionsOut, OutfitDetailOut, OutfitMetadata, OutfitOGOut, OutfitOut, OutfitOwner, VaultPage
 from app.schemas.social import (
     CommentOut,
     CommentPage,
@@ -21,6 +21,7 @@ from app.schemas.social import (
     LikeStatus,
     UpdateCommentRequest,
 )
+from app.services.caption import suggest_captions
 from app.services.storage import InvalidImageError, StorageError, upload_image
 from app.services.story_card import fetch_image, generate_story_card
 from app.services.vibe_check import run_vibe_check
@@ -95,6 +96,30 @@ def get_feed(
     return VaultPage(outfits=[OutfitOut.model_validate(o) for o in outfits], next_cursor=next_cursor)
 
 
+@router.post("/caption-suggestion", response_model=CaptionSuggestionsOut)
+def caption_suggestion(
+    image: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+) -> CaptionSuggestionsOut:
+    """
+    Generate AI caption suggestions for an outfit photo.
+
+    Call this during the upload flow — before creating the outfit — so the user
+    can pick a caption before submitting. Auth required to prevent abuse.
+
+    Returns up to 3 short caption ideas. Returns an empty list if the AI service
+    is unavailable (best-effort, never blocks the upload).
+    """
+    try:
+        file_bytes = image.file.read()
+        content_type = image.content_type or "image/jpeg"
+    except Exception as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Could not read image: {exc}")
+
+    suggestions = suggest_captions(file_bytes=file_bytes, content_type=content_type)
+    return CaptionSuggestionsOut(suggestions=suggestions)
+
+
 @router.get("/me", response_model=VaultPage)
 def my_vault(
     cursor: str | None = Query(default=None),
@@ -105,6 +130,23 @@ def my_vault(
     """Current user's own vault, newest first."""
     outfits, next_cursor = outfit_crud.get_user_outfits(db, current_user.id, cursor, limit)
     return VaultPage(outfits=[OutfitOut.model_validate(o) for o in outfits], next_cursor=next_cursor)
+
+
+@router.get("/me/search", response_model=list[OutfitOut])
+def search_vault(
+    q: str = Query(..., min_length=1, max_length=100),
+    limit: int = Query(default=20, ge=1, le=50),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[OutfitOut]:
+    """
+    Search your own vault by caption, event name, or clothing item details
+    (brand, category, color). Returns newest-first, no pagination.
+
+    Example: GET /outfits/me/search?q=zara
+    """
+    outfits = outfit_crud.search_user_outfits(db, current_user.id, q, limit)
+    return [OutfitOut.model_validate(o) for o in outfits]
 
 
 @router.get("/{outfit_id}/story-card", response_class=Response)

--- a/services/api/app/schemas/outfit.py
+++ b/services/api/app/schemas/outfit.py
@@ -94,3 +94,8 @@ class OutfitOGOut(BaseModel):
     page_url: str
     site_name: str
     twitter_card: str
+
+
+class CaptionSuggestionsOut(BaseModel):
+    """AI-generated caption suggestions for an outfit photo."""
+    suggestions: list[str]

--- a/services/api/app/services/caption.py
+++ b/services/api/app/services/caption.py
@@ -1,0 +1,89 @@
+"""
+Caption suggestion service — calls Claude to generate 3 caption ideas for an outfit photo.
+
+Best-effort: returns an empty list if the API key is missing or the call fails.
+The rest of the app never imports anthropic directly.
+
+Usage:
+    from app.services.caption import suggest_captions
+
+    suggestions = suggest_captions(file_bytes=image_bytes, content_type="image/jpeg")
+    # ["Sunday brunch fit", "Laid back and cozy", "Coffee run ready"]
+"""
+
+import base64
+import json
+import logging
+
+import anthropic
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+_PROMPT = """\
+You are a creative fashion copywriter helping someone write a fun, relatable caption for their outfit photo.
+
+Generate exactly 3 short caption suggestions for this outfit. Each should feel natural for social media —
+punchy, specific to what you see, and slightly different in tone (e.g. one playful, one aesthetic, one straightforward).
+
+Respond with ONLY a JSON object in this exact format (no markdown, no extra text):
+{"suggestions": ["caption one", "caption two", "caption three"]}
+
+Rules:
+- Each caption: 3–12 words, no hashtags, no emojis
+- Be specific to the outfit — mention colors, vibes, or occasion if clear
+- Keep it casual and genuine
+"""
+
+
+def suggest_captions(
+    file_bytes: bytes,
+    content_type: str,
+) -> list[str]:
+    """
+    Generate 3 caption suggestions for an outfit image.
+
+    Returns a list of suggestion strings (possibly empty on failure).
+    Never raises — callers get an empty list if anything goes wrong.
+    """
+    if not settings.anthropic_api_key:
+        return []
+
+    image_data = base64.standard_b64encode(file_bytes).decode("utf-8")
+
+    try:
+        client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+        message = client.messages.create(
+            model="claude-opus-4-5",
+            max_tokens=256,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": content_type,
+                                "data": image_data,
+                            },
+                        },
+                        {"type": "text", "text": _PROMPT},
+                    ],
+                }
+            ],
+        )
+
+        result = json.loads(message.content[0].text)
+        suggestions = result.get("suggestions", [])
+
+        if not isinstance(suggestions, list):
+            logger.warning("Caption suggestion returned unexpected shape: %s", result)
+            return []
+
+        return [str(s).strip() for s in suggestions if s][:3]
+
+    except Exception:
+        logger.exception("Caption suggestion failed")
+        return []

--- a/services/api/tests/test_caption_search_expiry.py
+++ b/services/api/tests/test_caption_search_expiry.py
@@ -1,0 +1,231 @@
+"""Tests for caption suggestion (#80), vault search (#56), and board expiry (#47)."""
+
+import io
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+REGISTER_URL = "/auth/register"
+
+USER_A = {"username": "cse_a", "email": "cse_a@example.com", "password": "password123"}
+USER_B = {"username": "cse_b", "email": "cse_b@example.com", "password": "password123"}
+
+
+def _register(client, payload):
+    res = client.post(REGISTER_URL, json=payload)
+    assert res.status_code == 201
+    return res.json()
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _post_outfit(client, token, caption="my fit", clothing_items=None):
+    meta = {"caption": caption}
+    if clothing_items:
+        meta["clothing_items"] = clothing_items
+    fake_image = io.BytesIO(b"fake-image-data")
+    res = client.post(
+        "/outfits",
+        headers=_auth(token),
+        files={"image": ("test.jpg", fake_image, "image/jpeg")},
+        data={"metadata": str(meta).replace("'", '"')},
+    )
+    assert res.status_code == 201
+    return res.json()
+
+
+def _create_board(client, token, name="Test Board", event_date=None):
+    body = {"name": name}
+    if event_date:
+        body["event_date"] = event_date
+    res = client.post("/boards", json=body, headers=_auth(token))
+    assert res.status_code == 201
+    return res.json()
+
+
+# ── Caption Suggestion (#80) ──────────────────────────────────────────────────
+
+class TestCaptionSuggestion:
+    def test_caption_suggestion_requires_auth(self, client):
+        fake_image = io.BytesIO(b"fake-image-data")
+        res = client.post(
+            "/outfits/caption-suggestion",
+            files={"image": ("test.jpg", fake_image, "image/jpeg")},
+        )
+        assert res.status_code == 401
+
+    def test_caption_suggestion_returns_list(self, client, monkeypatch):
+        """When AI is unavailable (no API key in test env), returns empty list — never errors."""
+        monkeypatch.setattr("app.services.caption.settings", type("S", (), {"anthropic_api_key": ""})())
+        a = _register(client, USER_A)
+        fake_image = io.BytesIO(b"fake-image-data")
+        res = client.post(
+            "/outfits/caption-suggestion",
+            headers=_auth(a["access_token"]),
+            files={"image": ("test.jpg", fake_image, "image/jpeg")},
+        )
+        assert res.status_code == 200
+        data = res.json()
+        assert "suggestions" in data
+        assert isinstance(data["suggestions"], list)
+
+    def test_caption_suggestion_mocked_response(self, client, monkeypatch):
+        """Verify the endpoint correctly returns whatever the service produces."""
+        monkeypatch.setattr(
+            "app.routers.outfits.suggest_captions",
+            lambda **kw: ["Sunday brunch fit", "Laid back and cozy", "Coffee run ready"],
+        )
+        a = _register(client, USER_A)
+        fake_image = io.BytesIO(b"fake-image-data")
+        res = client.post(
+            "/outfits/caption-suggestion",
+            headers=_auth(a["access_token"]),
+            files={"image": ("test.jpg", fake_image, "image/jpeg")},
+        )
+        assert res.status_code == 200
+        assert res.json()["suggestions"] == [
+            "Sunday brunch fit",
+            "Laid back and cozy",
+            "Coffee run ready",
+        ]
+
+    def test_caption_suggestion_empty_on_ai_failure(self, client, monkeypatch):
+        """Service-level failure returns empty list — upload flow is never blocked."""
+        monkeypatch.setattr("app.routers.outfits.suggest_captions", lambda **kw: [])
+        a = _register(client, USER_A)
+        fake_image = io.BytesIO(b"fake-image-data")
+        res = client.post(
+            "/outfits/caption-suggestion",
+            headers=_auth(a["access_token"]),
+            files={"image": ("test.jpg", fake_image, "image/jpeg")},
+        )
+        assert res.status_code == 200
+        assert res.json()["suggestions"] == []
+
+
+# ── Vault Search (#56) ────────────────────────────────────────────────────────
+
+class TestVaultSearch:
+    def test_search_requires_auth(self, client):
+        res = client.get("/outfits/me/search?q=zara")
+        assert res.status_code == 401
+
+    def test_search_by_caption(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        _post_outfit(client, a["access_token"], caption="brunch fit")
+        _post_outfit(client, a["access_token"], caption="gym session")
+
+        res = client.get("/outfits/me/search?q=brunch", headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        results = res.json()
+        assert len(results) == 1
+        assert results[0]["caption"] == "brunch fit"
+
+    def test_search_case_insensitive(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        _post_outfit(client, a["access_token"], caption="Summer Vibes")
+
+        res = client.get("/outfits/me/search?q=summer", headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        assert len(res.json()) == 1
+
+    def test_search_no_results(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        _post_outfit(client, a["access_token"], caption="casual friday")
+
+        res = client.get("/outfits/me/search?q=zara", headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        assert res.json() == []
+
+    def test_search_only_own_outfits(self, client, monkeypatch):
+        """User B's outfits don't show up in user A's search."""
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/img.jpg")
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        _post_outfit(client, b["access_token"], caption="brunch vibes")
+
+        res = client.get("/outfits/me/search?q=brunch", headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        assert res.json() == []
+
+    def test_search_query_required(self, client):
+        a = _register(client, USER_A)
+        res = client.get("/outfits/me/search", headers=_auth(a["access_token"]))
+        assert res.status_code == 422
+
+
+# ── Board Expiry (#47) ────────────────────────────────────────────────────────
+
+class TestBoardExpiry:
+    def test_expired_board_returns_410(self, client, monkeypatch):
+        """Accessing an expired board returns 410 Gone."""
+        a = _register(client, USER_A)
+        board = _create_board(client, a["access_token"])
+
+        # Manually expire the board in the DB via the CRUD
+        from app.crud import board as board_crud
+        from app.dependencies import get_db
+        from app.main import app
+
+        db = next(app.dependency_overrides[get_db]())
+        try:
+            b = board_crud.get_board(db, board["id"])
+            b.expires_at = datetime.now(timezone.utc) - timedelta(days=1)
+            db.commit()
+        finally:
+            db.close()
+
+        res = client.get(f"/boards/{board['id']}", headers=_auth(a["access_token"]))
+        assert res.status_code == 410
+
+    def test_active_board_not_expired(self, client):
+        a = _register(client, USER_A)
+        board = _create_board(client, a["access_token"])
+        res = client.get(f"/boards/{board['id']}", headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+
+    def test_admin_cleanup_disabled_without_secret(self, client):
+        """Cleanup endpoint returns 503 when ADMIN_SECRET is not configured."""
+        res = client.post("/boards/admin/cleanup")
+        assert res.status_code == 503
+
+    def test_admin_cleanup_rejects_wrong_secret(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.boards.settings", type("S", (), {"admin_secret": "correct-secret"})())
+        res = client.post("/boards/admin/cleanup", headers={"X-Admin-Secret": "wrong-secret"})
+        assert res.status_code == 403
+
+    def test_admin_cleanup_deletes_expired_boards(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.boards.settings", type("S", (), {"admin_secret": "test-secret"})())
+        a = _register(client, USER_A)
+        board = _create_board(client, a["access_token"])
+
+        # Expire the board
+        from app.crud import board as board_crud
+        from app.dependencies import get_db
+        from app.main import app
+
+        db = next(app.dependency_overrides[get_db]())
+        try:
+            b = board_crud.get_board(db, board["id"])
+            b.expires_at = datetime.now(timezone.utc) - timedelta(days=1)
+            db.commit()
+        finally:
+            db.close()
+
+        res = client.post("/boards/admin/cleanup", headers={"X-Admin-Secret": "test-secret"})
+        assert res.status_code == 200
+        assert res.json()["deleted"] == 1
+
+    def test_admin_cleanup_skips_active_boards(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.boards.settings", type("S", (), {"admin_secret": "test-secret"})())
+        a = _register(client, USER_A)
+        _create_board(client, a["access_token"])  # active board
+
+        res = client.post("/boards/admin/cleanup", headers={"X-Admin-Secret": "test-secret"})
+        assert res.status_code == 200
+        assert res.json()["deleted"] == 0


### PR DESCRIPTION
## Summary
Three backend features in one PR — all small and self-contained.

---

### AI Caption Generator (#80) — `POST /outfits/caption-suggestion`
Call this during the upload flow before creating an outfit. Returns up to 3 short caption ideas based on the photo.

```
POST /outfits/caption-suggestion   (multipart, auth required)
→ { "suggestions": ["Sunday brunch fit", "Laid back and cozy", "Coffee run ready"] }
```

- Auth required to prevent abuse
- Best-effort: returns `[]` if AI is unavailable — upload flow is never blocked
- Add `ANTHROPIC_API_KEY` to env to activate (same key as vibe check)

---

### Vault Search (#56) — `GET /outfits/me/search?q=`
Search your own outfit vault across all text fields.

```
GET /outfits/me/search?q=zara        → outfits with "zara" in brand/caption/etc.
GET /outfits/me/search?q=brunch      → outfits with "brunch" in caption or event_name
GET /outfits/me/search?q=blue        → outfits with blue clothing items
```

- Case-insensitive, auth required, scoped to current user
- Searches: `caption`, `event_name`, clothing item `brand` / `category` / `color`

---

### Board Expiry System (#47)
- Any expired board now returns **410 Gone** on all endpoints (previously would show stale data)
- New **`POST /boards/admin/cleanup`** endpoint deletes all boards past their `expires_at`
  - Protected by `X-Admin-Secret` header — set `ADMIN_SECRET` in `.env`
  - Returns `{ "deleted": N }`
  - Hook this up to a daily cron (GitHub Actions, Render, etc.):
    ```
    curl -X POST https://api.ootd.app/boards/admin/cleanup \
         -H "X-Admin-Secret: $ADMIN_SECRET"
    ```

## Test plan
- [x] 16 new tests — all passing
- [x] Full suite: 183/183 passed, no regressions
- [x] Caption: mocked AI response, empty-on-failure, auth guard
- [x] Search: caption match, case insensitivity, cross-user isolation
- [x] Expiry: 410 on expired board, cleanup counts correctly, secret guard

Closes #47, #56, #80