### PR TITLE
fix(api): add CORS middleware

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -23,6 +23,11 @@ class Settings(BaseSettings):
     # Set this to a long random string in production. Empty = endpoint disabled.
     admin_secret: str = ""
 
+    # CORS — comma-separated list of allowed origins.
+    # Defaults to localhost:3000 for local dev. Set in production to your real domain.
+    # Example: ALLOWED_ORIGINS=https://ootd.app,https://www.ootd.app
+    allowed_origins: list[str] = []
+
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
 

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -1,7 +1,9 @@
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
+from app.config import settings
 from app.routers import auth, boards, health, outfits, users
 
 
@@ -14,6 +16,21 @@ app = FastAPI(
     title="OOTD API",
     version="0.1.0",
     lifespan=lifespan,
+)
+
+# Allow requests from the frontend dev server and any configured origin.
+# In production set ALLOWED_ORIGINS to your real domain.
+_origins = settings.allowed_origins if settings.allowed_origins else [
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 app.include_router(health.router)


### PR DESCRIPTION
The browser frontend was getting \"Unable to reach the API\" because no CORS headers were set — browsers block cross-origin requests without them (`curl` works fine since it ignores CORS).

## What changed
- Added `CORSMiddleware` to `app/main.py`
- `localhost:3000` allowed by default (dev)
- Production: set `ALLOWED_ORIGINS=https://ootd.app` in env (comma-separated for multiple)
- Added `allowed_origins: list[str]` to `Settings`

## Verified
```
curl -I -X OPTIONS http://localhost:8000/health \
  -H "Origin: http://localhost:3000"
→ access-control-allow-origin: http://localhost:3000  ✓
```