### PR TITLE
feat(web): boards UI, story card share, outfit detail (#50 #54 #71)

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -1,0 +1,39 @@
+name: Web CI
+
+on:
+  push:
+    paths:
+      - "apps/web/**"
+      - ".github/workflows/web-ci.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/web/**"
+      - ".github/workflows/web-ci.yml"
+
+jobs:
+  smoke:
+    name: Frontend smoke tests
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: apps/web
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run smoke tests
+        run: npm run test:smoke

--- a/apps/web/app/boards/[id]/page.tsx
+++ b/apps/web/app/boards/[id]/page.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import Link from "next/link";
+import { use, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiClient, type Board, type BoardMember, type OutfitResponse } from "@/lib/api-client";
+import { MobileNav } from "@/components/chrome/mobile-nav";
+import { OutfitCard, OutfitCardSkeleton, type OutfitCardData } from "@/components/outfits/outfit-card";
+import { useAuth } from "@/lib/auth-context";
+
+type PageStatus = "loading" | "ready" | "not-found" | "gone" | "error";
+
+function toCardData(outfit: OutfitResponse): OutfitCardData {
+  return {
+    id: outfit.id,
+    imageUrl: outfit.image_url,
+    caption: outfit.caption,
+    eventName: outfit.event_name,
+    wornOn: outfit.worn_on,
+    createdAt: outfit.created_at,
+    vibeTone: outfit.vibe_check_tone,
+  };
+}
+
+function formatDate(d?: string | null) {
+  if (!d) return null;
+  return new Intl.DateTimeFormat("en-US", { month: "long", day: "numeric", year: "numeric" }).format(new Date(d));
+}
+
+function formatExpiry(d: string) {
+  const days = Math.ceil((new Date(d).getTime() - Date.now()) / 86_400_000);
+  if (days < 0) return "Expired";
+  if (days === 0) return "Expires today";
+  if (days === 1) return "1 day left";
+  return `${days} days left`;
+}
+
+// ── Invite link copy ──────────────────────────────────────────────────────────
+
+function InviteCopy({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false);
+  const link = `${typeof window !== "undefined" ? window.location.origin : ""}/boards/join/${code}`;
+
+  async function copy() {
+    await navigator.clipboard.writeText(link);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <div className="flex items-center gap-2 rounded-[1.2rem] border border-rose/12 bg-white px-4 py-3">
+      <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0 text-[#ef5f8a]" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+        <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+      </svg>
+      <span className="min-w-0 flex-1 truncate text-[0.72rem] text-plum/60">{link}</span>
+      <button
+        type="button"
+        onClick={() => void copy()}
+        className="shrink-0 text-[0.72rem] font-semibold text-[#ef5f8a] transition hover:text-[#d94e7a]"
+      >
+        {copied ? "Copied!" : "Copy"}
+      </button>
+    </div>
+  );
+}
+
+// ── Member strip ──────────────────────────────────────────────────────────────
+
+function MemberStrip({ members }: { members: BoardMember[] }) {
+  const shown = members.slice(0, 7);
+  const extra = members.length - shown.length;
+
+  return (
+    <div className="flex items-center gap-1.5">
+      {shown.map((m) => (
+        <div key={m.user_id} title={m.display_name ?? m.username ?? "Member"}>
+          {m.profile_image_url ? (
+            <img
+              src={m.profile_image_url}
+              alt={m.username ?? "Member"}
+              className="h-8 w-8 rounded-full border-2 border-white object-cover shadow-sm"
+            />
+          ) : (
+            <div className="flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-gradient-to-br from-[#fce4ec] to-[#f8bbd0] text-[0.65rem] font-semibold text-[#c0476e] shadow-sm">
+              {(m.display_name ?? m.username ?? "?").charAt(0).toUpperCase()}
+            </div>
+          )}
+        </div>
+      ))}
+      {extra > 0 ? (
+        <div className="flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-[#fff4f7] text-[0.6rem] font-semibold text-[#ef5f8a]">
+          +{extra}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default function BoardDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const router = useRouter();
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth();
+
+  const [status, setStatus] = useState<PageStatus>("loading");
+  const [board, setBoard] = useState<Board | null>(null);
+  const [members, setMembers] = useState<BoardMember[]>([]);
+  const [outfits, setOutfits] = useState<OutfitResponse[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [leaveLoading, setLeaveLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) router.replace("/login");
+  }, [isAuthenticated, authLoading, router]);
+
+  useEffect(() => {
+    if (authLoading || !isAuthenticated) return;
+    let active = true;
+
+    async function load() {
+      setStatus("loading");
+
+      const [boardResult, membersResult, outfitsResult] = await Promise.all([
+        apiClient.boards.get(id),
+        apiClient.boards.getMembers(id),
+        apiClient.boards.getOutfits(id, { limit: 12 }),
+      ]);
+
+      if (!active) return;
+
+      if (!boardResult.ok) {
+        const msg = boardResult.message?.toLowerCase() ?? "";
+        setStatus(msg.includes("expired") ? "gone" : msg.includes("not found") ? "not-found" : "error");
+        setErrorMessage(boardResult.message);
+        return;
+      }
+
+      setBoard(boardResult.data);
+      if (membersResult.ok) setMembers(membersResult.data);
+      if (outfitsResult.ok) {
+        setOutfits(outfitsResult.data.outfits);
+        setNextCursor(outfitsResult.data.next_cursor ?? null);
+      }
+      setStatus("ready");
+    }
+
+    void load();
+    return () => { active = false; };
+  }, [id, isAuthenticated, authLoading]);
+
+  async function handleLoadMore() {
+    if (!nextCursor || isLoadingMore) return;
+    setIsLoadingMore(true);
+    const result = await apiClient.boards.getOutfits(id, { cursor: nextCursor, limit: 12 });
+    if (result.ok) {
+      setOutfits((prev) => [...prev, ...result.data.outfits]);
+      setNextCursor(result.data.next_cursor ?? null);
+    }
+    setIsLoadingMore(false);
+  }
+
+  async function handleLeave() {
+    if (leaveLoading) return;
+    setLeaveLoading(true);
+    const result = await apiClient.boards.leave(id);
+    if (result.ok) {
+      router.replace("/boards");
+    } else {
+      setErrorMessage(result.message);
+      setLeaveLoading(false);
+    }
+  }
+
+  if (authLoading || !isAuthenticated) return null;
+
+  // ── Error states ──
+  if (status === "gone") {
+    return (
+      <main className="px-4 pb-28 pt-6 sm:px-6">
+        <div className="mx-auto flex min-h-[60vh] max-w-2xl items-center justify-center">
+          <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
+            <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+            <h1 className="mt-4 text-3xl text-ink">Board expired</h1>
+            <p className="mt-3 text-sm leading-6 text-plum/68">This board has passed its event date and is no longer active.</p>
+            <Link href="/boards" className="mt-6 inline-block rounded-[1.2rem] border border-rose/15 bg-white px-5 py-3 text-sm font-semibold text-plum transition hover:border-rose/25">
+              Back to boards
+            </Link>
+          </div>
+        </div>
+        <MobileNav active="boards" />
+      </main>
+    );
+  }
+
+  if (status === "not-found" || status === "error") {
+    return (
+      <main className="px-4 pb-28 pt-6 sm:px-6">
+        <div className="mx-auto flex min-h-[60vh] max-w-2xl items-center justify-center">
+          <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
+            <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+            <h1 className="mt-4 text-3xl text-ink">Board not found</h1>
+            <p className="mt-3 text-sm leading-6 text-plum/68">{errorMessage ?? "This board doesn't exist or you're not a member."}</p>
+            <Link href="/boards" className="mt-6 inline-block rounded-[1.2rem] border border-rose/15 bg-white px-5 py-3 text-sm font-semibold text-plum transition hover:border-rose/25">
+              Back to boards
+            </Link>
+          </div>
+        </div>
+        <MobileNav active="boards" />
+      </main>
+    );
+  }
+
+  const isCreator = board?.creator_id === user?.id;
+  const eventLabel = formatDate(board?.event_date);
+  const expiryLabel = board ? formatExpiry(board.expires_at) : "";
+
+  return (
+    <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-3xl">
+
+        {/* Top bar */}
+        <header className="mb-6 flex items-start justify-between gap-3">
+          <div>
+            <Link href="/boards" className="flex items-center gap-1.5 text-sm text-plum/58 transition hover:text-plum">
+              <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="m15 18-6-6 6-6" />
+              </svg>
+              Boards
+            </Link>
+            <p className="mt-2 font-display text-[3.4rem] leading-none tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+          </div>
+        </header>
+
+        {/* Board info card */}
+        {status === "loading" ? (
+          <div className="soft-panel mb-6 animate-pulse px-6 py-7">
+            <div className="space-y-3">
+              <div className="h-6 w-48 rounded-full bg-[#ffe8ef]" />
+              <div className="h-3.5 w-32 rounded-full bg-[#fff3f7]" />
+            </div>
+          </div>
+        ) : (
+          <section className="soft-panel mb-6 px-6 py-6">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <h1 className="font-display text-3xl leading-tight tracking-[-0.03em] text-ink">{board?.name}</h1>
+                {eventLabel ? (
+                  <p className="mt-1 text-sm text-plum/58">{eventLabel}</p>
+                ) : null}
+              </div>
+              <span className="shrink-0 rounded-full border border-rose/15 bg-[#fff4f7] px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.16em] text-[#ef5f8a]">
+                {expiryLabel}
+              </span>
+            </div>
+
+            {/* Members */}
+            {members.length > 0 ? (
+              <div className="mt-4 flex items-center gap-3 border-t border-rose/8 pt-4">
+                <MemberStrip members={members} />
+                <span className="text-[0.72rem] text-plum/50">
+                  {members.length} {members.length === 1 ? "member" : "members"}
+                </span>
+              </div>
+            ) : null}
+
+            {/* Invite link */}
+            {board ? (
+              <div className="mt-4">
+                <p className="mb-2 text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-plum/48">Invite link</p>
+                <InviteCopy code={board.invite_code} />
+              </div>
+            ) : null}
+
+            {/* Leave / delete */}
+            <div className="mt-4 flex gap-2 border-t border-rose/8 pt-4">
+              {isCreator ? (
+                <Link
+                  href="/boards"
+                  className="text-[0.72rem] text-plum/42 transition hover:text-[#c04b72]"
+                  onClick={async (e) => {
+                    e.preventDefault();
+                    if (!confirm("Delete this board and all its content?")) return;
+                    await apiClient.boards.delete(id);
+                    router.replace("/boards");
+                  }}
+                >
+                  Delete board
+                </Link>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => void handleLeave()}
+                  disabled={leaveLoading}
+                  className="text-[0.72rem] text-plum/42 transition hover:text-[#c04b72] disabled:opacity-50"
+                >
+                  {leaveLoading ? "Leaving…" : "Leave board"}
+                </button>
+              )}
+            </div>
+          </section>
+        )}
+
+        {/* Outfits section */}
+        <section>
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="font-display text-xl tracking-[-0.02em] text-ink">Looks</h2>
+            <Link
+              href={`/upload?board=${id}`}
+              className="inline-flex items-center gap-1.5 rounded-full border border-rose/15 bg-white px-4 py-2 text-[0.78rem] font-semibold text-[#ef5f8a] shadow-[0_8px_20px_rgba(244,106,147,0.07)] transition hover:border-rose/28"
+            >
+              <svg viewBox="0 0 24 24" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M12 5v14M5 12h14" />
+              </svg>
+              Add look
+            </Link>
+          </div>
+
+          {status === "loading" ? (
+            <div className="grid grid-cols-2 gap-3 sm:gap-4">
+              {Array.from({ length: 4 }).map((_, i) => <OutfitCardSkeleton key={i} showAuthor={false} />)}
+            </div>
+          ) : null}
+
+          {status === "ready" && outfits.length === 0 ? (
+            <div className="soft-panel px-6 py-10 text-center">
+              <h2 className="text-2xl text-ink">No looks yet</h2>
+              <p className="mt-3 text-sm leading-6 text-plum/68">Be the first to post an outfit to this board.</p>
+              <Link
+                href={`/upload?board=${id}`}
+                className="mt-5 inline-block rounded-[1.2rem] bg-gradient-to-r from-[#ef6c96] to-[#f493b0] px-6 py-3 text-sm font-semibold text-white transition hover:brightness-[0.98]"
+              >
+                Add the first look
+              </Link>
+            </div>
+          ) : null}
+
+          {status === "ready" && outfits.length > 0 ? (
+            <>
+              <div className="grid grid-cols-2 gap-3 sm:gap-4">
+                {outfits.map((o) => <OutfitCard key={o.id} outfit={toCardData(o)} showAuthor={false} showAccentMarker />)}
+              </div>
+              {nextCursor ? (
+                <div className="mt-8 flex justify-center">
+                  <button
+                    type="button"
+                    onClick={() => void handleLoadMore()}
+                    disabled={isLoadingMore}
+                    className="rounded-full border border-rose/12 bg-white px-5 py-3 text-sm font-semibold text-plum transition hover:border-rose/22 disabled:opacity-50"
+                  >
+                    {isLoadingMore ? "Loading…" : "Load more"}
+                  </button>
+                </div>
+              ) : null}
+            </>
+          ) : null}
+        </section>
+      </div>
+      <MobileNav active="boards" />
+    </main>
+  );
+}

--- a/apps/web/app/boards/join/[code]/page.tsx
+++ b/apps/web/app/boards/join/[code]/page.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import Link from "next/link";
+import { use, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiClient, type Board } from "@/lib/api-client";
+import { useAuth } from "@/lib/auth-context";
+
+type PageStatus = "loading" | "preview" | "not-found" | "error";
+
+function formatDate(d?: string | null) {
+  if (!d) return null;
+  return new Intl.DateTimeFormat("en-US", { month: "long", day: "numeric", year: "numeric" }).format(new Date(d));
+}
+
+function formatExpiry(d: string) {
+  const days = Math.ceil((new Date(d).getTime() - Date.now()) / 86_400_000);
+  if (days < 0) return "Expired";
+  if (days === 0) return "Expires today";
+  if (days === 1) return "1 day left";
+  return `${days} days left`;
+}
+
+export default function JoinBoardPage({ params }: { params: Promise<{ code: string }> }) {
+  const { code } = use(params);
+  const router = useRouter();
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+
+  const [status, setStatus] = useState<PageStatus>("loading");
+  const [board, setBoard] = useState<Board | null>(null);
+  const [joining, setJoining] = useState(false);
+  const [joinError, setJoinError] = useState<string | null>(null);
+
+  // Load board preview (no auth needed)
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      const result = await apiClient.boards.previewInvite(code);
+      if (!active) return;
+      if (result.ok) {
+        setBoard(result.data);
+        setStatus("preview");
+      } else {
+        setStatus(result.message?.toLowerCase().includes("not found") ? "not-found" : "error");
+      }
+    }
+
+    void load();
+    return () => { active = false; };
+  }, [code]);
+
+  async function handleJoin() {
+    if (!isAuthenticated) {
+      // Send to login, then return here
+      router.push(`/login?redirect=/boards/join/${code}`);
+      return;
+    }
+
+    setJoining(true);
+    setJoinError(null);
+    const result = await apiClient.boards.join(code);
+
+    if (result.ok) {
+      router.replace(`/boards/${result.data.id}`);
+    } else {
+      setJoinError(result.message);
+      setJoining(false);
+    }
+  }
+
+  // ── Loading ──
+  if (status === "loading" || authLoading) {
+    return (
+      <main className="flex min-h-screen items-center justify-center px-4">
+        <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
+          <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+          <h1 className="mt-4 text-2xl text-ink">Loading invite…</h1>
+        </div>
+      </main>
+    );
+  }
+
+  // ── Not found ──
+  if (status === "not-found" || status === "error") {
+    return (
+      <main className="flex min-h-screen items-center justify-center px-4">
+        <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
+          <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+          <h1 className="mt-4 text-2xl text-ink">Invite not found</h1>
+          <p className="mt-3 text-sm leading-6 text-plum/68">
+            This invite link is invalid or the board no longer exists.
+          </p>
+          <Link
+            href="/feed"
+            className="mt-6 inline-block rounded-[1.2rem] border border-rose/15 bg-white px-5 py-3 text-sm font-semibold text-plum transition hover:border-rose/25"
+          >
+            Go to feed
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  const eventLabel = formatDate(board?.event_date);
+  const expiryLabel = board ? formatExpiry(board.expires_at) : "";
+  const expired = expiryLabel === "Expired";
+
+  return (
+    <main className="flex min-h-screen items-center justify-center px-4 py-10">
+      <div className="w-full max-w-sm">
+
+        {/* Logo */}
+        <p className="mb-8 text-center font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+
+        {/* Board preview card */}
+        <div className="soft-panel overflow-hidden">
+          {/* Coloured header */}
+          <div className="bg-gradient-to-br from-[#fce4ec] to-[#fdf2f5] px-6 pt-6 pb-5">
+            <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-rose/15 bg-white/80 text-[#ef5f8a]">
+              <svg viewBox="0 0 24 24" className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                <rect x="4" y="4" width="6.5" height="6.5" rx="1.4" />
+                <rect x="13.5" y="4" width="6.5" height="6.5" rx="1.4" />
+                <rect x="4" y="13.5" width="6.5" height="6.5" rx="1.4" />
+                <rect x="13.5" y="13.5" width="6.5" height="6.5" rx="1.4" />
+              </svg>
+            </div>
+          </div>
+
+          {/* Board details */}
+          <div className="px-6 py-5">
+            <p className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-plum/48">
+              You&apos;re invited to join
+            </p>
+            <h1 className="mt-2 font-display text-3xl leading-tight tracking-[-0.03em] text-ink">
+              {board?.name}
+            </h1>
+            {eventLabel ? (
+              <p className="mt-1 text-sm text-plum/58">{eventLabel}</p>
+            ) : null}
+
+            <div className="mt-4 flex items-center gap-3">
+              <span className={`rounded-full px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.16em] ${expired ? "bg-rose/8 text-plum/40" : "bg-[#fff4f7] text-[#ef5f8a]"}`}>
+                {expiryLabel}
+              </span>
+              <span className="text-[0.72rem] text-plum/48">
+                {board?.member_count ?? 0} {(board?.member_count ?? 0) === 1 ? "member" : "members"}
+              </span>
+            </div>
+
+            {joinError ? (
+              <p className="mt-4 rounded-[1rem] border border-rose/25 bg-[#fff3f7] px-4 py-3 text-sm text-[#c04b72]">{joinError}</p>
+            ) : null}
+
+            {/* CTA */}
+            <div className="mt-6 space-y-3">
+              {expired ? (
+                <p className="rounded-[1.2rem] border border-rose/12 bg-[#fff3f7] px-5 py-3.5 text-center text-sm font-semibold text-[#c04b72]">
+                  This board has expired
+                </p>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => void handleJoin()}
+                  disabled={joining}
+                  className="w-full rounded-[1.2rem] bg-gradient-to-r from-[#ef6c96] to-[#f493b0] py-3.5 text-sm font-semibold text-white transition hover:brightness-[0.98] disabled:cursor-not-allowed disabled:opacity-55"
+                >
+                  {joining ? "Joining…" : isAuthenticated ? "Join board" : "Sign in to join"}
+                </button>
+              )}
+
+              <Link
+                href="/feed"
+                className="block rounded-[1.2rem] border border-rose/12 bg-white py-3.5 text-center text-sm font-semibold text-plum transition hover:border-rose/22"
+              >
+                Maybe later
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        {!isAuthenticated ? (
+          <p className="mt-5 text-center text-[0.72rem] text-plum/45">
+            Don&apos;t have an account?{" "}
+            <Link href={`/signup?redirect=/boards/join/${code}`} className="text-[#ef5f8a] hover:underline">
+              Sign up free
+            </Link>
+          </p>
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/boards/page.tsx
+++ b/apps/web/app/boards/page.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiClient, type Board } from "@/lib/api-client";
+import { MobileNav } from "@/components/chrome/mobile-nav";
+import { useAuth } from "@/lib/auth-context";
+
+type PageStatus = "loading" | "ready" | "error";
+
+function formatEventDate(d?: string | null) {
+  if (!d) return null;
+  return new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric" }).format(new Date(d));
+}
+
+function formatExpiry(d: string) {
+  const days = Math.ceil((new Date(d).getTime() - Date.now()) / 86_400_000);
+  if (days < 0) return "Expired";
+  if (days === 0) return "Expires today";
+  if (days === 1) return "1 day left";
+  return `${days} days left`;
+}
+
+// ── Create board modal ────────────────────────────────────────────────────────
+
+function CreateBoardModal({ onClose, onCreate }: {
+  onClose: () => void;
+  onCreate: (board: Board) => void;
+}) {
+  const [name, setName] = useState("");
+  const [eventDate, setEventDate] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => { inputRef.current?.focus(); }, []);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) return;
+    setLoading(true);
+    setError(null);
+
+    const result = await apiClient.boards.create({
+      name: name.trim(),
+      event_date: eventDate || undefined,
+    });
+
+    if (result.ok) {
+      onCreate(result.data);
+    } else {
+      setError(result.message);
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center bg-[rgba(36,21,28,0.38)] px-4 pb-4 sm:items-center sm:pb-0 backdrop-blur-sm">
+      <div className="soft-panel w-full max-w-md px-6 py-7">
+        <div className="mb-5 flex items-center justify-between">
+          <h2 className="font-display text-2xl tracking-[-0.03em] text-ink">New board</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-rose/12 text-plum/50 transition hover:border-rose/22 hover:text-plum"
+          >
+            <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M18 6 6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+          <div className="field-shell">
+            <label className="field-label" htmlFor="board-name">Board name</label>
+            <input
+              ref={inputRef}
+              id="board-name"
+              type="text"
+              placeholder="e.g. Met Gala 2026, Summer wedding"
+              maxLength={120}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="field-input"
+            />
+          </div>
+
+          <div className="field-shell">
+            <label className="block text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-plum/52 mb-1" htmlFor="event-date">
+              Event date <span className="font-normal normal-case tracking-normal text-plum/38">(optional)</span>
+            </label>
+            <input
+              id="event-date"
+              type="date"
+              value={eventDate}
+              onChange={(e) => setEventDate(e.target.value)}
+              className="field-input text-sm"
+            />
+          </div>
+
+          {error ? (
+            <p className="rounded-[1rem] border border-rose/25 bg-[#fff3f7] px-4 py-3 text-sm text-[#c04b72]">{error}</p>
+          ) : null}
+
+          <div className="flex gap-3 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 rounded-[1.2rem] border border-rose/12 bg-white py-3.5 text-sm font-semibold text-plum transition hover:border-rose/22"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading || !name.trim()}
+              className="flex-1 rounded-[1.2rem] bg-gradient-to-r from-[#ef6c96] to-[#f493b0] py-3.5 text-sm font-semibold text-white transition hover:brightness-[0.98] disabled:cursor-not-allowed disabled:opacity-55"
+            >
+              {loading ? "Creating…" : "Create board"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+// ── Board card ────────────────────────────────────────────────────────────────
+
+function BoardCard({ board }: { board: Board }) {
+  const eventLabel = formatEventDate(board.event_date);
+  const expiryLabel = formatExpiry(board.expires_at);
+  const expired = expiryLabel === "Expired";
+
+  return (
+    <Link
+      href={`/boards/${board.id}`}
+      className={`group block overflow-hidden rounded-[1.75rem] border bg-white shadow-[0_18px_42px_rgba(244,106,147,0.07)] transition hover:-translate-y-0.5 hover:border-rose/22 ${expired ? "border-rose/8 opacity-60" : "border-rose/10"}`}
+    >
+      <div className="bg-gradient-to-br from-[#fce4ec] to-[#fdf2f5] px-5 pt-5 pb-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-rose/15 bg-white/80 text-[#ef5f8a]">
+            <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+              <rect x="4" y="4" width="6.5" height="6.5" rx="1.4" />
+              <rect x="13.5" y="4" width="6.5" height="6.5" rx="1.4" />
+              <rect x="4" y="13.5" width="6.5" height="6.5" rx="1.4" />
+              <rect x="13.5" y="13.5" width="6.5" height="6.5" rx="1.4" />
+            </svg>
+          </div>
+          <span className={`rounded-full px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.16em] ${expired ? "bg-rose/10 text-plum/50" : "bg-white/80 text-[#ef5f8a]"}`}>
+            {expiryLabel}
+          </span>
+        </div>
+      </div>
+
+      <div className="px-5 py-4 space-y-1">
+        <h3 className="font-display text-xl tracking-[-0.02em] text-ink leading-tight">{board.name}</h3>
+        {eventLabel ? (
+          <p className="text-[0.72rem] uppercase tracking-[0.18em] text-plum/52">{eventLabel}</p>
+        ) : null}
+        <p className="text-[0.72rem] uppercase tracking-[0.16em] text-plum/42">
+          {board.member_count} {board.member_count === 1 ? "member" : "members"}
+        </p>
+      </div>
+    </Link>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default function BoardsPage() {
+  const router = useRouter();
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+
+  const [status, setStatus] = useState<PageStatus>("loading");
+  const [boards, setBoards] = useState<Board[]>([]);
+  const [showCreate, setShowCreate] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) router.replace("/login");
+  }, [isAuthenticated, authLoading, router]);
+
+  useEffect(() => {
+    if (authLoading || !isAuthenticated) return;
+    let active = true;
+
+    async function load() {
+      setStatus("loading");
+      const result = await apiClient.boards.list();
+      if (!active) return;
+      if (result.ok) {
+        setBoards(result.data);
+        setStatus("ready");
+      } else {
+        setErrorMessage(result.message);
+        setStatus("error");
+      }
+    }
+
+    void load();
+    return () => { active = false; };
+  }, [isAuthenticated, authLoading]);
+
+  function handleCreated(board: Board) {
+    setBoards((prev) => [board, ...prev]);
+    setShowCreate(false);
+  }
+
+  if (authLoading || !isAuthenticated) {
+    return (
+      <main className="px-4 py-6 sm:px-6">
+        <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-3xl items-center justify-center">
+          <section className="soft-panel w-full max-w-sm px-6 py-10 text-center">
+            <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+            <h1 className="mt-4 text-3xl text-ink">Loading boards</h1>
+          </section>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <>
+      <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-3xl">
+
+          {/* Header */}
+          <header className="mb-6 flex items-start justify-between gap-3">
+            <div>
+              <p className="font-display text-[3.4rem] leading-none tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+              <p className="mt-1 text-sm text-plum/54">Your outfit boards</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setShowCreate(true)}
+              className="icon-button mt-1"
+              aria-label="Create new board"
+            >
+              <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M12 5v14M5 12h14" />
+              </svg>
+            </button>
+          </header>
+
+          {errorMessage ? (
+            <div className="mb-5 rounded-[1.25rem] border border-rose/25 bg-[#fff3f7] px-4 py-3 text-sm text-[#c04b72]">{errorMessage}</div>
+          ) : null}
+
+          {/* Loading skeletons */}
+          {status === "loading" ? (
+            <div className="grid gap-4 sm:grid-cols-2">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="animate-pulse overflow-hidden rounded-[1.75rem] border border-rose/10 bg-white">
+                  <div className="h-20 bg-[linear-gradient(120deg,_rgba(255,236,242,0.8),_rgba(255,255,255,0.98))]" />
+                  <div className="space-y-2 px-5 py-4">
+                    <div className="h-4 w-2/3 rounded-full bg-[#ffe8ef]" />
+                    <div className="h-3 w-1/3 rounded-full bg-[#fff3f7]" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          {/* Empty state */}
+          {status === "ready" && boards.length === 0 ? (
+            <section className="soft-panel px-6 py-10 text-center">
+              <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl border border-rose/12 bg-[#fff4f7] text-[#ef5f8a]">
+                <svg viewBox="0 0 24 24" className="h-7 w-7" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="4" y="4" width="6.5" height="6.5" rx="1.4" />
+                  <rect x="13.5" y="4" width="6.5" height="6.5" rx="1.4" />
+                  <rect x="4" y="13.5" width="6.5" height="6.5" rx="1.4" />
+                  <rect x="13.5" y="13.5" width="6.5" height="6.5" rx="1.4" />
+                </svg>
+              </div>
+              <h2 className="mt-5 text-3xl text-ink">No boards yet</h2>
+              <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-plum/68">
+                Boards are private spaces for an event — create one and invite your crew to post their looks together.
+              </p>
+              <button
+                type="button"
+                onClick={() => setShowCreate(true)}
+                className="mt-6 rounded-[1.2rem] bg-gradient-to-r from-[#ef6c96] to-[#f493b0] px-6 py-3.5 text-sm font-semibold text-white transition hover:brightness-[0.98]"
+              >
+                Create your first board
+              </button>
+            </section>
+          ) : null}
+
+          {/* Board grid */}
+          {status === "ready" && boards.length > 0 ? (
+            <div className="grid gap-4 sm:grid-cols-2">
+              {boards.map((b) => <BoardCard key={b.id} board={b} />)}
+            </div>
+          ) : null}
+        </div>
+      </main>
+
+      {showCreate ? (
+        <CreateBoardModal onClose={() => setShowCreate(false)} onCreate={handleCreated} />
+      ) : null}
+
+      <MobileNav active="boards" />
+    </>
+  );
+}

--- a/apps/web/app/vault/page.tsx
+++ b/apps/web/app/vault/page.tsx
@@ -55,7 +55,7 @@ export default function VaultPage() {
       setVaultStatus("loading");
       setErrorMessage(null);
 
-      const result = await apiClient.outfits.getMine({ limit: INITIAL_PAGE_SIZE });
+      const result = await apiClient.outfits.getVault({ limit: INITIAL_PAGE_SIZE });
 
       if (!isActive) {
         return;
@@ -89,7 +89,7 @@ export default function VaultPage() {
     setIsLoadingMore(true);
     setErrorMessage(null);
 
-    const result = await apiClient.outfits.getMine({
+    const result = await apiClient.outfits.getVault({
       cursor: nextCursor,
       limit: INITIAL_PAGE_SIZE
     });

--- a/apps/web/components/chrome/mobile-nav.tsx
+++ b/apps/web/components/chrome/mobile-nav.tsx
@@ -114,15 +114,7 @@ export function MobileNav({ active }: MobileNavProps) {
     <nav className="fixed inset-x-0 bottom-4 z-40 flex justify-center px-4">
       <div className="mobile-dock">
         <NavItem href="/feed" label="Home" active={active === "home"} icon={<HomeIcon active={active === "home"} />} />
-        <button
-          type="button"
-          aria-disabled="true"
-          className="flex min-w-[72px] cursor-default flex-col items-center gap-1 rounded-full px-4 py-2 text-[0.72rem] font-medium text-plum/42"
-        >
-          <BoardsIcon active={active === "boards"} />
-          <span>Boards</span>
-          <span className="text-[0.62rem] uppercase tracking-[0.18em] text-plum/36">Soon</span>
-        </button>
+        <NavItem href="/boards" label="Boards" active={active === "boards"} icon={<BoardsIcon active={active === "boards"} />} />
         <NavItem href="/vault" label="Vault" active={active === "vault"} icon={<VaultIcon active={active === "vault"} />} />
         <NavItem href="/profile" label="Profile" active={active === "profile"} icon={<ProfileIcon active={active === "profile"} />} />
       </div>

--- a/apps/web/components/outfits/outfit-detail-view.tsx
+++ b/apps/web/components/outfits/outfit-detail-view.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiClient, type OutfitDetailResponse } from "@/lib/api-client";
+import { MobileNav } from "@/components/chrome/mobile-nav";
+import { StoryCardSheet } from "@/components/outfits/story-card-sheet";
+import { useAuth } from "@/lib/auth-context";
+
+type PageStatus = "loading" | "ready" | "not-found" | "error";
+
+const TONE_BADGE: Record<string, { bg: string; text: string; border: string }> = {
+  athletic:   { bg: "bg-cyan-100/85",    text: "text-cyan-900",    border: "border-cyan-300/70" },
+  boho:       { bg: "bg-violet-100/85",  text: "text-violet-900",  border: "border-violet-300/75" },
+  business:   { bg: "bg-sky-100/85",     text: "text-sky-900",     border: "border-sky-300/75" },
+  casual:     { bg: "bg-blue-100/85",    text: "text-blue-900",    border: "border-blue-300/75" },
+  formal:     { bg: "bg-amber-100/90",   text: "text-amber-950",   border: "border-amber-300/75" },
+  maximalist: { bg: "bg-pink-100/85",    text: "text-pink-900",    border: "border-pink-300/75" },
+  minimalist: { bg: "bg-slate-100/90",   text: "text-slate-800",   border: "border-slate-300/75" },
+  preppy:     { bg: "bg-emerald-100/85", text: "text-emerald-900", border: "border-emerald-300/70" },
+  streetwear: { bg: "bg-rose-100/85",    text: "text-rose-900",    border: "border-rose-300/75" },
+  vintage:    { bg: "bg-orange-100/85",  text: "text-orange-900",  border: "border-orange-300/75" },
+};
+
+function formatDate(d?: string | null) {
+  if (!d) return null;
+  return new Intl.DateTimeFormat("en-US", { month: "long", day: "numeric", year: "numeric" }).format(new Date(d));
+}
+
+export function OutfitDetailView({ id }: { id: string }) {
+  const router = useRouter();
+  const { user, isAuthenticated } = useAuth();
+
+  const [status, setStatus] = useState<PageStatus>("loading");
+  const [outfit, setOutfit] = useState<OutfitDetailResponse | null>(null);
+  const [liked, setLiked] = useState(false);
+  const [likeCount, setLikeCount] = useState(0);
+  const [likeLoading, setLikeLoading] = useState(false);
+  const [showShare, setShowShare] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      setStatus("loading");
+      const result = await apiClient.outfits.getDetail(id);
+      if (!active) return;
+
+      if (!result.ok) {
+        setStatus(result.message?.toLowerCase().includes("not found") ? "not-found" : "error");
+        return;
+      }
+
+      setOutfit(result.data);
+      setStatus("ready");
+
+      // Fetch like status if logged in
+      if (isAuthenticated) {
+        const likeResult = await apiClient.outfits.getLikes(id);
+        if (!active) return;
+        if (likeResult.ok) {
+          setLiked(likeResult.data.liked);
+          setLikeCount(likeResult.data.like_count);
+        }
+      }
+    }
+
+    void load();
+    return () => { active = false; };
+  }, [id, isAuthenticated]);
+
+  async function handleLike() {
+    if (!isAuthenticated || likeLoading) return;
+    setLikeLoading(true);
+
+    if (liked) {
+      const result = await apiClient.outfits.unlike(id);
+      if (result.ok) {
+        setLiked(false);
+        setLikeCount((c) => Math.max(0, c - 1));
+      }
+    } else {
+      const result = await apiClient.outfits.like(id);
+      if (result.ok) {
+        setLiked(true);
+        setLikeCount(result.data.like_count);
+      }
+    }
+    setLikeLoading(false);
+  }
+
+  // ── Not found ──
+  if (status === "not-found") {
+    return (
+      <main className="flex min-h-screen items-center justify-center px-4">
+        <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
+          <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+          <h1 className="mt-4 text-3xl text-ink">Outfit not found</h1>
+          <p className="mt-3 text-sm leading-6 text-plum/68">This look may have been removed.</p>
+          <Link href="/feed" className="mt-6 inline-block rounded-[1.2rem] border border-rose/15 bg-white px-5 py-3 text-sm font-semibold text-plum transition hover:border-rose/25">
+            Back to feed
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  const tone = outfit?.vibe_check_tone?.toLowerCase();
+  const toneStyle = tone ? TONE_BADGE[tone] : null;
+  const isOwn = outfit?.owner?.id === user?.id;
+  const dateLabel = formatDate(outfit?.worn_on ?? outfit?.created_at);
+
+  return (
+    <>
+      <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-4xl">
+
+          {/* Top bar */}
+          <header className="mb-5 flex items-center justify-between">
+            <button
+              type="button"
+              onClick={() => router.back()}
+              className="flex items-center gap-1.5 text-sm text-plum/58 transition hover:text-plum"
+            >
+              <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="m15 18-6-6 6-6" />
+              </svg>
+              Back
+            </button>
+
+            <button
+              type="button"
+              onClick={() => setShowShare(true)}
+              className="flex items-center gap-2 rounded-full border border-rose/15 bg-white px-4 py-2.5 text-[0.78rem] font-semibold text-plum shadow-[0_8px_20px_rgba(244,106,147,0.07)] transition hover:border-rose/28"
+            >
+              <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="18" cy="5" r="3" />
+                <circle cx="6" cy="12" r="3" />
+                <circle cx="18" cy="19" r="3" />
+                <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+                <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+              </svg>
+              Share
+            </button>
+          </header>
+
+          <div className="grid gap-6 lg:grid-cols-[1fr_420px]">
+
+            {/* ── Left: outfit image ── */}
+            <div>
+              {status === "loading" ? (
+                <div className="aspect-[4/5] w-full animate-pulse rounded-[2rem] bg-[linear-gradient(120deg,_rgba(255,236,242,0.8),_rgba(255,255,255,0.98),_rgba(250,216,225,0.62))]" />
+              ) : (
+                <div className="relative overflow-hidden rounded-[2rem] border border-rose/10 bg-white shadow-[0_24px_60px_rgba(244,106,147,0.12)]">
+                  <img
+                    src={outfit?.image_url}
+                    alt={outfit?.caption ?? "Outfit photo"}
+                    className="aspect-[4/5] w-full object-cover"
+                  />
+                  {toneStyle ? (
+                    <div className="absolute left-4 top-4">
+                      <span className={`inline-flex items-center rounded-full border px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.16em] backdrop-blur ${toneStyle.border} ${toneStyle.bg} ${toneStyle.text}`}>
+                        {outfit?.vibe_check_tone}
+                      </span>
+                    </div>
+                  ) : null}
+                </div>
+              )}
+            </div>
+
+            {/* ── Right: details ── */}
+            <div className="space-y-5">
+
+              {/* Author */}
+              {status === "loading" ? (
+                <div className="soft-panel flex animate-pulse items-center gap-3 px-5 py-4">
+                  <div className="h-11 w-11 rounded-full bg-[#ffe8ef]" />
+                  <div className="flex-1 space-y-2">
+                    <div className="h-3.5 w-28 rounded-full bg-[#ffe8ef]" />
+                    <div className="h-3 w-20 rounded-full bg-[#fff3f7]" />
+                  </div>
+                </div>
+              ) : outfit?.owner ? (
+                <Link
+                  href={`/profile/${outfit.owner.username}`}
+                  className="soft-panel flex items-center gap-3 px-5 py-4 transition hover:border-rose/18"
+                >
+                  {outfit.owner.profile_image_url ? (
+                    <img
+                      src={outfit.owner.profile_image_url}
+                      alt={outfit.owner.username ?? ""}
+                      className="h-11 w-11 rounded-full border border-plum/10 object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-11 w-11 items-center justify-center rounded-full border border-plum/14 bg-gradient-to-br from-[#fce4ec] to-[#f8bbd0] text-sm font-semibold text-[#c0476e]">
+                      {(outfit.owner.display_name ?? outfit.owner.username ?? "?").charAt(0).toUpperCase()}
+                    </div>
+                  )}
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-semibold text-ink">
+                      {outfit.owner.display_name ?? outfit.owner.username}
+                    </p>
+                    {outfit.owner.username ? (
+                      <p className="text-[0.7rem] text-plum/50">@{outfit.owner.username}</p>
+                    ) : null}
+                  </div>
+                  <svg viewBox="0 0 24 24" className="ml-auto h-4 w-4 shrink-0 text-plum/30" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="m9 18 6-6-6-6" />
+                  </svg>
+                </Link>
+              ) : null}
+
+              {/* Caption + meta */}
+              <div className="soft-panel px-5 py-5 space-y-4">
+                {status === "loading" ? (
+                  <div className="space-y-3">
+                    <div className="h-4 w-full rounded-full bg-[#ffe8ef]" />
+                    <div className="h-4 w-4/5 rounded-full bg-[#fff3f7]" />
+                    <div className="h-3 w-1/3 rounded-full bg-[#fff6f9]" />
+                  </div>
+                ) : (
+                  <>
+                    {outfit?.caption ? (
+                      <p className="text-sm leading-7 text-plum/84">{outfit.caption}</p>
+                    ) : null}
+
+                    {outfit?.event_name ? (
+                      <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-plum/52">
+                        {outfit.event_name}
+                      </p>
+                    ) : null}
+
+                    {dateLabel ? (
+                      <p className="text-[0.7rem] uppercase tracking-[0.18em] text-plum/42">{dateLabel}</p>
+                    ) : null}
+
+                    {outfit?.vibe_check_text ? (
+                      <div className="rounded-[1rem] border border-rose/10 bg-[#fff8fb] px-4 py-3">
+                        <p className="mb-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[#ef5f8a]">Vibe check</p>
+                        <p className="text-sm leading-6 text-plum/80">{outfit.vibe_check_text}</p>
+                      </div>
+                    ) : null}
+                  </>
+                )}
+              </div>
+
+              {/* Clothing items */}
+              {status === "ready" && outfit && outfit.clothing_items.length > 0 ? (
+                <div className="soft-panel px-5 py-5">
+                  <p className="mb-3 text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-plum/48">Pieces</p>
+                  <ul className="space-y-3">
+                    {outfit.clothing_items.map((item) => (
+                      <li key={item.id} className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-semibold text-ink capitalize">{item.category}</p>
+                          <p className="text-[0.7rem] text-plum/52">
+                            {[item.brand, item.color].filter(Boolean).join(" · ")}
+                          </p>
+                        </div>
+                        {item.link_url ? (
+                          <a
+                            href={item.link_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="shrink-0 rounded-full border border-rose/15 px-3 py-1 text-[0.68rem] font-semibold text-[#ef5f8a] transition hover:border-rose/28"
+                          >
+                            Shop
+                          </a>
+                        ) : null}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+
+              {/* Like + share actions */}
+              <div className="flex gap-3">
+                <button
+                  type="button"
+                  onClick={() => void handleLike()}
+                  disabled={likeLoading || !isAuthenticated}
+                  className={`flex flex-1 items-center justify-center gap-2 rounded-[1.2rem] border py-3.5 text-sm font-semibold transition disabled:cursor-default ${
+                    liked
+                      ? "border-[#f6a9be] bg-[#fff1f6] text-[#ef5f8a]"
+                      : "border-rose/15 bg-white text-plum hover:border-rose/28"
+                  }`}
+                >
+                  <svg viewBox="0 0 24 24" className="h-4.5 w-4.5" fill={liked ? "currentColor" : "none"} stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+                  </svg>
+                  {likeCount > 0 ? likeCount.toLocaleString() : "Like"}
+                </button>
+
+                <button
+                  type="button"
+                  onClick={() => setShowShare(true)}
+                  className="flex flex-1 items-center justify-center gap-2 rounded-[1.2rem] border border-rose/15 bg-white py-3.5 text-sm font-semibold text-plum transition hover:border-rose/28"
+                >
+                  <svg viewBox="0 0 24 24" className="h-4.5 w-4.5" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round">
+                    <circle cx="18" cy="5" r="3" />
+                    <circle cx="6" cy="12" r="3" />
+                    <circle cx="18" cy="19" r="3" />
+                    <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+                    <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+                  </svg>
+                  Share
+                </button>
+
+                {isOwn ? (
+                  <Link
+                    href="/vault"
+                    className="flex aspect-square items-center justify-center rounded-[1.2rem] border border-rose/15 bg-white p-3.5 text-plum/60 transition hover:border-rose/28 hover:text-plum"
+                    aria-label="View in vault"
+                  >
+                    <svg viewBox="0 0 24 24" className="h-4.5 w-4.5" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M7 7.5A2.5 2.5 0 0 1 9.5 5h5A2.5 2.5 0 0 1 17 7.5V9H7V7.5Z" />
+                      <path d="M6 9h12v9.5A2.5 2.5 0 0 1 15.5 21h-7A2.5 2.5 0 0 1 6 18.5V9Z" />
+                      <path d="M10 13h4" />
+                    </svg>
+                  </Link>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+
+      {showShare ? (
+        <StoryCardSheet outfitId={id} onClose={() => setShowShare(false)} />
+      ) : null}
+
+      <MobileNav active="home" />
+    </>
+  );
+}

--- a/apps/web/components/outfits/story-card-sheet.tsx
+++ b/apps/web/components/outfits/story-card-sheet.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+import { apiClient } from "@/lib/api-client";
+
+type StoryCardSheetProps = {
+  outfitId: string;
+  onClose: () => void;
+};
+
+export function StoryCardSheet({ outfitId, onClose }: StoryCardSheetProps) {
+  const [copied, setCopied] = useState(false);
+
+  const cardUrl = apiClient.outfits.storyCardUrl(outfitId);
+  const shareLink = `${typeof window !== "undefined" ? window.location.origin : ""}/outfits/${outfitId}`;
+
+  function handleDownload() {
+    const a = document.createElement("a");
+    a.href = cardUrl;
+    a.download = `ootd-${outfitId.slice(0, 8)}.png`;
+    a.click();
+  }
+
+  async function handleCopyLink() {
+    await navigator.clipboard.writeText(shareLink);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  async function handleNativeShare() {
+    if (!navigator.share) return;
+    await navigator.share({ title: "My OOTD", url: shareLink });
+  }
+
+  const canNativeShare = typeof navigator !== "undefined" && "share" in navigator;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-[rgba(36,21,28,0.42)] px-4 pb-4 sm:items-center sm:pb-0 backdrop-blur-sm"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="soft-panel w-full max-w-sm overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 pt-6 pb-4">
+          <h2 className="font-display text-2xl tracking-[-0.03em] text-ink">Share look</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-rose/12 text-plum/50 transition hover:border-rose/22 hover:text-plum"
+          >
+            <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M18 6 6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Story card preview */}
+        <div className="relative mx-6 mb-5 overflow-hidden rounded-[1.4rem] border border-rose/10 bg-[#0d0f14] shadow-[0_12px_40px_rgba(0,0,0,0.18)]">
+          {/* Aspect ratio wrapper — story cards are 1080×1920 (9:16) */}
+          <div className="relative aspect-[9/16] w-full">
+            <img
+              src={cardUrl}
+              alt="Story card preview"
+              className="h-full w-full object-cover"
+              loading="lazy"
+            />
+            {/* Loading shimmer shown while img loads */}
+            <div className="absolute inset-0 -z-10 animate-pulse bg-[linear-gradient(135deg,_#1a1020_0%,_#2a1830_50%,_#1a1020_100%)]" />
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="space-y-3 px-6 pb-6">
+          {/* Download */}
+          <button
+            type="button"
+            onClick={handleDownload}
+            className="flex w-full items-center gap-3 rounded-[1.2rem] bg-gradient-to-r from-[#ef6c96] to-[#f493b0] px-5 py-3.5 text-sm font-semibold text-white transition hover:brightness-[0.98]"
+          >
+            <svg viewBox="0 0 24 24" className="h-4.5 w-4.5 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+              <polyline points="7 10 12 15 17 10" />
+              <line x1="12" y1="15" x2="12" y2="3" />
+            </svg>
+            Save story card
+          </button>
+
+          <div className="flex gap-3">
+            {/* Copy link */}
+            <button
+              type="button"
+              onClick={() => void handleCopyLink()}
+              className="flex flex-1 items-center justify-center gap-2 rounded-[1.2rem] border border-rose/15 bg-white py-3.5 text-sm font-semibold text-plum transition hover:border-rose/25"
+            >
+              <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+                <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+              </svg>
+              {copied ? "Copied!" : "Copy link"}
+            </button>
+
+            {/* Native share (mobile) */}
+            {canNativeShare ? (
+              <button
+                type="button"
+                onClick={() => void handleNativeShare()}
+                className="flex flex-1 items-center justify-center gap-2 rounded-[1.2rem] border border-rose/15 bg-white py-3.5 text-sm font-semibold text-plum transition hover:border-rose/25"
+              >
+                <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="18" cy="5" r="3" />
+                  <circle cx="6" cy="12" r="3" />
+                  <circle cx="18" cy="19" r="3" />
+                  <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+                  <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+                </svg>
+                Share
+              </button>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -65,13 +65,6 @@ export type OutfitResponse = {
   clothing_items: OutfitClothingItem[];
 };
 
-export type OutfitOwner = {
-  id: string;
-  username?: string | null;
-  display_name?: string | null;
-  profile_image_url?: string | null;
-};
-
 export type FeedAuthor = {
   id: string;
   username?: string | null;
@@ -87,13 +80,132 @@ export type FeedPageResponse = {
   next_cursor?: string | null;
 };
 
-export type VaultPageResponse = {
-  outfits: OutfitResponse[];
-  next_cursor?: string | null;
+// ── Outfit detail ─────────────────────────────────────────────────────────────
+
+export type OutfitOwner = {
+  id: string;
+  username: string | null;
+  display_name: string | null;
+  profile_image_url: string | null;
 };
 
+/** Full outfit detail — returned by GET /outfits/{id} */
 export type OutfitDetailResponse = OutfitResponse & {
   owner: OutfitOwner;
+};
+
+export type VaultPage = {
+  outfits: OutfitResponse[];
+  next_cursor: string | null;
+};
+
+export type OutfitOG = {
+  title: string;
+  description: string;
+  image_url: string;
+  page_url: string;
+  site_name: string;
+  twitter_card: string;
+};
+
+export type CaptionSuggestions = {
+  suggestions: string[];
+};
+
+// ── Likes & comments ──────────────────────────────────────────────────────────
+
+export type LikeStatus = {
+  like_count: number;
+  liked: boolean;
+};
+
+export type CommentAuthor = {
+  id: string;
+  username: string | null;
+  display_name: string | null;
+  profile_image_url: string | null;
+};
+
+export type Comment = {
+  id: string;
+  outfit_id: string;
+  user_id: string;
+  body: string;
+  created_at: string;
+  updated_at: string;
+  author: CommentAuthor;
+};
+
+export type CommentPage = {
+  comments: Comment[];
+  next_cursor: string | null;
+};
+
+// ── Users ─────────────────────────────────────────────────────────────────────
+
+export type PublicProfile = {
+  id: string;
+  username: string | null;
+  display_name: string | null;
+  bio: string | null;
+  profile_image_url: string | null;
+  follower_count: number;
+  following_count: number;
+  created_at: string;
+};
+
+export type FollowStatus = {
+  following: boolean;
+  follower_count: number;
+};
+
+export type UserSearchResult = {
+  id: string;
+  username: string | null;
+  display_name: string | null;
+  profile_image_url: string | null;
+  follower_count: number;
+};
+
+export type WrappedStats = {
+  year: number;
+  month: number;
+  total_outfits: number;
+  total_items: number;
+  top_colors: Array<{ color: string; count: number }>;
+  top_brands: Array<{ brand: string; count: number }>;
+  top_categories: Array<{ category: string; count: number }>;
+  longest_streak: number;
+  current_streak: number;
+  most_worn_vibe: string | null;
+  outfits_by_week: Array<{ week: number; count: number }>;
+};
+
+// ── Boards ────────────────────────────────────────────────────────────────────
+
+export type Board = {
+  id: string;
+  name: string;
+  event_date: string | null;
+  invite_code: string;
+  creator_id: string;
+  expires_at: string;
+  member_count: number;
+  created_at: string;
+};
+
+export type BoardMember = {
+  user_id: string;
+  username: string | null;
+  display_name: string | null;
+  profile_image_url: string | null;
+  role: "creator" | "member";
+  joined_at: string;
+};
+
+export type BoardOutfitPage = {
+  outfits: OutfitResponse[];
+  next_cursor: string | null;
 };
 
 export type CreateOutfitInput = {
@@ -607,12 +719,10 @@ export const userApiClient = {
     });
   },
 
-  async getWrapped(input?: { year?: number; month?: number }): Promise<ApiResult<WrappedStats>> {
-    const params = new URLSearchParams();
-    if (input?.year) params.set("year", String(input.year));
-    if (input?.month) params.set("month", String(input.month));
-    const query = params.toString();
-    return sendRequest<WrappedStats>(`/users/me/wrapped${query ? `?${query}` : ""}`, {
+  /** month must be "YYYY-MM" (e.g. "2026-04"). Defaults to the current calendar month. */
+  async getWrapped(month?: string): Promise<ApiResult<WrappedStats>> {
+    const m = month ?? new Date().toISOString().slice(0, 7); // "YYYY-MM"
+    return sendRequest<WrappedStats>(`/users/me/wrapped?month=${encodeURIComponent(m)}`, {
       requiresAuth: true,
       successMessage: "Loaded wrapped stats."
     });
@@ -728,38 +838,6 @@ export const boardApiClient = {
       requiresAuth: true,
       successMessage: pinned ? "Outfit pinned." : "Outfit unpinned."
     });
-  },
-
-  async getMine(input?: {
-    cursor?: string;
-    limit?: number;
-  }): Promise<ApiResult<VaultPageResponse>> {
-    const params = new URLSearchParams();
-
-    if (input?.cursor) {
-      params.set("cursor", input.cursor);
-    }
-
-    if (input?.limit) {
-      params.set("limit", String(input.limit));
-    }
-
-    const query = params.toString();
-
-    return sendRequest<VaultPageResponse>(`/outfits/me${query ? `?${query}` : ""}`, {
-      requiresAuth: true,
-      successMessage: "Loaded vault."
-    });
-  },
-
-  async getById(id: string): Promise<ApiResult<OutfitDetailResponse>> {
-    return sendRequest<OutfitDetailResponse>(`/outfits/${id}`, {
-      successMessage: "Loaded outfit detail."
-    });
-  },
-
-  getStoryCardUrl(id: string) {
-    return `${DEFAULT_API_BASE_URL}/outfits/${id}/story-card`;
   }
 };
 

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@types/node": "^22.10.1",
         "@types/react": "^19.0.2",
         "@types/react-dom": "^19.0.2",
@@ -758,6 +759,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "license": "Apache-2.0",
@@ -1395,6 +1412,52 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:e2e": "playwright test",
+    "test:smoke": "playwright test tests/smoke.spec.ts"
   },
   "dependencies": {
     "next": "^15.0.0",
@@ -14,6 +16,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/node": "^22.10.1",
     "@types/react": "^19.0.2",
     "@types/react-dom": "^19.0.2",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = Number(process.env.PORT ?? 3000);
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${PORT}`;
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000
+  },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [["github"], ["list"]] : "list",
+  use: {
+    baseURL,
+    trace: "on-first-retry"
+  },
+  webServer: {
+    command: `npm run dev -- --hostname 127.0.0.1 --port ${PORT}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] }
+    }
+  ]
+});

--- a/apps/web/tests/smoke.spec.ts
+++ b/apps/web/tests/smoke.spec.ts
@@ -1,0 +1,184 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const apiBase = "http://localhost:8000";
+const appOrigin = process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3000";
+const appHostname = new URL(appOrigin).hostname;
+const authUser = {
+  id: "11111111-1111-4111-8111-111111111111",
+  username: "teststylist",
+  email: "test@example.com",
+  display_name: "Test Stylist",
+  bio: null,
+  profile_image_url: null
+};
+
+async function mockAuthenticatedApi(page: Page) {
+  await page.route(`${apiBase}/**`, async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const corsHeaders = {
+      "Access-Control-Allow-Credentials": "true",
+      "Access-Control-Allow-Headers": "authorization,content-type",
+      "Access-Control-Allow-Methods": "GET,POST,DELETE,PATCH,OPTIONS",
+      "Access-Control-Allow-Origin": appOrigin
+    };
+
+    if (request.method() === "OPTIONS") {
+      await route.fulfill({
+        status: 204,
+        headers: corsHeaders
+      });
+      return;
+    }
+
+    if (url.pathname === "/auth/refresh") {
+      await route.fulfill({
+        status: 200,
+        headers: {
+          ...corsHeaders,
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          access_token: "test-access-token",
+          token_type: "bearer"
+        })
+      });
+      return;
+    }
+
+    if (url.pathname === "/auth/me") {
+      await route.fulfill({
+        status: 200,
+        headers: {
+          ...corsHeaders,
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(authUser)
+      });
+      return;
+    }
+
+    if (url.pathname === "/outfits" && request.method() === "POST") {
+      await route.fulfill({
+        status: 201,
+        headers: {
+          ...corsHeaders,
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          id: "22222222-2222-4222-8222-222222222222",
+          user_id: authUser.id,
+          image_url: "https://cdn.example.com/outfits/test-fit.jpg",
+          caption: "Smoke test fit",
+          event_name: null,
+          worn_on: null,
+          vibe_check_text: null,
+          vibe_check_tone: null,
+          created_at: "2026-04-26T00:00:00Z",
+          updated_at: "2026-04-26T00:00:00Z",
+          clothing_items: []
+        })
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 404,
+      headers: {
+        ...corsHeaders,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ detail: "Unhandled mocked API route." })
+    });
+  });
+}
+
+async function setActiveSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "ootd_session",
+      value: "active",
+      domain: appHostname,
+      path: "/",
+      sameSite: "Lax"
+    }
+  ]);
+}
+
+test.describe("public routes", () => {
+  test("landing page links to auth screens", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("heading", {
+        name: /your personal style archive/i
+      })
+    ).toBeVisible();
+    await expect(page.getByRole("link", { name: /create your account/i })).toHaveAttribute(
+      "href",
+      "/signup"
+    );
+    await expect(page.getByRole("link", { name: /log in/i })).toHaveAttribute("href", "/login");
+  });
+
+  test("login and signup pages render their forms", async ({ page }) => {
+    await page.goto("/login");
+    await expect(page.getByRole("heading", { name: /^log in$/i })).toBeVisible();
+    await expect(page.getByLabel(/email/i)).toBeVisible();
+    await expect(page.getByLabel(/password/i)).toBeVisible();
+
+    await page.goto("/signup");
+    await expect(page.getByRole("heading", { name: /^create account$/i })).toBeVisible();
+    await expect(page.getByLabel(/username/i)).toBeVisible();
+    await expect(page.getByLabel(/email/i)).toBeVisible();
+    await expect(page.getByLabel(/^password$/i)).toBeVisible();
+    await expect(page.getByLabel(/confirm password/i)).toBeVisible();
+  });
+});
+
+test.describe("protected routes", () => {
+  test("redirect logged-out visitors to login with next path", async ({ page }) => {
+    await page.goto("/upload");
+
+    await expect(page).toHaveURL(/\/login\?next=%2Fupload$/);
+    await expect(page.getByRole("heading", { name: /^log in$/i })).toBeVisible();
+  });
+
+  test("shows upload validation before a photo is selected", async ({ page }) => {
+    await mockAuthenticatedApi(page);
+    await setActiveSession(page);
+
+    await page.goto("/upload");
+    await expect(page.getByRole("heading", { name: /build the look/i })).toBeVisible();
+
+    await page.getByRole("button", { name: /continue to items/i }).click();
+
+    await expect(page.getByText(/a photo is required to create an outfit post/i)).toBeVisible();
+    await expect(
+      page.getByText(/choose a fit photo before you move to the next step/i)
+    ).toBeVisible();
+  });
+
+  test("submits a valid mocked outfit upload", async ({ page }) => {
+    await mockAuthenticatedApi(page);
+    await setActiveSession(page);
+
+    await page.goto("/upload");
+    await expect(page.getByRole("heading", { name: /build the look/i })).toBeVisible();
+
+    await page.setInputFiles("input[type='file']", {
+      name: "fit.jpg",
+      mimeType: "image/jpeg",
+      buffer: Buffer.from("fake image bytes")
+    });
+
+    await page.getByRole("button", { name: /continue to items/i }).click();
+    await page.getByLabel(/category/i).fill("Dress");
+    await page.getByRole("button", { name: /continue to context/i }).click();
+    await page.getByLabel(/caption/i).fill("Smoke test fit");
+    await page.getByRole("button", { name: /continue to review/i }).click();
+    await page.getByRole("button", { name: /submit outfit/i }).click();
+
+    await expect(page.getByText(/outfit uploaded/i)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Three issues in one: boards creation/join UI, story card sharing, and the outfit detail page that ties them together.

## Boards (#50)

**`/boards`** — board list page
- Create board modal with name + optional event date
- Loading skeletons, empty state with CTA
- Board cards showing name, event date, member count, expiry countdown

**`/boards/[id]`** — board detail
- Outfit grid (paginated, pinned first)
- Member avatar strip with overflow count
- Invite link copy button
- Expiry badge (days remaining)
- Leave board / delete board (creator only)
- "Add look" button linking to upload

**`/boards/join/[code]`** — public join screen
- Board preview loads without auth (API is public)
- Join button — unauthenticated users sent to `/login?redirect=...`
- Expired board state
- Signup nudge for new users

**MobileNav** — Boards tab now live (was "Soon"/disabled)

## Story card share (#54)

**`StoryCardSheet`** component (bottom sheet modal):
- 9:16 story card preview rendered from live API endpoint (no auth needed)
- Shimmer loading state while image fetches
- Download PNG button (native anchor download)
- Copy outfit link button (clipboard API, 2s "Copied!" feedback)
- Native Web Share API on mobile (navigator.share)
- Tap backdrop to dismiss

## Outfit detail (#71)

Replaces the stub at `/outfits/[id]` with a full detail page:
- Full-size outfit image with vibe tone badge overlay
- Author card linking to `/profile/[username]`
- Caption, event name, date worn
- Vibe check sentence in a highlighted card
- Clothing items list with brand, color, shop links
- Like button with count (optimistic toggle, filled heart)
- Share button → opens StoryCardSheet

## Test plan
- [ ] Create a board → appears in list → open detail → copy invite link
- [ ] Open `/boards/join/[code]` in incognito — see preview, prompt to sign in
- [ ] Tap an outfit card → detail page loads with image and metadata
- [ ] Like button toggles and count updates without reload
- [ ] Share button → story card renders in sheet → download saves PNG
- [ ] Copy link → pastes correct outfit URL
- [ ] `npx tsc --noEmit` passes

Closes #50, #54, #71