### PR TITLE
fix: security patches and bug fixes (auth bypass, type mismatch, timing attack, cursor 500s)

### DIFF
--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -168,17 +168,15 @@ export type UserSearchResult = {
 };
 
 export type WrappedStats = {
-  year: number;
-  month: number;
+  month: string;           // "2026-04"
   total_outfits: number;
-  total_items: number;
-  top_colors: Array<{ color: string; count: number }>;
-  top_brands: Array<{ brand: string; count: number }>;
-  top_categories: Array<{ category: string; count: number }>;
+  top_colors: string[];    // up to 3, most frequent first
+  top_brands: string[];    // up to 3, most frequent first
+  top_category: string | null;
+  vibe_of_month: string | null;
+  most_active_day: string | null;  // e.g. "Monday"
   longest_streak: number;
-  current_streak: number;
-  most_worn_vibe: string | null;
-  outfits_by_week: Array<{ week: number; count: number }>;
+  top_outfit: OutfitResponse | null;
 };
 
 // ── Boards ────────────────────────────────────────────────────────────────────

--- a/services/api/app/crud/board.py
+++ b/services/api/app/crud/board.py
@@ -10,6 +10,8 @@ import string
 import uuid
 from datetime import datetime, timedelta, timezone
 
+from fastapi import HTTPException, status as http_status
+
 from sqlalchemy.orm import Session
 
 from app.models.board import Board, BoardMember, BoardOutfit
@@ -173,12 +175,18 @@ def add_outfit(
     return bo
 
 
-def remove_outfit(db: Session, board_id: uuid.UUID, outfit_id: uuid.UUID) -> None:
-    row = (
+def get_board_outfit(
+    db: Session, board_id: uuid.UUID, outfit_id: uuid.UUID
+) -> "BoardOutfit | None":
+    return (
         db.query(BoardOutfit)
         .filter(BoardOutfit.board_id == board_id, BoardOutfit.outfit_id == outfit_id)
         .first()
     )
+
+
+def remove_outfit(db: Session, board_id: uuid.UUID, outfit_id: uuid.UUID) -> None:
+    row = get_board_outfit(db, board_id, outfit_id)
     if row:
         db.delete(row)
         db.commit()
@@ -237,7 +245,10 @@ def get_board_outfits(
     )
 
     if cursor:
-        cursor_dt = datetime.fromisoformat(cursor.replace(" ", "+"))
+        try:
+            cursor_dt = datetime.fromisoformat(cursor.replace(" ", "+"))
+        except ValueError:
+            raise HTTPException(status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid cursor.")
         query = query.filter(BoardOutfit.added_at < cursor_dt)
 
     outfits = (

--- a/services/api/app/crud/outfit.py
+++ b/services/api/app/crud/outfit.py
@@ -1,6 +1,8 @@
 import uuid
 from datetime import date, datetime, timezone
 
+from fastapi import HTTPException, status as http_status
+
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
@@ -71,7 +73,10 @@ def get_user_outfits(
     query = db.query(Outfit).filter(Outfit.user_id == user_id)
 
     if cursor:
-        cursor_dt = datetime.fromisoformat(cursor.replace(" ", "+"))
+        try:
+            cursor_dt = datetime.fromisoformat(cursor.replace(" ", "+"))
+        except ValueError:
+            raise HTTPException(status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid cursor.")
         query = query.filter(Outfit.created_at < cursor_dt)
 
     outfits = query.order_by(Outfit.created_at.desc()).limit(limit + 1).all()
@@ -151,7 +156,10 @@ def get_feed(
     query = db.query(Outfit).filter(Outfit.user_id.in_(following_ids))
 
     if cursor:
-        cursor_dt = datetime.fromisoformat(cursor.replace(" ", "+"))
+        try:
+            cursor_dt = datetime.fromisoformat(cursor.replace(" ", "+"))
+        except ValueError:
+            raise HTTPException(status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid cursor.")
         query = query.filter(Outfit.created_at < cursor_dt)
 
     outfits = query.order_by(Outfit.created_at.desc()).limit(limit + 1).all()

--- a/services/api/app/crud/social.py
+++ b/services/api/app/crud/social.py
@@ -8,6 +8,8 @@ Comments — full CRUD; only the author or the outfit owner may delete.
 import uuid
 from datetime import datetime, timezone
 
+from fastapi import HTTPException, status as http_status
+
 from sqlalchemy.orm import Session
 
 from app.models.comment import Comment
@@ -81,7 +83,10 @@ def get_outfit_comments(
     query = db.query(Comment).filter(Comment.outfit_id == outfit_id)
 
     if cursor:
-        cursor_dt = datetime.fromisoformat(cursor.replace(" ", "+"))
+        try:
+            cursor_dt = datetime.fromisoformat(cursor.replace(" ", "+"))
+        except ValueError:
+            raise HTTPException(status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid cursor.")
         query = query.filter(Comment.created_at > cursor_dt)
 
     comments = query.order_by(Comment.created_at.asc()).limit(limit + 1).all()

--- a/services/api/app/routers/boards.py
+++ b/services/api/app/routers/boards.py
@@ -5,6 +5,7 @@ All board content is private: only members can read or post.
 The invite_code is the only way to join.
 """
 
+import hmac
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -254,6 +255,14 @@ def remove_outfit(
     """Remove an outfit from a board. Creator can remove any; members can remove their own."""
     _board_or_404(db, board_id)
     _require_member(db, board_id, current_user.id)
+    # Non-creators can only remove outfits they personally added.
+    if not board_crud.is_creator(db, board_id, current_user.id):
+        bo = board_crud.get_board_outfit(db, board_id, outfit_id)
+        if bo is None or bo.added_by != current_user.id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You can only remove outfits you added.",
+            )
     board_crud.remove_outfit(db, board_id, outfit_id)
 
 
@@ -303,7 +312,8 @@ def cleanup_expired_boards(
     """
     if not settings.admin_secret:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Admin endpoint not configured.")
-    if x_admin_secret != settings.admin_secret:
+    provided = x_admin_secret or ""
+    if not hmac.compare_digest(provided, settings.admin_secret):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid admin secret.")
     deleted = board_crud.delete_expired_boards(db)
     return CleanupResult(deleted=deleted)

--- a/services/api/app/services/story_card.py
+++ b/services/api/app/services/story_card.py
@@ -83,10 +83,13 @@ def _font(path: Path, size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont
         return ImageFont.load_default()
 
 
+_MAX_IMAGE_BYTES = 20 * 1024 * 1024  # 20 MB — sanity cap to prevent OOM
+
+
 def fetch_image(url: str) -> bytes:
     """Download image bytes from a URL. Isolated for easy monkeypatching in tests."""
     with urllib.request.urlopen(url, timeout=10) as resp:  # noqa: S310
-        return resp.read()
+        return resp.read(_MAX_IMAGE_BYTES)
 
 
 def generate_story_card(


### PR DESCRIPTION
## What

Five confirmed bugs fixed across the backend and API client.

## Fixes

### 🔴 Authorization bypass — board outfit removal
Any board member could remove **any** outfit, not just their own. The docstring said "Creator can remove any; members can remove their own" but the check wasn't there.
- Added `get_board_outfit()` CRUD helper
- Router now: if not creator → verify `bo.added_by == current_user.id`, else 403

### 🟠 WrappedStats TypeScript type mismatch
`WrappedStats` in `api-client.ts` expected `{color: string; count: number}[]` but the Python schema returns `list[str]`. Would have crashed any Wrapped UI page at runtime.
- Updated TS type to exactly match `schemas/wrapped.py`

### 🟡 Admin secret timing attack
`x_admin_secret != settings.admin_secret` is a string equality check vulnerable to timing-based enumeration. Replaced with `hmac.compare_digest()`.

### 🟡 Bad cursor → unhandled 500
A malformed or tampered pagination cursor passed to `datetime.fromisoformat()` caused an unhandled `ValueError` → 500. Now returns a proper 422 in all three CRUD files (outfit, social, board).

### 🟡 `fetch_image` unbounded response read
Story card endpoint fetched the outfit image with no size limit — a large file could OOM the server. Capped at 20 MB.

## Test plan
- [ ] Board member cannot remove another member's outfit (403)
- [ ] Board creator can remove any outfit (204)
- [ ] `/users/me/wrapped` response matches `WrappedStats` type in client
- [ ] Passing `?cursor=garbage` returns 422 not 500
- [ ] Full test suite passes in CI