### PR TITLE
feat(web): profile page UI (#41)

### DIFF
--- a/apps/web/app/profile/[username]/page.tsx
+++ b/apps/web/app/profile/[username]/page.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import Link from "next/link";
+import { use, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiClient, type OutfitResponse, type PublicProfile } from "@/lib/api-client";
+import { MobileNav } from "@/components/chrome/mobile-nav";
+import { OutfitCard, OutfitCardSkeleton, type OutfitCardData } from "@/components/outfits/outfit-card";
+import { useAuth } from "@/lib/auth-context";
+
+type PageStatus = "loading" | "ready" | "not-found" | "error";
+
+function toCardData(outfit: OutfitResponse): OutfitCardData {
+  return {
+    id: outfit.id,
+    imageUrl: outfit.image_url,
+    caption: outfit.caption,
+    eventName: outfit.event_name,
+    wornOn: outfit.worn_on,
+    createdAt: outfit.created_at,
+    vibeTone: outfit.vibe_check_tone,
+  };
+}
+
+function getInitial(displayName?: string | null, username?: string | null) {
+  const source = displayName?.trim() || username?.trim() || "?";
+  return source.charAt(0).toUpperCase();
+}
+
+// ── Avatar ────────────────────────────────────────────────────────────────────
+
+function Avatar({ src, initial }: { src?: string | null; initial: string }) {
+  if (src) {
+    return (
+      <img
+        src={src}
+        alt="Profile photo"
+        className="h-24 w-24 rounded-full border-2 border-rose/20 object-cover shadow-[0_8px_24px_rgba(244,106,147,0.16)]"
+      />
+    );
+  }
+  return (
+    <div className="flex h-24 w-24 items-center justify-center rounded-full border-2 border-rose/20 bg-gradient-to-br from-[#fce4ec] to-[#f8bbd0] text-2xl font-semibold text-[#c0476e] shadow-[0_8px_24px_rgba(244,106,147,0.14)]">
+      {initial}
+    </div>
+  );
+}
+
+function StatPill({ value, label }: { value: number; label: string }) {
+  return (
+    <div className="flex flex-col items-center gap-0.5">
+      <span className="font-display text-2xl leading-none tracking-[-0.04em] text-ink">
+        {value.toLocaleString()}
+      </span>
+      <span className="text-[0.68rem] uppercase tracking-[0.18em] text-plum/52">{label}</span>
+    </div>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default function PublicProfilePage({
+  params,
+}: {
+  params: Promise<{ username: string }>;
+}) {
+  const { username } = use(params);
+  const router = useRouter();
+  const { user: authUser, isAuthenticated } = useAuth();
+
+  const [status, setStatus] = useState<PageStatus>("loading");
+  const [profile, setProfile] = useState<PublicProfile | null>(null);
+  const [outfits, setOutfits] = useState<OutfitResponse[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [following, setFollowing] = useState(false);
+  const [followerCount, setFollowerCount] = useState(0);
+  const [followLoading, setFollowLoading] = useState(false);
+
+  const isOwnProfile = isAuthenticated && authUser?.username === username;
+
+  // Redirect own profile to /profile
+  useEffect(() => {
+    if (isOwnProfile) {
+      router.replace("/profile");
+    }
+  }, [isOwnProfile, router]);
+
+  useEffect(() => {
+    if (isOwnProfile) return;
+
+    let active = true;
+
+    async function load() {
+      setStatus("loading");
+
+      const [profileResult, outfitsResult] = await Promise.all([
+        apiClient.users.getProfile(username),
+        apiClient.outfits.getByUser(username, { limit: 12 }),
+      ]);
+
+      if (!active) return;
+
+      if (!profileResult.ok) {
+        setStatus(profileResult.message?.toLowerCase().includes("not found") ? "not-found" : "error");
+        return;
+      }
+
+      setProfile(profileResult.data);
+      setFollowerCount(profileResult.data.follower_count);
+
+      if (outfitsResult.ok) {
+        setOutfits(outfitsResult.data.outfits);
+        setNextCursor(outfitsResult.data.next_cursor ?? null);
+      }
+
+      setStatus("ready");
+    }
+
+    void load();
+
+    return () => {
+      active = false;
+    };
+  }, [username, isOwnProfile]);
+
+  async function handleFollow() {
+    if (!isAuthenticated || followLoading) return;
+    setFollowLoading(true);
+
+    if (following) {
+      const result = await apiClient.users.unfollow(username);
+      if (result.ok) {
+        setFollowing(false);
+        setFollowerCount((c) => Math.max(0, c - 1));
+      }
+    } else {
+      const result = await apiClient.users.follow(username);
+      if (result.ok) {
+        setFollowing(result.data.following);
+        setFollowerCount(result.data.follower_count);
+      }
+    }
+
+    setFollowLoading(false);
+  }
+
+  async function handleLoadMore() {
+    if (!nextCursor || isLoadingMore) return;
+    setIsLoadingMore(true);
+
+    const result = await apiClient.outfits.getByUser(username, { cursor: nextCursor, limit: 12 });
+    if (result.ok) {
+      setOutfits((prev) => [...prev, ...result.data.outfits]);
+      setNextCursor(result.data.next_cursor ?? null);
+    }
+    setIsLoadingMore(false);
+  }
+
+  if (isOwnProfile) return null; // redirecting
+
+  // ── Not found ──
+  if (status === "not-found") {
+    return (
+      <main className="px-4 pb-28 pt-6 sm:px-6">
+        <div className="mx-auto flex min-h-[60vh] max-w-2xl items-center justify-center">
+          <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
+            <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+            <h1 className="mt-4 text-3xl text-ink">Profile not found</h1>
+            <p className="mt-3 text-sm leading-6 text-plum/68">
+              @{username} doesn&apos;t exist or may have changed their username.
+            </p>
+            <Link
+              href="/feed"
+              className="mt-6 inline-block rounded-[1.2rem] border border-rose/15 bg-white px-5 py-3 text-sm font-semibold text-plum transition hover:border-rose/25"
+            >
+              Back to feed
+            </Link>
+          </div>
+        </div>
+        <MobileNav active="home" />
+      </main>
+    );
+  }
+
+  const displayName = profile?.display_name || profile?.username || username;
+  const bio = profile?.bio;
+  const avatarSrc = profile?.profile_image_url;
+
+  return (
+    <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-3xl">
+
+        {/* ── Top bar ────────────────────────────────────────────────────── */}
+        <header className="mb-6 flex items-start justify-between gap-3">
+          <div>
+            <button
+              type="button"
+              onClick={() => router.back()}
+              className="flex items-center gap-2 text-sm text-plum/60 transition hover:text-plum"
+            >
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                className="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="m15 18-6-6 6-6" />
+              </svg>
+              Back
+            </button>
+            <p className="mt-2 font-display text-[3.4rem] leading-none tracking-[-0.08em] text-[#f09ab4]">
+              OOTD
+            </p>
+          </div>
+        </header>
+
+        {/* ── Profile card ───────────────────────────────────────────────── */}
+        {status === "loading" ? (
+          <section className="soft-panel mb-6 animate-pulse px-6 py-7">
+            <div className="flex items-start gap-5">
+              <div className="h-24 w-24 rounded-full bg-[#ffe8ef]" />
+              <div className="flex-1 space-y-3 pt-1">
+                <div className="h-5 w-36 rounded-full bg-[#ffe8ef]" />
+                <div className="h-3.5 w-24 rounded-full bg-[#fff3f7]" />
+                <div className="h-3 w-full rounded-full bg-[#fff6f9]" />
+                <div className="h-3 w-4/5 rounded-full bg-[#fff6f9]" />
+              </div>
+            </div>
+          </section>
+        ) : (
+          <section className="soft-panel mb-6 px-6 py-7">
+            <div className="flex items-start gap-5">
+              <Avatar
+                src={avatarSrc}
+                initial={getInitial(profile?.display_name, username)}
+              />
+
+              <div className="min-w-0 flex-1">
+                <h1 className="font-display text-3xl leading-tight tracking-[-0.03em] text-ink">
+                  {displayName}
+                </h1>
+                <p className="mt-0.5 text-sm text-plum/58">@{username}</p>
+                {bio ? (
+                  <p className="mt-3 text-sm leading-6 text-plum/72">{bio}</p>
+                ) : null}
+
+                {isAuthenticated ? (
+                  <button
+                    type="button"
+                    onClick={() => void handleFollow()}
+                    disabled={followLoading}
+                    className={`mt-4 rounded-full px-5 py-2 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-60 ${
+                      following
+                        ? "border border-rose/20 bg-white text-plum hover:border-rose/35 hover:bg-[#fff4f7]"
+                        : "bg-gradient-to-r from-[#ef6c96] to-[#f493b0] text-white hover:brightness-[0.98]"
+                    }`}
+                  >
+                    {followLoading ? "…" : following ? "Following" : "Follow"}
+                  </button>
+                ) : (
+                  <Link
+                    href="/login"
+                    className="mt-4 inline-block rounded-full bg-gradient-to-r from-[#ef6c96] to-[#f493b0] px-5 py-2 text-sm font-semibold text-white transition hover:brightness-[0.98]"
+                  >
+                    Follow
+                  </Link>
+                )}
+              </div>
+            </div>
+
+            {/* Stats row */}
+            <div className="mt-6 flex items-center justify-around border-t border-rose/8 pt-5">
+              <StatPill value={outfits.length} label="Outfits" />
+              <div className="h-8 w-px bg-rose/10" />
+              <StatPill value={followerCount} label="Followers" />
+              <div className="h-8 w-px bg-rose/10" />
+              <StatPill value={profile?.following_count ?? 0} label="Following" />
+            </div>
+          </section>
+        )}
+
+        {/* ── Outfit grid ─────────────────────────────────────────────────── */}
+        <section>
+          <h2 className="mb-4 font-display text-xl tracking-[-0.02em] text-ink">
+            {status === "ready" ? `${displayName?.split(" ")[0]}'s looks` : "Looks"}
+          </h2>
+
+          {status === "loading" ? (
+            <div className="grid grid-cols-2 gap-3 sm:gap-4">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <OutfitCardSkeleton key={i} showAuthor={false} />
+              ))}
+            </div>
+          ) : null}
+
+          {status === "ready" && outfits.length === 0 ? (
+            <div className="soft-panel px-6 py-10 text-center">
+              <h2 className="text-2xl text-ink">No looks yet</h2>
+              <p className="mt-3 text-sm leading-6 text-plum/68">
+                @{username} hasn&apos;t uploaded any outfits yet.
+              </p>
+            </div>
+          ) : null}
+
+          {status === "ready" && outfits.length > 0 ? (
+            <>
+              <div className="grid grid-cols-2 gap-3 sm:gap-4">
+                {outfits.map((outfit) => (
+                  <OutfitCard
+                    key={outfit.id}
+                    outfit={toCardData(outfit)}
+                    showAuthor={false}
+                    showAccentMarker
+                  />
+                ))}
+              </div>
+
+              {nextCursor ? (
+                <div className="mt-8 flex justify-center">
+                  <button
+                    type="button"
+                    onClick={() => void handleLoadMore()}
+                    disabled={isLoadingMore}
+                    className="rounded-full border border-rose/12 bg-white px-5 py-3 text-sm font-semibold text-plum transition hover:border-rose/22 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {isLoadingMore ? "Loading more..." : "Load more looks"}
+                  </button>
+                </div>
+              ) : null}
+            </>
+          ) : null}
+        </section>
+      </div>
+
+      <MobileNav active="home" />
+    </main>
+  );
+}

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiClient, type OutfitResponse, type PublicProfile } from "@/lib/api-client";
+import { MobileNav } from "@/components/chrome/mobile-nav";
+import { OutfitCard, OutfitCardSkeleton, type OutfitCardData } from "@/components/outfits/outfit-card";
+import { useAuth } from "@/lib/auth-context";
+
+type PageStatus = "idle" | "loading" | "ready" | "error";
+
+function toCardData(outfit: OutfitResponse): OutfitCardData {
+  return {
+    id: outfit.id,
+    imageUrl: outfit.image_url,
+    caption: outfit.caption,
+    eventName: outfit.event_name,
+    wornOn: outfit.worn_on,
+    createdAt: outfit.created_at,
+    vibeTone: outfit.vibe_check_tone,
+  };
+}
+
+function getInitial(displayName?: string | null, username?: string | null) {
+  const source = displayName?.trim() || username?.trim() || "?";
+  return source.charAt(0).toUpperCase();
+}
+
+// ── Avatar ────────────────────────────────────────────────────────────────────
+
+function Avatar({
+  src,
+  initial,
+  size = "lg",
+}: {
+  src?: string | null;
+  initial: string;
+  size?: "lg" | "xl";
+}) {
+  const dim = size === "xl" ? "h-24 w-24 text-2xl" : "h-16 w-16 text-lg";
+
+  if (src) {
+    return (
+      <img
+        src={src}
+        alt="Your profile photo"
+        className={`${dim} rounded-full border-2 border-rose/20 object-cover shadow-[0_8px_24px_rgba(244,106,147,0.16)]`}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={`${dim} flex items-center justify-center rounded-full border-2 border-rose/20 bg-gradient-to-br from-[#fce4ec] to-[#f8bbd0] font-semibold text-[#c0476e] shadow-[0_8px_24px_rgba(244,106,147,0.14)]`}
+    >
+      {initial}
+    </div>
+  );
+}
+
+// ── Stat pill ─────────────────────────────────────────────────────────────────
+
+function StatPill({ value, label }: { value: number; label: string }) {
+  return (
+    <div className="flex flex-col items-center gap-0.5">
+      <span className="font-display text-2xl leading-none tracking-[-0.04em] text-ink">
+        {value.toLocaleString()}
+      </span>
+      <span className="text-[0.68rem] uppercase tracking-[0.18em] text-plum/52">{label}</span>
+    </div>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default function ProfilePage() {
+  const router = useRouter();
+  const { user, isAuthenticated, isLoading: authLoading, logout } = useAuth();
+
+  const [status, setStatus] = useState<PageStatus>("idle");
+  const [profile, setProfile] = useState<PublicProfile | null>(null);
+  const [outfits, setOutfits] = useState<OutfitResponse[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // Redirect if not authed
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.replace("/login");
+    }
+  }, [isAuthenticated, authLoading, router]);
+
+  // Load profile + outfits
+  useEffect(() => {
+    if (authLoading || !isAuthenticated || !user?.username) return;
+
+    let active = true;
+
+    async function load() {
+      setStatus("loading");
+      setErrorMessage(null);
+
+      const [profileResult, outfitsResult] = await Promise.all([
+        apiClient.users.getProfile(user!.username),
+        apiClient.outfits.getVault({ limit: 12 }),
+      ]);
+
+      if (!active) return;
+
+      if (!profileResult.ok) {
+        setStatus("error");
+        setErrorMessage(profileResult.message);
+        return;
+      }
+
+      if (!outfitsResult.ok) {
+        setStatus("error");
+        setErrorMessage(outfitsResult.message);
+        return;
+      }
+
+      setProfile(profileResult.data);
+      setOutfits(outfitsResult.data.outfits);
+      setNextCursor(outfitsResult.data.next_cursor ?? null);
+      setStatus("ready");
+    }
+
+    void load();
+
+    return () => {
+      active = false;
+    };
+  }, [authLoading, isAuthenticated, user]);
+
+  async function handleLoadMore() {
+    if (!nextCursor || isLoadingMore) return;
+    setIsLoadingMore(true);
+
+    const result = await apiClient.outfits.getVault({ cursor: nextCursor, limit: 12 });
+
+    if (result.ok) {
+      setOutfits((prev) => [...prev, ...result.data.outfits]);
+      setNextCursor(result.data.next_cursor ?? null);
+    }
+    setIsLoadingMore(false);
+  }
+
+  // Loading gate
+  if (authLoading || !isAuthenticated) {
+    return (
+      <main className="px-4 py-6 sm:px-6">
+        <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-2xl items-center justify-center">
+          <section className="soft-panel w-full max-w-sm px-6 py-10 text-center">
+            <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+            <h1 className="mt-4 text-3xl text-ink">Loading your profile</h1>
+          </section>
+        </div>
+      </main>
+    );
+  }
+
+  const displayName = profile?.display_name ?? user?.display_name ?? user?.username ?? "Your profile";
+  const username = user?.username ?? "";
+  const bio = profile?.bio ?? user?.bio ?? null;
+  const avatarSrc = profile?.profile_image_url ?? user?.profile_image_url ?? null;
+  const followerCount = profile?.follower_count ?? 0;
+  const followingCount = profile?.following_count ?? 0;
+
+  return (
+    <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-3xl">
+
+        {/* ── Top bar ────────────────────────────────────────────────────── */}
+        <header className="mb-6 flex items-start justify-between gap-3">
+          <div>
+            <p className="font-display text-[3.4rem] leading-none tracking-[-0.08em] text-[#f09ab4]">
+              OOTD
+            </p>
+            <p className="mt-1 text-sm text-plum/54">@{username}</p>
+          </div>
+
+          <div className="flex items-center gap-2 pt-1">
+            <Link href="/profile/edit" className="icon-button" aria-label="Edit profile">
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                className="h-4.5 w-4.5"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5Z" />
+              </svg>
+            </Link>
+
+            <button
+              type="button"
+              onClick={() => void logout()}
+              className="icon-button"
+              aria-label="Sign out"
+            >
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                className="h-4.5 w-4.5"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                <polyline points="16 17 21 12 16 7" />
+                <line x1="21" y1="12" x2="9" y2="12" />
+              </svg>
+            </button>
+          </div>
+        </header>
+
+        {/* ── Profile card ───────────────────────────────────────────────── */}
+        <section className="soft-panel mb-6 px-6 py-7">
+          <div className="flex items-start gap-5">
+            <Avatar src={avatarSrc} initial={getInitial(displayName, username)} size="xl" />
+
+            <div className="min-w-0 flex-1">
+              <h1 className="font-display text-3xl leading-tight tracking-[-0.03em] text-ink">
+                {displayName}
+              </h1>
+              {username ? (
+                <p className="mt-0.5 text-sm text-plum/58">@{username}</p>
+              ) : null}
+              {bio ? (
+                <p className="mt-3 text-sm leading-6 text-plum/72">{bio}</p>
+              ) : (
+                <Link
+                  href="/profile/edit"
+                  className="mt-3 inline-block text-sm text-[#ef5f8a] hover:underline"
+                >
+                  Add a bio →
+                </Link>
+              )}
+            </div>
+          </div>
+
+          {/* Stats row */}
+          <div className="mt-6 flex items-center justify-around border-t border-rose/8 pt-5">
+            <StatPill value={outfits.length + (nextCursor ? 1 : 0)} label="Outfits" />
+            <div className="h-8 w-px bg-rose/10" />
+            <StatPill value={followerCount} label="Followers" />
+            <div className="h-8 w-px bg-rose/10" />
+            <StatPill value={followingCount} label="Following" />
+          </div>
+        </section>
+
+        {/* ── Error state ─────────────────────────────────────────────────── */}
+        {errorMessage ? (
+          <div className="mb-5 rounded-[1.25rem] border border-rose/25 bg-[#fff3f7] px-4 py-3 text-sm text-[#c04b72]">
+            {errorMessage}
+          </div>
+        ) : null}
+
+        {/* ── Outfit grid ─────────────────────────────────────────────────── */}
+        <section>
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="font-display text-xl tracking-[-0.02em] text-ink">Your looks</h2>
+            <Link
+              href="/upload"
+              className="inline-flex items-center gap-1.5 rounded-full border border-rose/15 bg-white px-4 py-2 text-[0.78rem] font-semibold text-[#ef5f8a] shadow-[0_8px_20px_rgba(244,106,147,0.07)] transition hover:border-rose/28"
+            >
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                className="h-3.5 w-3.5"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M12 5v14" />
+                <path d="M5 12h14" />
+              </svg>
+              Add look
+            </Link>
+          </div>
+
+          {status === "loading" ? (
+            <div className="grid grid-cols-2 gap-3 sm:gap-4">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <OutfitCardSkeleton key={i} showAuthor={false} />
+              ))}
+            </div>
+          ) : null}
+
+          {status === "ready" && outfits.length === 0 ? (
+            <div className="soft-panel px-6 py-10 text-center">
+              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-plum/52">
+                Nothing yet
+              </p>
+              <h2 className="mt-3 text-3xl text-ink">Start your style archive</h2>
+              <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-plum/68">
+                Upload your first outfit and it will live here, forever ready to revisit.
+              </p>
+              <Link
+                href="/upload"
+                className="mt-6 inline-block rounded-[1.2rem] bg-gradient-to-r from-[#ef6c96] to-[#f493b0] px-6 py-3.5 text-sm font-semibold text-white transition hover:brightness-[0.98]"
+              >
+                Upload your first look
+              </Link>
+            </div>
+          ) : null}
+
+          {status === "ready" && outfits.length > 0 ? (
+            <>
+              <div className="grid grid-cols-2 gap-3 sm:gap-4">
+                {outfits.map((outfit) => (
+                  <OutfitCard
+                    key={outfit.id}
+                    outfit={toCardData(outfit)}
+                    showAuthor={false}
+                    showAccentMarker
+                  />
+                ))}
+              </div>
+
+              {nextCursor ? (
+                <div className="mt-8 flex justify-center">
+                  <button
+                    type="button"
+                    onClick={() => void handleLoadMore()}
+                    disabled={isLoadingMore}
+                    className="rounded-full border border-rose/12 bg-white px-5 py-3 text-sm font-semibold text-plum transition hover:border-rose/22 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {isLoadingMore ? "Loading more..." : "Load more looks"}
+                  </button>
+                </div>
+              ) : null}
+            </>
+          ) : null}
+        </section>
+      </div>
+
+      <MobileNav active="profile" />
+    </main>
+  );
+}

--- a/apps/web/components/chrome/mobile-nav.tsx
+++ b/apps/web/components/chrome/mobile-nav.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import type { ReactNode } from "react";
 
 type MobileNavProps = {
-  active: "home" | "boards" | "vault";
+  active: "home" | "boards" | "vault" | "profile";
 };
 
 function HomeIcon({ active }: { active: boolean }) {
@@ -41,6 +41,24 @@ function BoardsIcon({ active }: { active: boolean }) {
       <rect x="13.5" y="4" width="6.5" height="6.5" rx="1.4" />
       <rect x="4" y="13.5" width="6.5" height="6.5" rx="1.4" />
       <rect x="13.5" y="13.5" width="6.5" height="6.5" rx="1.4" />
+    </svg>
+  );
+}
+
+function ProfileIcon({ active }: { active: boolean }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      className={`h-5 w-5 ${active ? "text-[#f46a93]" : "text-plum/60"}`}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="8" r="4" />
+      <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" />
     </svg>
   );
 }
@@ -106,6 +124,7 @@ export function MobileNav({ active }: MobileNavProps) {
           <span className="text-[0.62rem] uppercase tracking-[0.18em] text-plum/36">Soon</span>
         </button>
         <NavItem href="/vault" label="Vault" active={active === "vault"} icon={<VaultIcon active={active === "vault"} />} />
+        <NavItem href="/profile" label="Profile" active={active === "profile"} icon={<ProfileIcon active={active === "profile"} />} />
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary

- Builds own profile page at `/profile` — pulls real data from the API, full outfit grid with infinite scroll
- Builds public profile page at `/profile/[username]` — follow/unfollow with optimistic UI, 404 state, auto-redirects own username to `/profile`
- Adds Profile tab to `MobileNav` as 4th item (person icon), active state wired

## Own profile (`/profile`)
- Avatar with initials fallback
- Display name, @username, bio (with "Add a bio →" nudge if empty)
- Stat pills: outfits / followers / following
- Edit profile + sign out buttons in top bar
- Paginated outfit grid via `apiClient.outfits.getVault()` — load more button
- Empty state with upload CTA

## Public profile (`/profile/[username]`)
- Same profile card layout, read-only
- Follow button (pink gradient) / Following (outlined) — toggles on click, optimistic count update using `FollowStatus` response
- Loads outfits via `apiClient.outfits.getByUser(username)` with load-more
- Not-found state for unknown usernames
- Auto-redirects to `/profile` if viewing own username

## Test plan
- [ ] `/profile` loads and shows real user data when logged in
- [ ] Outfit grid paginates correctly
- [ ] `/profile/someuser` shows another user's profile and follow button
- [ ] Follow/unfollow updates count without page reload
- [ ] `/profile/me` (own username) redirects to `/profile`
- [ ] `/profile/nobody` shows not-found state
- [ ] Profile tab in nav highlights correctly
- [ ] TypeScript: `npx tsc --noEmit` passes

Closes #41