### PR TITLE
feat: apply checkd design system to OOTD frontend

### DIFF
--- a/apps/web/app/boards/[id]/page.tsx
+++ b/apps/web/app/boards/[id]/page.tsx
@@ -49,15 +49,15 @@ function InviteCopy({ code }: { code: string }) {
 
   return (
     <div className="flex items-center gap-2 rounded-[1.2rem] border border-rose/12 bg-white px-4 py-3">
-      <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0 text-[#ef5f8a]" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0 text-pink-deep" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
         <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
         <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
       </svg>
-      <span className="min-w-0 flex-1 truncate text-[0.72rem] text-plum/60">{link}</span>
+      <span className="min-w-0 flex-1 truncate text-[0.72rem] text-mute">{link}</span>
       <button
         type="button"
         onClick={() => void copy()}
-        className="shrink-0 text-[0.72rem] font-semibold text-[#ef5f8a] transition hover:text-[#d94e7a]"
+        className="shrink-0 text-[0.72rem] font-semibold text-pink-deep transition hover:text-[#d94e7a]"
       >
         {copied ? "Copied!" : "Copy"}
       </button>
@@ -82,14 +82,14 @@ function MemberStrip({ members }: { members: BoardMember[] }) {
               className="h-8 w-8 rounded-full border-2 border-white object-cover shadow-sm"
             />
           ) : (
-            <div className="flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-gradient-to-br from-[#fce4ec] to-[#f8bbd0] text-[0.65rem] font-semibold text-[#c0476e] shadow-sm">
+            <div className="flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-pink-soft text-[0.65rem] font-semibold text-ink-soft shadow-sm">
               {(m.display_name ?? m.username ?? "?").charAt(0).toUpperCase()}
             </div>
           )}
         </div>
       ))}
       {extra > 0 ? (
-        <div className="flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-[#fff4f7] text-[0.6rem] font-semibold text-[#ef5f8a]">
+        <div className="flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-pink-soft text-[0.6rem] font-semibold text-pink-deep">
           +{extra}
         </div>
       ) : null}
@@ -183,9 +183,9 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
       <main className="px-4 pb-28 pt-6 sm:px-6">
         <div className="mx-auto flex min-h-[60vh] max-w-2xl items-center justify-center">
           <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-            <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+            <p className="font-display text-5xl text-pink-deep">OOTD</p>
             <h1 className="mt-4 text-3xl text-ink">Board expired</h1>
-            <p className="mt-3 text-sm leading-6 text-plum/68">This board has passed its event date and is no longer active.</p>
+            <p className="mt-3 text-sm leading-6 text-ink-soft">This board has passed its event date and is no longer active.</p>
             <Link href="/boards" className="mt-6 inline-block rounded-[1.2rem] border border-rose/15 bg-white px-5 py-3 text-sm font-semibold text-plum transition hover:border-rose/25">
               Back to boards
             </Link>
@@ -201,9 +201,9 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
       <main className="px-4 pb-28 pt-6 sm:px-6">
         <div className="mx-auto flex min-h-[60vh] max-w-2xl items-center justify-center">
           <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-            <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+            <p className="font-display text-5xl text-pink-deep">OOTD</p>
             <h1 className="mt-4 text-3xl text-ink">Board not found</h1>
-            <p className="mt-3 text-sm leading-6 text-plum/68">{errorMessage ?? "This board doesn't exist or you're not a member."}</p>
+            <p className="mt-3 text-sm leading-6 text-ink-soft">{errorMessage ?? "This board doesn't exist or you're not a member."}</p>
             <Link href="/boards" className="mt-6 inline-block rounded-[1.2rem] border border-rose/15 bg-white px-5 py-3 text-sm font-semibold text-plum transition hover:border-rose/25">
               Back to boards
             </Link>
@@ -225,13 +225,13 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
         {/* Top bar */}
         <header className="mb-6 flex items-start justify-between gap-3">
           <div>
-            <Link href="/boards" className="flex items-center gap-1.5 text-sm text-plum/58 transition hover:text-plum">
+            <Link href="/boards" className="flex items-center gap-1.5 text-sm text-mute transition hover:text-plum">
               <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="m15 18-6-6 6-6" />
               </svg>
               Boards
             </Link>
-            <p className="mt-2 font-display text-[3.4rem] leading-none tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+            <p className="mt-2 font-display text-[3.4rem] leading-none text-pink-deep">OOTD</p>
           </div>
         </header>
 
@@ -239,8 +239,8 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
         {status === "loading" ? (
           <div className="soft-panel mb-6 animate-pulse px-6 py-7">
             <div className="space-y-3">
-              <div className="h-6 w-48 rounded-full bg-[#ffe8ef]" />
-              <div className="h-3.5 w-32 rounded-full bg-[#fff3f7]" />
+              <div className="h-6 w-48 rounded-full bg-pink-soft" />
+              <div className="h-3.5 w-32 rounded-full bg-pink-soft" />
             </div>
           </div>
         ) : (
@@ -249,10 +249,10 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
               <div className="min-w-0">
                 <h1 className="font-display text-3xl leading-tight tracking-[-0.03em] text-ink">{board?.name}</h1>
                 {eventLabel ? (
-                  <p className="mt-1 text-sm text-plum/58">{eventLabel}</p>
+                  <p className="mt-1 text-sm text-mute">{eventLabel}</p>
                 ) : null}
               </div>
-              <span className="shrink-0 rounded-full border border-rose/15 bg-[#fff4f7] px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.16em] text-[#ef5f8a]">
+              <span className="shrink-0 rounded-full border border-rose/15 bg-pink-soft px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.16em] text-pink-deep">
                 {expiryLabel}
               </span>
             </div>
@@ -261,7 +261,7 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
             {members.length > 0 ? (
               <div className="mt-4 flex items-center gap-3 border-t border-rose/8 pt-4">
                 <MemberStrip members={members} />
-                <span className="text-[0.72rem] text-plum/50">
+                <span className="text-[0.72rem] text-mute">
                   {members.length} {members.length === 1 ? "member" : "members"}
                 </span>
               </div>
@@ -270,7 +270,7 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
             {/* Invite link */}
             {board ? (
               <div className="mt-4">
-                <p className="mb-2 text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-plum/48">Invite link</p>
+                <p className="mb-2 text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-mute">Invite link</p>
                 <InviteCopy code={board.invite_code} />
               </div>
             ) : null}
@@ -280,7 +280,7 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
               {isCreator ? (
                 <Link
                   href="/boards"
-                  className="text-[0.72rem] text-plum/42 transition hover:text-[#c04b72]"
+                  className="text-[0.72rem] text-mute transition hover:text-error"
                   onClick={async (e) => {
                     e.preventDefault();
                     if (!confirm("Delete this board and all its content?")) return;
@@ -295,7 +295,7 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
                   type="button"
                   onClick={() => void handleLeave()}
                   disabled={leaveLoading}
-                  className="text-[0.72rem] text-plum/42 transition hover:text-[#c04b72] disabled:opacity-50"
+                  className="text-[0.72rem] text-mute transition hover:text-error disabled:opacity-50"
                 >
                   {leaveLoading ? "Leaving…" : "Leave board"}
                 </button>
@@ -310,7 +310,7 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
             <h2 className="font-display text-xl tracking-[-0.02em] text-ink">Looks</h2>
             <Link
               href={`/upload?board=${id}`}
-              className="inline-flex items-center gap-1.5 rounded-full border border-rose/15 bg-white px-4 py-2 text-[0.78rem] font-semibold text-[#ef5f8a] shadow-[0_8px_20px_rgba(244,106,147,0.07)] transition hover:border-rose/28"
+              className="inline-flex items-center gap-1.5 rounded-full border border-rose/15 bg-white px-4 py-2 text-[0.78rem] font-semibold text-pink-deep transition hover:border-rose/28"
             >
               <svg viewBox="0 0 24 24" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M12 5v14M5 12h14" />
@@ -328,10 +328,10 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
           {status === "ready" && outfits.length === 0 ? (
             <div className="soft-panel px-6 py-10 text-center">
               <h2 className="text-2xl text-ink">No looks yet</h2>
-              <p className="mt-3 text-sm leading-6 text-plum/68">Be the first to post an outfit to this board.</p>
+              <p className="mt-3 text-sm leading-6 text-ink-soft">Be the first to post an outfit to this board.</p>
               <Link
                 href={`/upload?board=${id}`}
-                className="mt-5 inline-block rounded-[1.2rem] bg-gradient-to-r from-[#ef6c96] to-[#f493b0] px-6 py-3 text-sm font-semibold text-white transition hover:brightness-[0.98]"
+                className="mt-5 inline-block btn-primary"
               >
                 Add the first look
               </Link>

--- a/apps/web/app/boards/join/[code]/page.tsx
+++ b/apps/web/app/boards/join/[code]/page.tsx
@@ -74,7 +74,7 @@ export default function JoinBoardPage({ params }: { params: Promise<{ code: stri
     return (
       <main className="flex min-h-screen items-center justify-center px-4">
         <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-          <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+          <p className="font-display text-5xl text-pink-deep">OOTD</p>
           <h1 className="mt-4 text-2xl text-ink">Loading invite…</h1>
         </div>
       </main>
@@ -86,9 +86,9 @@ export default function JoinBoardPage({ params }: { params: Promise<{ code: stri
     return (
       <main className="flex min-h-screen items-center justify-center px-4">
         <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-          <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+          <p className="font-display text-5xl text-pink-deep">OOTD</p>
           <h1 className="mt-4 text-2xl text-ink">Invite not found</h1>
-          <p className="mt-3 text-sm leading-6 text-plum/68">
+          <p className="mt-3 text-sm leading-6 text-ink-soft">
             This invite link is invalid or the board no longer exists.
           </p>
           <Link
@@ -111,13 +111,13 @@ export default function JoinBoardPage({ params }: { params: Promise<{ code: stri
       <div className="w-full max-w-sm">
 
         {/* Logo */}
-        <p className="mb-8 text-center font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+        <p className="mb-8 text-center font-display text-5xl text-pink-deep">OOTD</p>
 
         {/* Board preview card */}
         <div className="soft-panel overflow-hidden">
           {/* Coloured header */}
-          <div className="bg-gradient-to-br from-[#fce4ec] to-[#fdf2f5] px-6 pt-6 pb-5">
-            <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-rose/15 bg-white/80 text-[#ef5f8a]">
+          <div className="bg-pink-soft px-6 pt-6 pb-5">
+            <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-rose/15 bg-white/80 text-pink-deep">
               <svg viewBox="0 0 24 24" className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
                 <rect x="4" y="4" width="6.5" height="6.5" rx="1.4" />
                 <rect x="13.5" y="4" width="6.5" height="6.5" rx="1.4" />
@@ -129,33 +129,33 @@ export default function JoinBoardPage({ params }: { params: Promise<{ code: stri
 
           {/* Board details */}
           <div className="px-6 py-5">
-            <p className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-plum/48">
+            <p className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-mute">
               You&apos;re invited to join
             </p>
             <h1 className="mt-2 font-display text-3xl leading-tight tracking-[-0.03em] text-ink">
               {board?.name}
             </h1>
             {eventLabel ? (
-              <p className="mt-1 text-sm text-plum/58">{eventLabel}</p>
+              <p className="mt-1 text-sm text-mute">{eventLabel}</p>
             ) : null}
 
             <div className="mt-4 flex items-center gap-3">
-              <span className={`rounded-full px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.16em] ${expired ? "bg-rose/8 text-plum/40" : "bg-[#fff4f7] text-[#ef5f8a]"}`}>
+              <span className={`rounded-full px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.16em] ${expired ? "bg-rose/8 text-mute" : "bg-pink-soft text-pink-deep"}`}>
                 {expiryLabel}
               </span>
-              <span className="text-[0.72rem] text-plum/48">
+              <span className="text-[0.72rem] text-mute">
                 {board?.member_count ?? 0} {(board?.member_count ?? 0) === 1 ? "member" : "members"}
               </span>
             </div>
 
             {joinError ? (
-              <p className="mt-4 rounded-[1rem] border border-rose/25 bg-[#fff3f7] px-4 py-3 text-sm text-[#c04b72]">{joinError}</p>
+              <p className="mt-4 rounded-[1rem] border border-rose/25 bg-pink-soft px-4 py-3 text-sm text-error">{joinError}</p>
             ) : null}
 
             {/* CTA */}
             <div className="mt-6 space-y-3">
               {expired ? (
-                <p className="rounded-[1.2rem] border border-rose/12 bg-[#fff3f7] px-5 py-3.5 text-center text-sm font-semibold text-[#c04b72]">
+                <p className="rounded-[1.2rem] border border-rose/12 bg-pink-soft px-5 py-3.5 text-center text-sm font-semibold text-error">
                   This board has expired
                 </p>
               ) : (
@@ -163,7 +163,7 @@ export default function JoinBoardPage({ params }: { params: Promise<{ code: stri
                   type="button"
                   onClick={() => void handleJoin()}
                   disabled={joining}
-                  className="w-full rounded-[1.2rem] bg-gradient-to-r from-[#ef6c96] to-[#f493b0] py-3.5 text-sm font-semibold text-white transition hover:brightness-[0.98] disabled:cursor-not-allowed disabled:opacity-55"
+                  className="btn-primary w-full"
                 >
                   {joining ? "Joining…" : isAuthenticated ? "Join board" : "Sign in to join"}
                 </button>
@@ -180,9 +180,9 @@ export default function JoinBoardPage({ params }: { params: Promise<{ code: stri
         </div>
 
         {!isAuthenticated ? (
-          <p className="mt-5 text-center text-[0.72rem] text-plum/45">
+          <p className="mt-5 text-center text-[0.72rem] text-mute">
             Don&apos;t have an account?{" "}
-            <Link href={`/signup?redirect=/boards/join/${code}`} className="text-[#ef5f8a] hover:underline">
+            <Link href={`/signup?redirect=/boards/join/${code}`} className="text-pink-deep hover:underline">
               Sign up free
             </Link>
           </p>

--- a/apps/web/app/boards/page.tsx
+++ b/apps/web/app/boards/page.tsx
@@ -63,7 +63,7 @@ function CreateBoardModal({ onClose, onCreate }: {
           <button
             type="button"
             onClick={onClose}
-            className="flex h-8 w-8 items-center justify-center rounded-full border border-rose/12 text-plum/50 transition hover:border-rose/22 hover:text-plum"
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-rose/12 text-mute transition hover:border-rose/22 hover:text-plum"
           >
             <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M18 6 6 18M6 6l12 12" />
@@ -87,8 +87,8 @@ function CreateBoardModal({ onClose, onCreate }: {
           </div>
 
           <div className="field-shell">
-            <label className="block text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-plum/52 mb-1" htmlFor="event-date">
-              Event date <span className="font-normal normal-case tracking-normal text-plum/38">(optional)</span>
+            <label className="block text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-mute mb-1" htmlFor="event-date">
+              Event date <span className="font-normal normal-case tracking-normal text-mute">(optional)</span>
             </label>
             <input
               id="event-date"
@@ -100,7 +100,7 @@ function CreateBoardModal({ onClose, onCreate }: {
           </div>
 
           {error ? (
-            <p className="rounded-[1rem] border border-rose/25 bg-[#fff3f7] px-4 py-3 text-sm text-[#c04b72]">{error}</p>
+            <p className="rounded-[1rem] border border-rose/25 bg-pink-soft px-4 py-3 text-sm text-error">{error}</p>
           ) : null}
 
           <div className="flex gap-3 pt-1">
@@ -114,7 +114,7 @@ function CreateBoardModal({ onClose, onCreate }: {
             <button
               type="submit"
               disabled={loading || !name.trim()}
-              className="flex-1 rounded-[1.2rem] bg-gradient-to-r from-[#ef6c96] to-[#f493b0] py-3.5 text-sm font-semibold text-white transition hover:brightness-[0.98] disabled:cursor-not-allowed disabled:opacity-55"
+              className="btn-primary flex-1"
             >
               {loading ? "Creating…" : "Create board"}
             </button>
@@ -135,11 +135,11 @@ function BoardCard({ board }: { board: Board }) {
   return (
     <Link
       href={`/boards/${board.id}`}
-      className={`group block overflow-hidden rounded-[1.75rem] border bg-white shadow-[0_18px_42px_rgba(244,106,147,0.07)] transition hover:-translate-y-0.5 hover:border-rose/22 ${expired ? "border-rose/8 opacity-60" : "border-rose/10"}`}
+      className={`group block overflow-hidden rounded-[1.75rem] border bg-white transition hover:-translate-y-0.5 hover:border-rose/22 ${expired ? "border-rose/8 opacity-60" : "border-rose/10"}`}
     >
-      <div className="bg-gradient-to-br from-[#fce4ec] to-[#fdf2f5] px-5 pt-5 pb-4">
+      <div className="bg-pink-soft px-5 pt-5 pb-4">
         <div className="flex items-start justify-between gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-rose/15 bg-white/80 text-[#ef5f8a]">
+          <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-rose/15 bg-white/80 text-pink-deep">
             <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
               <rect x="4" y="4" width="6.5" height="6.5" rx="1.4" />
               <rect x="13.5" y="4" width="6.5" height="6.5" rx="1.4" />
@@ -147,7 +147,7 @@ function BoardCard({ board }: { board: Board }) {
               <rect x="13.5" y="13.5" width="6.5" height="6.5" rx="1.4" />
             </svg>
           </div>
-          <span className={`rounded-full px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.16em] ${expired ? "bg-rose/10 text-plum/50" : "bg-white/80 text-[#ef5f8a]"}`}>
+          <span className={`rounded-full px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.16em] ${expired ? "bg-rose/10 text-mute" : "bg-white/80 text-pink-deep"}`}>
             {expiryLabel}
           </span>
         </div>
@@ -156,9 +156,9 @@ function BoardCard({ board }: { board: Board }) {
       <div className="px-5 py-4 space-y-1">
         <h3 className="font-display text-xl tracking-[-0.02em] text-ink leading-tight">{board.name}</h3>
         {eventLabel ? (
-          <p className="text-[0.72rem] uppercase tracking-[0.18em] text-plum/52">{eventLabel}</p>
+          <p className="text-[0.72rem] uppercase tracking-[0.18em] text-mute">{eventLabel}</p>
         ) : null}
-        <p className="text-[0.72rem] uppercase tracking-[0.16em] text-plum/42">
+        <p className="text-[0.72rem] uppercase tracking-[0.16em] text-mute">
           {board.member_count} {board.member_count === 1 ? "member" : "members"}
         </p>
       </div>
@@ -212,7 +212,7 @@ export default function BoardsPage() {
       <main className="px-4 py-6 sm:px-6">
         <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-3xl items-center justify-center">
           <section className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-            <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+            <p className="font-display text-5xl text-pink-deep">OOTD</p>
             <h1 className="mt-4 text-3xl text-ink">Loading boards</h1>
           </section>
         </div>
@@ -228,8 +228,8 @@ export default function BoardsPage() {
           {/* Header */}
           <header className="mb-6 flex items-start justify-between gap-3">
             <div>
-              <p className="font-display text-[3.4rem] leading-none tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
-              <p className="mt-1 text-sm text-plum/54">Your outfit boards</p>
+              <p className="font-display text-[3.4rem] leading-none text-pink-deep">OOTD</p>
+              <p className="mt-1 text-sm text-mute">Your outfit boards</p>
             </div>
             <div className="flex items-center gap-2 mt-1">
               <Link href="/search" className="icon-button" aria-label="Search people">
@@ -252,7 +252,7 @@ export default function BoardsPage() {
           </header>
 
           {errorMessage ? (
-            <div className="mb-5 rounded-[1.25rem] border border-rose/25 bg-[#fff3f7] px-4 py-3 text-sm text-[#c04b72]">{errorMessage}</div>
+            <div className="mb-5 rounded-[1.25rem] border border-rose/25 bg-pink-soft px-4 py-3 text-sm text-error">{errorMessage}</div>
           ) : null}
 
           {/* Loading skeletons */}
@@ -262,8 +262,8 @@ export default function BoardsPage() {
                 <div key={i} className="animate-pulse overflow-hidden rounded-[1.75rem] border border-rose/10 bg-white">
                   <div className="h-20 bg-[linear-gradient(120deg,_rgba(255,236,242,0.8),_rgba(255,255,255,0.98))]" />
                   <div className="space-y-2 px-5 py-4">
-                    <div className="h-4 w-2/3 rounded-full bg-[#ffe8ef]" />
-                    <div className="h-3 w-1/3 rounded-full bg-[#fff3f7]" />
+                    <div className="h-4 w-2/3 rounded-full bg-pink-soft" />
+                    <div className="h-3 w-1/3 rounded-full bg-pink-soft" />
                   </div>
                 </div>
               ))}
@@ -273,7 +273,7 @@ export default function BoardsPage() {
           {/* Empty state */}
           {status === "ready" && boards.length === 0 ? (
             <section className="soft-panel px-6 py-10 text-center">
-              <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl border border-rose/12 bg-[#fff4f7] text-[#ef5f8a]">
+              <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl border border-rose/12 bg-pink-soft text-pink-deep">
                 <svg viewBox="0 0 24 24" className="h-7 w-7" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
                   <rect x="4" y="4" width="6.5" height="6.5" rx="1.4" />
                   <rect x="13.5" y="4" width="6.5" height="6.5" rx="1.4" />
@@ -282,13 +282,13 @@ export default function BoardsPage() {
                 </svg>
               </div>
               <h2 className="mt-5 text-3xl text-ink">No boards yet</h2>
-              <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-plum/68">
+              <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-ink-soft">
                 Boards are private spaces for an event — create one and invite your crew to post their looks together.
               </p>
               <button
                 type="button"
                 onClick={() => setShowCreate(true)}
-                className="mt-6 rounded-[1.2rem] bg-gradient-to-r from-[#ef6c96] to-[#f493b0] px-6 py-3.5 text-sm font-semibold text-white transition hover:brightness-[0.98]"
+                className="mt-6 btn-primary"
               >
                 Create your first board
               </button>

--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -72,7 +72,7 @@ function UserChip({
   const initial = (user.display_name?.trim() || user.username?.trim() || "?").charAt(0).toUpperCase();
 
   return (
-    <div className="flex shrink-0 items-center gap-2 rounded-[1.25rem] border border-rose/10 bg-white px-3 py-2 shadow-[0_4px_12px_rgba(244,106,147,0.06)]">
+    <div className="flex shrink-0 items-center gap-2 rounded-[1.25rem] border border-rose/10 bg-white px-3 py-2">
       {user.profile_image_url ? (
         <img
           src={user.profile_image_url}
@@ -80,7 +80,7 @@ function UserChip({
           className="h-8 w-8 shrink-0 rounded-full border border-plum/10 object-cover"
         />
       ) : (
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-[#fce4ec] to-[#f8bbd0] text-xs font-semibold text-[#c0476e]">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-pink-soft text-xs font-semibold text-ink-soft">
           {initial}
         </div>
       )}
@@ -90,10 +90,10 @@ function UserChip({
       <button
         type="button"
         onClick={following ? onUnfollow : onFollow}
-        className={`shrink-0 rounded-full px-2.5 py-1 text-[0.68rem] font-semibold transition ${
+        className={`shrink-0 rounded-full px-2.5 py-1 text-[0.68rem] font-medium lowercase transition ${
           following
-            ? "border border-rose/15 bg-white text-plum hover:border-rose/28"
-            : "bg-gradient-to-r from-[#ef6c96] to-[#f493b0] text-white hover:brightness-[0.97]"
+            ? "border border-line bg-white text-ink-soft hover:border-pink-deep"
+            : "bg-ink text-paper hover:opacity-90"
         }`}
       >
         {following ? "Following" : "Follow"}
@@ -119,7 +119,7 @@ function WhoToFollowRail({
 
   return (
     <div className="mb-5">
-      <p className="mb-2 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-plum/40">
+      <p className="mb-2 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-mute">
         People to follow
       </p>
       <div className="flex gap-2 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
@@ -127,7 +127,7 @@ function WhoToFollowRail({
           ? Array.from({ length: 4 }).map((_, i) => (
               <div
                 key={i}
-                className="flex h-12 w-44 shrink-0 animate-pulse items-center gap-2 rounded-[1.25rem] border border-rose/10 bg-[#fff3f7] px-3"
+                className="flex h-12 w-44 shrink-0 animate-pulse items-center gap-2 rounded-[1.25rem] border border-rose/10 bg-pink-soft px-3"
               />
             ))
           : users.map((user) => (
@@ -236,7 +236,7 @@ export default function ExplorePage() {
       <main className="px-4 py-6 sm:px-6">
         <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-2xl items-center justify-center">
           <section className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-            <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+            <p className="font-display text-5xl text-pink-deep">OOTD</p>
             <h1 className="mt-4 text-3xl text-ink">Loading</h1>
           </section>
         </div>
@@ -252,10 +252,10 @@ export default function ExplorePage() {
         <header className="mb-5">
           <div className="mb-4 flex items-center justify-between gap-3">
             <div>
-              <p className="font-display text-[3.4rem] leading-none tracking-[-0.08em] text-[#f09ab4]">
+              <p className="font-display text-[3.4rem] leading-none text-pink-deep">
                 OOTD
               </p>
-              <p className="mt-1 text-sm text-plum/54">Explore</p>
+              <p className="mt-1 text-sm text-mute">Explore</p>
             </div>
             <Link href="/search" className="icon-button" aria-label="Search people">
               <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
@@ -271,11 +271,11 @@ export default function ExplorePage() {
             className="search-shell mb-5 block"
             aria-label="Search people"
           >
-            <svg aria-hidden="true" viewBox="0 0 24 24" className="h-4 w-4 shrink-0 text-plum/40" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <svg aria-hidden="true" viewBox="0 0 24 24" className="h-4 w-4 shrink-0 text-mute" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
               <circle cx="11" cy="11" r="6.5" />
               <path d="m16 16 4 4" />
             </svg>
-            <span className="search-input text-plum/40">Find people…</span>
+            <span className="search-input text-mute">Find people…</span>
           </Link>
 
           {/* Who to follow rail */}
@@ -300,13 +300,13 @@ export default function ExplorePage() {
 
           {gridStatus === "ready" && outfits.length === 0 ? (
             <div className="soft-panel px-6 py-10 text-center">
-              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-plum/42">
+              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-mute">
                 Nothing yet
               </p>
               <h2 className="mt-3 text-2xl text-ink">Follow some people to see outfits here</h2>
               <Link
                 href="/search"
-                className="mt-5 inline-block rounded-[1.2rem] bg-gradient-to-r from-[#ef6c96] to-[#f493b0] px-6 py-3 text-sm font-semibold text-white transition hover:brightness-[0.98]"
+                className="mt-5 inline-block btn-primary"
               >
                 Find people to follow
               </Link>
@@ -337,7 +337,7 @@ export default function ExplorePage() {
 
           {gridStatus === "error" ? (
             <div className="soft-panel px-6 py-8 text-center">
-              <p className="text-sm text-plum/60">Couldn&rsquo;t load outfits. Try refreshing.</p>
+              <p className="text-sm text-mute">Couldn&rsquo;t load outfits. Try refreshing.</p>
               <button
                 type="button"
                 onClick={() => router.refresh()}

--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -98,19 +98,19 @@ function useSentinel(onIntersect: () => void) {
 
 function TabSwitcher({ active, onChange }: { active: Tab; onChange: (t: Tab) => void }) {
   return (
-    <div className="inline-flex rounded-full border border-rose/12 bg-white/80 p-1 shadow-[0_4px_14px_rgba(244,106,147,0.08)]">
+    <div className="inline-flex rounded-full border border-rose/12 bg-white/80 p-1">
       {(["vault", "boards"] as Tab[]).map((tab) => (
         <button
           key={tab}
           type="button"
           onClick={() => onChange(tab)}
-          className={`rounded-full px-5 py-2 text-[0.78rem] font-semibold transition ${
+          className={`rounded-full px-5 py-2 text-[0.78rem] font-medium lowercase transition ${
             active === tab
-              ? "bg-gradient-to-r from-[#ef6c96] to-[#f493b0] text-white shadow-[0_4px_10px_rgba(244,106,147,0.3)]"
-              : "text-plum/60 hover:text-plum"
+              ? "bg-ink text-paper"
+              : "text-mute hover:text-ink"
           }`}
         >
-          {tab === "vault" ? "Vault Feed" : "Boards"}
+          {tab === "vault" ? "vault feed" : "boards"}
         </button>
       ))}
     </div>
@@ -131,7 +131,7 @@ function BoardActivityCard({
       <OutfitCard outfit={toBoardCardData(outfit)} showAuthor={false} />
       {/* Board name badge */}
       <div className="pointer-events-none absolute left-3 bottom-[4.5rem] right-3">
-        <span className="inline-flex max-w-full items-center gap-1.5 truncate rounded-full border border-plum/10 bg-white/88 px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.14em] text-plum/70 backdrop-blur">
+        <span className="inline-flex max-w-full items-center gap-1.5 truncate rounded-full border border-plum/10 bg-white/88 px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.14em] text-ink-soft backdrop-blur">
           <svg viewBox="0 0 24 24" className="h-3 w-3 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <rect x="4" y="4" width="6.5" height="6.5" rx="1.4" />
             <rect x="13.5" y="4" width="6.5" height="6.5" rx="1.4" />
@@ -201,7 +201,7 @@ function VaultFeedTab({ displayName }: { displayName: string }) {
   if (status === "error") {
     return (
       <div className="soft-panel px-6 py-8 text-center">
-        <p className="text-sm text-[#c04b72]">{error}</p>
+        <p className="text-sm text-error">{error}</p>
       </div>
     );
   }
@@ -209,15 +209,15 @@ function VaultFeedTab({ displayName }: { displayName: string }) {
   if (status === "ready" && outfits.length === 0) {
     return (
       <section className="soft-panel p-6 sm:p-8">
-        <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-plum/58">Empty feed</p>
+        <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-mute">Empty feed</p>
         <h2 className="mt-4 max-w-2xl text-4xl leading-tight text-ink sm:text-5xl">
           Your feed is ready. It just needs people.
         </h2>
-        <p className="mt-4 max-w-2xl text-sm leading-7 text-plum/70 sm:text-base">
+        <p className="mt-4 max-w-2xl text-sm leading-7 text-ink-soft sm:text-base">
           Once you follow people, their outfits will land here newest first. Until then, keep building your own archive.
         </p>
         <div className="mt-6 grid gap-3 sm:grid-cols-2">
-          <Link href="/upload" className="rounded-[1.2rem] bg-gradient-to-r from-[#ef6c96] to-[#f493b0] px-5 py-4 text-center text-sm font-semibold text-white transition hover:brightness-[0.98]">
+          <Link href="/upload" className="btn-primary">
             Upload your next outfit
           </Link>
           <Link href="/vault" className="rounded-[1.2rem] border border-rose/12 bg-white px-5 py-4 text-center text-sm font-semibold text-plum transition hover:border-rose/22">
@@ -339,7 +339,7 @@ function BoardsActivityTab() {
       <div className="space-y-8">
         {Array.from({ length: 2 }).map((_, i) => (
           <div key={i}>
-            <div className="mb-4 h-5 w-36 animate-pulse rounded-full bg-[#ffe8ef]" />
+            <div className="mb-4 h-5 w-36 animate-pulse rounded-full bg-pink-soft" />
             <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-3">
               {Array.from({ length: 4 }).map((_, j) => <OutfitCardSkeleton key={j} showAuthor={false} />)}
             </div>
@@ -352,7 +352,7 @@ function BoardsActivityTab() {
   if (boardsStatus === "error") {
     return (
       <div className="soft-panel px-6 py-8 text-center">
-        <p className="text-sm text-[#c04b72]">{boardsError}</p>
+        <p className="text-sm text-error">{boardsError}</p>
       </div>
     );
   }
@@ -360,12 +360,12 @@ function BoardsActivityTab() {
   if (boardsStatus === "ready" && sections.length === 0) {
     return (
       <section className="soft-panel p-6 sm:p-8">
-        <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-plum/58">No boards yet</p>
+        <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-mute">No boards yet</p>
         <h2 className="mt-4 text-4xl leading-tight text-ink">Join a board to see activity here</h2>
-        <p className="mt-4 text-sm leading-7 text-plum/70">
+        <p className="mt-4 text-sm leading-7 text-ink-soft">
           Boards are where you coordinate looks with friends for events. Get an invite link from someone to join.
         </p>
-        <Link href="/boards" className="mt-6 inline-block rounded-[1.2rem] bg-gradient-to-r from-[#ef6c96] to-[#f493b0] px-5 py-4 text-sm font-semibold text-white transition hover:brightness-[0.98]">
+        <Link href="/boards" className="mt-6 inline-block btn-primary">
           Go to boards
         </Link>
       </section>
@@ -383,21 +383,21 @@ function BoardsActivityTab() {
                 {section.board.name}
               </h2>
               {section.board.event_date ? (
-                <p className="mt-0.5 text-[0.68rem] uppercase tracking-[0.18em] text-plum/50">
+                <p className="mt-0.5 text-[0.68rem] uppercase tracking-[0.18em] text-mute">
                   {formatEventDate(section.board.event_date)}
                 </p>
               ) : null}
             </div>
             <Link
               href={`/boards/${section.board.id}`}
-              className="shrink-0 text-[0.72rem] font-semibold text-[#ef5f8a] hover:underline"
+              className="shrink-0 text-[0.72rem] font-semibold text-pink-deep hover:underline"
             >
               View board →
             </Link>
           </div>
 
           {section.outfits.length === 0 ? (
-            <p className="rounded-2xl border border-rose/10 bg-white/70 px-4 py-5 text-sm text-plum/54">
+            <p className="rounded-2xl border border-rose/10 bg-white/70 px-4 py-5 text-sm text-mute">
               No outfits posted yet.
             </p>
           ) : (
@@ -446,7 +446,7 @@ export default function FeedPage() {
       <main className="px-4 py-6 sm:px-6 lg:px-10">
         <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-6xl items-center justify-center">
           <section className="soft-panel w-full max-w-xl px-6 py-10 text-center sm:px-8">
-            <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+            <p className="font-display text-5xl text-pink-deep">OOTD</p>
             <h1 className="mt-4 text-4xl text-ink">Opening your feed</h1>
           </section>
         </div>
@@ -462,10 +462,10 @@ export default function FeedPage() {
         <header className="mb-6">
           <div className="mb-5 flex items-center justify-between gap-3">
             <div>
-              <p className="font-display text-[3.4rem] leading-none tracking-[-0.08em] text-[#f09ab4]">
+              <p className="font-display text-[3.4rem] leading-none text-pink-deep">
                 OOTD
               </p>
-              <p className="mt-1 text-sm text-plum/54">Welcome back, {displayName}.</p>
+              <p className="mt-1 text-sm text-mute">Welcome back, {displayName}.</p>
             </div>
 
             <div className="flex items-center gap-2">

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3,10 +3,14 @@
 @tailwind utilities;
 
 :root {
-  --surface: 255 248 245;
-  --surface-strong: 255 255 255;
-  --border: 139 88 115;
-  --ink: 36 21 28;
+  --ink: #1a1416;
+  --ink-soft: #4a3f43;
+  --mute: #8a7a80;
+  --pink: #F8C8DC;
+  --pink-soft: #FDEDF3;
+  --pink-deep: #E8A8C0;
+  --line: #efe4e8;
+  --paper: #faf7f5;
 }
 
 * {
@@ -19,11 +23,8 @@ html {
 
 body {
   min-height: 100vh;
-  color: rgb(var(--ink));
-  background:
-    radial-gradient(circle at top, rgba(242, 196, 206, 0.4), transparent 26%),
-    radial-gradient(circle at 100% 0%, rgba(255, 230, 237, 0.85), transparent 22%),
-    linear-gradient(180deg, #ffffff 0%, #fff9fb 42%, #fff7fa 100%);
+  color: var(--ink);
+  background-color: var(--paper);
   font-family: var(--font-sans), sans-serif;
 }
 
@@ -33,7 +34,7 @@ a {
 }
 
 ::selection {
-  background: rgba(139, 88, 115, 0.18);
+  background: rgba(248, 200, 220, 0.35);
 }
 
 @layer base {
@@ -42,62 +43,66 @@ a {
   h3,
   h4 {
     font-family: var(--font-display), serif;
-    letter-spacing: -0.025em;
   }
 }
 
 @layer components {
+  /* Card — 1px line border, no heavy shadow */
   .soft-panel {
-    @apply rounded-[2rem] border border-rose/10 bg-white shadow-[0_20px_70px_rgba(244,106,147,0.08)];
+    @apply rounded-xl border border-line bg-white;
   }
 
+  /* Input shell — label sits above this */
   .field-shell {
-    @apply rounded-[1.2rem] border border-rose/15 bg-white px-4 py-4 transition focus-within:border-[#f289a8] focus-within:shadow-[0_0_0_4px_rgba(244,106,147,0.08)];
+    @apply flex h-12 items-center rounded-md border border-line bg-white px-4 transition focus-within:border-pink-deep focus-within:ring-2 focus-within:ring-pink/40;
   }
 
   .field-input {
-    @apply w-full bg-transparent text-base text-ink outline-none;
+    @apply w-full bg-transparent text-sm text-ink outline-none;
     &::placeholder {
-      color: rgba(107, 57, 85, 0.35);
+      color: var(--mute);
     }
   }
 
+  /* Label sits above the field-shell */
   .field-label {
-    @apply sr-only;
+    @apply mb-1.5 block text-xs font-medium lowercase text-ink-soft;
   }
 
   .search-shell {
-    @apply flex flex-1 items-center gap-3 rounded-full border bg-white px-4 py-3 shadow-[0_12px_35px_rgba(244,106,147,0.06)];
-    border-color: rgba(230, 170, 184, 0.12);
+    @apply flex flex-1 items-center gap-3 rounded-full border border-line bg-white px-4 py-3;
   }
 
   .search-input {
-    @apply min-w-0 flex-1 text-sm;
-    color: rgba(107, 57, 85, 0.48);
+    @apply min-w-0 flex-1 bg-transparent text-sm text-mute outline-none;
   }
 
+  /* Icon button — clean circular, minimal */
   .icon-button {
-    @apply inline-flex h-11 w-11 items-center justify-center rounded-full border bg-white shadow-[0_12px_30px_rgba(244,106,147,0.06)] transition hover:text-plum;
-    border-color: rgba(230, 170, 184, 0.12);
-    color: rgba(107, 57, 85, 0.7);
-    &:hover {
-      border-color: rgba(230, 170, 184, 0.25);
-    }
+    @apply inline-flex h-10 w-10 items-center justify-center rounded-full border border-line bg-white text-mute transition hover:border-pink-deep hover:text-ink;
   }
 
+  /* Filter chip */
   .filter-chip {
-    @apply inline-flex items-center gap-2 rounded-full border bg-white px-4 py-2 text-sm shadow-[0_10px_24px_rgba(244,106,147,0.04)];
-    border-color: rgba(230, 170, 184, 0.12);
-    color: rgba(107, 57, 85, 0.72);
+    @apply inline-flex cursor-pointer items-center gap-2 rounded-full border border-line bg-white px-4 py-2 text-sm text-mute transition hover:border-pink-deep hover:text-ink;
   }
 
   .filter-chip-active {
-    @apply border-[#f6a9be] bg-[#fff1f6] text-[#ef5f8a];
+    @apply border-ink bg-ink text-paper;
   }
 
+  /* Bottom nav dock */
   .mobile-dock {
-    @apply flex w-full max-w-[24rem] items-center justify-between rounded-[2rem] border px-3 py-2 shadow-[0_18px_45px_rgba(244,106,147,0.12)];
-    border-color: rgba(230, 170, 184, 0.12);
-    background-color: rgba(255, 255, 255, 0.98);
+    @apply flex w-full max-w-sm items-center justify-between rounded-xl border border-line bg-white px-3 py-2;
+  }
+
+  /* Primary CTA */
+  .btn-primary {
+    @apply inline-flex h-[50px] items-center justify-center rounded-full bg-ink px-6 text-sm font-medium lowercase tracking-normal text-paper transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50;
+  }
+
+  /* Secondary / outline */
+  .btn-secondary {
+    @apply inline-flex h-[50px] items-center justify-center rounded-full border border-line bg-white px-6 text-sm font-medium lowercase text-ink-soft transition hover:border-pink-deep hover:text-ink disabled:cursor-not-allowed disabled:opacity-50;
   }
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,24 +1,25 @@
 import type { Metadata } from "next";
-import { Cormorant_Garamond, Manrope } from "next/font/google";
+import { Instrument_Serif, Inter } from "next/font/google";
 import type { ReactNode } from "react";
 import { AuthProvider } from "@/lib/auth-context";
 import "./globals.css";
 
-const display = Cormorant_Garamond({
+const display = Instrument_Serif({
   subsets: ["latin"],
-  weight: ["500", "600", "700"],
+  weight: ["400"],
+  style: ["italic"],
   variable: "--font-display"
 });
 
-const sans = Manrope({
+const sans = Inter({
   subsets: ["latin"],
-  weight: ["400", "500", "600", "700"],
+  weight: ["400", "500", "600"],
   variable: "--font-sans"
 });
 
 export const metadata: Metadata = {
-  title: "OOTD Vault",
-  description: "Social outfit logging with a personal vault, event boards, and story-ready sharing."
+  title: "OOTD",
+  description: "a soft place for outfits — your daily fit, kept close, shared with the girls."
 };
 
 export default function RootLayout({

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -24,10 +24,10 @@ function StepDots({ total, current }: { total: number; current: number }) {
           key={i}
           className={`h-1.5 rounded-full transition-all duration-300 ${
             i === current
-              ? "w-5 bg-[#f46a93]"
+              ? "w-5 bg-pink-deep"
               : i < current
-              ? "w-1.5 bg-[#f46a93]/40"
-              : "w-1.5 bg-plum/14"
+              ? "w-1.5 bg-pink-deep/40"
+              : "w-1.5 bg-line"
           }`}
         />
       ))}
@@ -40,7 +40,7 @@ function StepDots({ total, current }: { total: number; current: number }) {
 function StepWelcome({ onNext }: { onNext: () => void }) {
   return (
     <div className="flex flex-col items-center text-center">
-      <p className="font-display text-[4.5rem] leading-none tracking-[-0.08em] text-[#f09ab4]">
+      <p className="font-display text-[4.5rem] leading-none text-pink-deep">
         OOTD
       </p>
       <h1 className="mt-8 text-3xl leading-tight text-ink sm:text-4xl">
@@ -52,7 +52,7 @@ function StepWelcome({ onNext }: { onNext: () => void }) {
       <button
         type="button"
         onClick={onNext}
-        className="mt-10 rounded-[1.2rem] bg-gradient-to-r from-[#ef6c96] to-[#f493b0] px-8 py-4 text-sm font-semibold text-white shadow-[0_8px_24px_rgba(244,106,147,0.3)] transition hover:brightness-[0.97]"
+        className="mt-10 btn-primary"
       >
         Let&rsquo;s build your vault →
       </button>
@@ -82,7 +82,7 @@ function UserSuggestionRow({
           className="h-11 w-11 shrink-0 rounded-full border border-plum/10 object-cover"
         />
       ) : (
-        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-[#fce4ec] to-[#f8bbd0] text-sm font-semibold text-[#c0476e]">
+        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-pink-soft text-sm font-semibold text-ink-soft">
           {getInitial(user.display_name, user.username)}
         </div>
       )}
@@ -92,9 +92,9 @@ function UserSuggestionRow({
           {user.display_name ?? user.username ?? "Unknown"}
         </p>
         {user.username ? (
-          <p className="text-[0.68rem] text-plum/50">@{user.username}</p>
+          <p className="text-[0.68rem] text-mute">@{user.username}</p>
         ) : null}
-        <p className="text-[0.65rem] uppercase tracking-[0.14em] text-plum/38">
+        <p className="text-[0.65rem] uppercase tracking-[0.14em] text-mute">
           {user.follower_count.toLocaleString()} {user.follower_count === 1 ? "follower" : "followers"}
         </p>
       </div>
@@ -102,10 +102,10 @@ function UserSuggestionRow({
       <button
         type="button"
         onClick={following ? onUnfollow : onFollow}
-        className={`shrink-0 rounded-full px-4 py-1.5 text-[0.75rem] font-semibold transition ${
+        className={`shrink-0 rounded-full px-4 py-1.5 text-[0.75rem] font-medium lowercase transition ${
           following
-            ? "border border-rose/15 bg-white text-plum hover:border-rose/28"
-            : "bg-gradient-to-r from-[#ef6c96] to-[#f493b0] text-white hover:brightness-[0.97]"
+            ? "border border-line bg-white text-ink-soft hover:border-pink-deep"
+            : "bg-ink text-paper hover:opacity-90"
         }`}
       >
         {following ? "Following" : "Follow"}
@@ -138,7 +138,7 @@ function StepFollow({
   return (
     <div className="w-full">
       <h2 className="text-2xl text-ink">Find people to follow</h2>
-      <p className="mt-1.5 text-sm text-plum/60">
+      <p className="mt-1.5 text-sm text-mute">
         See what the community is wearing. You can always find more later.
       </p>
 
@@ -146,12 +146,12 @@ function StepFollow({
         {loading
           ? Array.from({ length: 5 }).map((_, i) => (
               <div key={i} className="flex items-center gap-3 py-3">
-                <div className="h-11 w-11 shrink-0 animate-pulse rounded-full bg-[#ffe8ef]" />
+                <div className="h-11 w-11 shrink-0 animate-pulse rounded-full bg-pink-soft" />
                 <div className="flex-1 space-y-2">
-                  <div className="h-3 w-28 animate-pulse rounded-full bg-[#ffe8ef]" />
-                  <div className="h-2.5 w-20 animate-pulse rounded-full bg-[#fff3f7]" />
+                  <div className="h-3 w-28 animate-pulse rounded-full bg-pink-soft" />
+                  <div className="h-2.5 w-20 animate-pulse rounded-full bg-pink-soft" />
                 </div>
-                <div className="h-7 w-20 animate-pulse rounded-full bg-[#ffe8ef]" />
+                <div className="h-7 w-20 animate-pulse rounded-full bg-pink-soft" />
               </div>
             ))
           : users.map((user) => (
@@ -168,7 +168,7 @@ function StepFollow({
       <button
         type="button"
         onClick={onNext}
-        className="mt-8 w-full rounded-[1.2rem] bg-gradient-to-r from-[#ef6c96] to-[#f493b0] py-4 text-sm font-semibold text-white shadow-[0_8px_24px_rgba(244,106,147,0.25)] transition hover:brightness-[0.97]"
+        className="btn-primary mt-8 w-full"
       >
         Continue
       </button>
@@ -182,8 +182,8 @@ function StepUpload({ onDone }: { onDone: () => void }) {
   return (
     <div className="flex flex-col items-center text-center">
       {/* Decorative outfit frame */}
-      <div className="flex h-36 w-28 items-center justify-center rounded-[1.75rem] border-2 border-dashed border-rose/25 bg-gradient-to-b from-[#fff0f4] to-[#fff7fa]">
-        <svg viewBox="0 0 24 24" className="h-10 w-10 text-[#f09ab4]" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+      <div className="flex h-36 w-28 items-center justify-center rounded-[1.75rem] border-2 border-dashed border-rose/25 bg-pink-soft">
+        <svg viewBox="0 0 24 24" className="h-10 w-10 text-pink-deep" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
           <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
           <polyline points="17 8 12 3 7 8" />
           <line x1="12" y1="3" x2="12" y2="15" />
@@ -200,14 +200,14 @@ function StepUpload({ onDone }: { onDone: () => void }) {
       <Link
         href="/upload"
         onClick={onDone}
-        className="mt-8 block w-full rounded-[1.2rem] bg-gradient-to-r from-[#ef6c96] to-[#f493b0] py-4 text-center text-sm font-semibold text-white shadow-[0_8px_24px_rgba(244,106,147,0.3)] transition hover:brightness-[0.97]"
+        className="mt-8 btn-primary block w-full"
       >
         Upload my first look →
       </Link>
       <button
         type="button"
         onClick={onDone}
-        className="mt-3 text-sm text-plum/50 transition hover:text-plum"
+        className="mt-3 text-sm text-mute transition hover:text-plum"
       >
         Maybe later
       </button>
@@ -265,14 +265,14 @@ export default function OnboardingPage() {
 
   if (!ready) {
     return (
-      <main className="flex min-h-screen items-center justify-center bg-[#fffafc] px-4">
-        <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+      <main className="flex min-h-screen items-center justify-center bg-paper px-4">
+        <p className="font-display text-5xl text-pink-deep">OOTD</p>
       </main>
     );
   }
 
   return (
-    <main className="flex min-h-screen flex-col bg-[#fffafc] px-5 pb-10 pt-6 sm:px-8">
+    <main className="flex min-h-screen flex-col bg-paper px-5 pb-10 pt-6 sm:px-8">
       {/* ── Top bar ──────────────────────────────────────────────────────── */}
       <div className="flex items-center justify-between">
         <StepDots total={STEPS} current={step} />

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -45,41 +45,39 @@ export default async function HomePage() {
   }
 
   return (
-    <main className="px-4 py-6 sm:px-6 lg:px-10">
-      <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-6xl items-center">
+    <main className="px-4 py-10 sm:px-6 lg:px-10">
+      <div className="mx-auto flex min-h-[calc(100vh-5rem)] max-w-5xl items-center">
         <section className="soft-panel w-full overflow-hidden">
-          <div className="grid gap-8 lg:grid-cols-[1.05fr_0.95fr]">
-            <div className="bg-brand-glow px-6 py-8 sm:px-8 sm:py-10 lg:px-10 lg:py-12">
-              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-plum/70">
-                OOTD Vault
-              </p>
-              <h1 className="mt-4 max-w-2xl text-5xl leading-none text-ink sm:text-6xl">
-                Your personal style archive, built for the plans that become memories.
+          <div className="grid lg:grid-cols-[1fr_380px]">
+            {/* Left — brand + feature pillars */}
+            <div className="border-b border-line px-6 py-8 sm:px-8 sm:py-10 lg:border-b-0 lg:border-r lg:px-10 lg:py-12">
+              <p className="font-display text-6xl italic text-pink-deep sm:text-7xl">OOTD</p>
+              <h1 className="mt-5 max-w-xl text-3xl leading-snug text-ink sm:text-4xl">
+                your daily fit, kept close,<br />shared with the girls.
               </h1>
-              <p className="mt-5 max-w-2xl text-base leading-7 text-plum/85 sm:text-lg">
-                OOTD Vault helps you log outfits, coordinate looks with friends, and turn
-                great nights into reusable style history instead of one-off screenshots.
+              <p className="mt-4 max-w-md text-sm leading-7 text-ink-soft">
+                log outfits, coordinate with friends, and turn great nights into reusable style history.
               </p>
 
-              <div className="mt-8 flex flex-wrap gap-3">
+              <div className="mt-8 flex flex-wrap gap-2">
                 {highlights.map((highlight) => (
                   <span
                     key={highlight}
-                    className="rounded-full border border-plum/15 bg-white/75 px-4 py-2 text-sm text-plum/85"
+                    className="rounded-full border border-line bg-paper px-3.5 py-1.5 text-xs lowercase text-mute"
                   >
                     {highlight}
                   </span>
                 ))}
               </div>
 
-              <div className="mt-10 grid gap-4 sm:grid-cols-2">
+              <div className="mt-8 grid gap-3 sm:grid-cols-2">
                 {productPillars.map((pillar) => (
                   <article
                     key={pillar.title}
-                    className="rounded-[1.75rem] border border-plum/12 bg-white/72 p-5 shadow-card"
+                    className="rounded-xl border border-line bg-paper p-4"
                   >
-                    <h2 className="text-2xl text-ink">{pillar.title}</h2>
-                    <p className="mt-3 text-sm leading-6 text-plum/82">
+                    <h2 className="font-display text-xl italic text-ink">{pillar.title}</h2>
+                    <p className="mt-2 text-xs leading-5 text-mute">
                       {pillar.description}
                     </p>
                   </article>
@@ -87,43 +85,32 @@ export default async function HomePage() {
               </div>
             </div>
 
-            <div className="flex flex-col justify-between gap-8 px-6 py-8 sm:px-8 sm:py-10 lg:px-10 lg:py-12">
+            {/* Right — CTA */}
+            <div className="flex flex-col justify-between gap-8 px-6 py-8 sm:px-8 sm:py-10 lg:px-8 lg:py-12">
               <div>
-                <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-plum/70">
-                  Launch loop
-                </p>
-                <h2 className="mt-4 max-w-lg text-4xl leading-tight text-ink">
-                  Save the outfit, share the vibe, and remember what actually worked.
+                <h2 className="text-2xl leading-snug text-ink">
+                  a soft place for outfits.
                 </h2>
-                <p className="mt-4 max-w-lg text-base leading-7 text-plum/85">
-                  Start with your archive, then layer on social discovery, event planning,
-                  AI support, and instant export for the looks worth keeping.
+                <p className="mt-3 text-sm leading-6 text-ink-soft">
+                  start with your archive, then layer on social discovery, event planning, and story-ready exports.
                 </p>
               </div>
 
-              <div className="rounded-[1.75rem] border border-plum/12 bg-cream/75 p-5">
-                <p className="text-[0.72rem] font-semibold uppercase tracking-[0.26em] text-plum/70">
-                  Built for
-                </p>
-                <ul className="mt-4 grid gap-3 text-sm leading-6 text-plum/85">
-                  <li>People who want a real archive of what they wore and loved</li>
-                  <li>Friends coordinating events without matching by accident</li>
-                  <li>Creators who want captions and exports without extra steps</li>
+              <div className="rounded-xl border border-line bg-paper p-4">
+                <p className="text-xs font-medium lowercase text-mute">built for</p>
+                <ul className="mt-3 grid gap-2 text-xs leading-5 text-ink-soft">
+                  <li>people who want a real archive of what they wore</li>
+                  <li>friends coordinating events without matching by accident</li>
+                  <li>creators who want captions and exports without extra steps</li>
                 </ul>
               </div>
 
-              <div className="grid gap-4">
-                <Link
-                  href="/signup"
-                  className="rounded-[1.5rem] bg-plum px-5 py-4 text-center text-sm font-semibold text-white transition hover:bg-[#5c3049]"
-                >
-                  Create your account
+              <div className="grid gap-3">
+                <Link href="/signup" className="btn-primary text-center">
+                  get started
                 </Link>
-                <Link
-                  href="/login"
-                  className="rounded-[1.5rem] border border-plum/20 bg-white/80 px-5 py-4 text-center text-sm font-semibold text-plum transition hover:bg-white"
-                >
-                  Log in
+                <Link href="/login" className="btn-secondary text-center">
+                  log in
                 </Link>
               </div>
             </div>

--- a/apps/web/app/profile/[username]/page.tsx
+++ b/apps/web/app/profile/[username]/page.tsx
@@ -35,12 +35,12 @@ function Avatar({ src, initial }: { src?: string | null; initial: string }) {
       <img
         src={src}
         alt="Profile photo"
-        className="h-24 w-24 rounded-full border-2 border-rose/20 object-cover shadow-[0_8px_24px_rgba(244,106,147,0.16)]"
+        className="h-24 w-24 rounded-full border-2 border-line object-cover"
       />
     );
   }
   return (
-    <div className="flex h-24 w-24 items-center justify-center rounded-full border-2 border-rose/20 bg-gradient-to-br from-[#fce4ec] to-[#f8bbd0] text-2xl font-semibold text-[#c0476e] shadow-[0_8px_24px_rgba(244,106,147,0.14)]">
+    <div className="flex h-24 w-24 items-center justify-center rounded-full border-2 border-line bg-pink-soft text-2xl font-semibold text-ink-soft">
       {initial}
     </div>
   );
@@ -52,7 +52,7 @@ function StatPill({ value, label }: { value: number; label: string }) {
       <span className="font-display text-2xl leading-none tracking-[-0.04em] text-ink">
         {value.toLocaleString()}
       </span>
-      <span className="text-[0.68rem] uppercase tracking-[0.18em] text-plum/52">{label}</span>
+      <span className="text-[0.68rem] uppercase tracking-[0.18em] text-mute">{label}</span>
     </div>
   );
 }
@@ -165,9 +165,9 @@ export default function PublicProfilePage({
       <main className="px-4 pb-28 pt-6 sm:px-6">
         <div className="mx-auto flex min-h-[60vh] max-w-2xl items-center justify-center">
           <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-            <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+            <p className="font-display text-5xl text-pink-deep">OOTD</p>
             <h1 className="mt-4 text-3xl text-ink">Profile not found</h1>
-            <p className="mt-3 text-sm leading-6 text-plum/68">
+            <p className="mt-3 text-sm leading-6 text-ink-soft">
               @{username} doesn&apos;t exist or may have changed their username.
             </p>
             <Link
@@ -197,7 +197,7 @@ export default function PublicProfilePage({
             <button
               type="button"
               onClick={() => router.back()}
-              className="flex items-center gap-2 text-sm text-plum/60 transition hover:text-plum"
+              className="flex items-center gap-2 text-sm text-mute transition hover:text-plum"
             >
               <svg
                 aria-hidden="true"
@@ -213,7 +213,7 @@ export default function PublicProfilePage({
               </svg>
               Back
             </button>
-            <p className="mt-2 font-display text-[3.4rem] leading-none tracking-[-0.08em] text-[#f09ab4]">
+            <p className="mt-2 font-display text-[3.4rem] leading-none text-pink-deep">
               OOTD
             </p>
           </div>
@@ -223,12 +223,12 @@ export default function PublicProfilePage({
         {status === "loading" ? (
           <section className="soft-panel mb-6 animate-pulse px-6 py-7">
             <div className="flex items-start gap-5">
-              <div className="h-24 w-24 rounded-full bg-[#ffe8ef]" />
+              <div className="h-24 w-24 rounded-full bg-pink-soft" />
               <div className="flex-1 space-y-3 pt-1">
-                <div className="h-5 w-36 rounded-full bg-[#ffe8ef]" />
-                <div className="h-3.5 w-24 rounded-full bg-[#fff3f7]" />
-                <div className="h-3 w-full rounded-full bg-[#fff6f9]" />
-                <div className="h-3 w-4/5 rounded-full bg-[#fff6f9]" />
+                <div className="h-5 w-36 rounded-full bg-pink-soft" />
+                <div className="h-3.5 w-24 rounded-full bg-pink-soft" />
+                <div className="h-3 w-full rounded-full bg-line/60" />
+                <div className="h-3 w-4/5 rounded-full bg-line/60" />
               </div>
             </div>
           </section>
@@ -244,9 +244,9 @@ export default function PublicProfilePage({
                 <h1 className="font-display text-3xl leading-tight tracking-[-0.03em] text-ink">
                   {displayName}
                 </h1>
-                <p className="mt-0.5 text-sm text-plum/58">@{username}</p>
+                <p className="mt-0.5 text-sm text-mute">@{username}</p>
                 {bio ? (
-                  <p className="mt-3 text-sm leading-6 text-plum/72">{bio}</p>
+                  <p className="mt-3 text-sm leading-6 text-ink-soft">{bio}</p>
                 ) : null}
 
                 {isAuthenticated ? (
@@ -254,20 +254,20 @@ export default function PublicProfilePage({
                     type="button"
                     onClick={() => void handleFollow()}
                     disabled={followLoading}
-                    className={`mt-4 rounded-full px-5 py-2 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-60 ${
+                    className={`mt-4 rounded-full px-5 py-2 text-sm font-medium lowercase transition disabled:cursor-not-allowed disabled:opacity-60 ${
                       following
-                        ? "border border-rose/20 bg-white text-plum hover:border-rose/35 hover:bg-[#fff4f7]"
-                        : "bg-gradient-to-r from-[#ef6c96] to-[#f493b0] text-white hover:brightness-[0.98]"
+                        ? "border border-line bg-white text-ink-soft hover:border-pink-deep"
+                        : "bg-ink text-paper hover:opacity-90"
                     }`}
                   >
-                    {followLoading ? "…" : following ? "Following" : "Follow"}
+                    {followLoading ? "…" : following ? "following" : "follow"}
                   </button>
                 ) : (
                   <Link
                     href="/login"
-                    className="mt-4 inline-block rounded-full bg-gradient-to-r from-[#ef6c96] to-[#f493b0] px-5 py-2 text-sm font-semibold text-white transition hover:brightness-[0.98]"
+                    className="mt-4 inline-block rounded-full bg-ink px-5 py-2 text-sm font-medium lowercase text-paper transition hover:opacity-90"
                   >
-                    Follow
+                    follow
                   </Link>
                 )}
               </div>
@@ -301,7 +301,7 @@ export default function PublicProfilePage({
           {status === "ready" && outfits.length === 0 ? (
             <div className="soft-panel px-6 py-10 text-center">
               <h2 className="text-2xl text-ink">No looks yet</h2>
-              <p className="mt-3 text-sm leading-6 text-plum/68">
+              <p className="mt-3 text-sm leading-6 text-ink-soft">
                 @{username} hasn&apos;t uploaded any outfits yet.
               </p>
             </div>

--- a/apps/web/app/profile/edit/page.tsx
+++ b/apps/web/app/profile/edit/page.tsx
@@ -36,17 +36,17 @@ function AvatarUpload({
         type="button"
         onClick={() => inputRef.current?.click()}
         disabled={uploading}
-        className="group relative h-24 w-24 flex-shrink-0 rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-[#ef5f8a]/50"
+        className="group relative h-24 w-24 flex-shrink-0 rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-pink-deep/50"
         aria-label="Change profile photo"
       >
         {src ? (
           <img
             src={src}
             alt="Your profile photo"
-            className="h-24 w-24 rounded-full border-2 border-rose/20 object-cover shadow-[0_8px_24px_rgba(244,106,147,0.16)]"
+            className="h-24 w-24 rounded-full border-2 border-line object-cover"
           />
         ) : (
-          <div className="flex h-24 w-24 items-center justify-center rounded-full border-2 border-rose/20 bg-gradient-to-br from-[#fce4ec] to-[#f8bbd0] text-2xl font-semibold text-[#c0476e] shadow-[0_8px_24px_rgba(244,106,147,0.14)]">
+          <div className="flex h-24 w-24 items-center justify-center rounded-full border-2 border-line bg-pink-soft text-2xl font-semibold text-ink-soft">
             {initial}
           </div>
         )}
@@ -70,7 +70,7 @@ function AvatarUpload({
         </span>
       </button>
 
-      <p className="text-[0.72rem] text-plum/52">Tap to change photo</p>
+      <p className="text-[0.72rem] text-mute">Tap to change photo</p>
 
       <input
         ref={inputRef}
@@ -103,7 +103,7 @@ function UsernameHint({ status }: { status: UsernameStatus }) {
 
   if (status === "taken") {
     return (
-      <p className="mt-1.5 flex items-center gap-1.5 text-xs text-[#c04b72]">
+      <p className="mt-1.5 flex items-center gap-1.5 text-xs text-error">
         <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
           <line x1="18" y1="6" x2="6" y2="18" />
           <line x1="6" y1="6" x2="18" y2="18" />
@@ -236,7 +236,7 @@ export default function EditProfilePage() {
       <main className="px-4 py-6 sm:px-6">
         <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-2xl items-center justify-center">
           <section className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-            <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+            <p className="font-display text-5xl text-pink-deep">OOTD</p>
             <h1 className="mt-4 text-3xl text-ink">Loading…</h1>
           </section>
         </div>
@@ -254,7 +254,7 @@ export default function EditProfilePage() {
 
         {/* ── Top bar ─────────────────────────────────────────────────────── */}
         <header className="mb-6 flex items-center justify-between">
-          <p className="font-display text-[3.4rem] leading-none tracking-[-0.08em] text-[#f09ab4]">
+          <p className="font-display text-[3.4rem] leading-none text-pink-deep">
             OOTD
           </p>
           <button
@@ -273,7 +273,7 @@ export default function EditProfilePage() {
         {/* ── Title ───────────────────────────────────────────────────────── */}
         <div className="mb-6">
           <h1 className="font-display text-3xl tracking-[-0.03em] text-ink">Edit profile</h1>
-          <p className="mt-1 text-sm text-plum/54">Changes are visible on your public profile</p>
+          <p className="mt-1 text-sm text-mute">Changes are visible on your public profile</p>
         </div>
 
         <form onSubmit={(e) => void handleSave(e)} noValidate>
@@ -287,7 +287,7 @@ export default function EditProfilePage() {
               onFile={(file) => void handleAvatarFile(file)}
             />
             {avatarError ? (
-              <p className="mt-3 text-center text-xs text-[#c04b72]">{avatarError}</p>
+              <p className="mt-3 text-center text-xs text-error">{avatarError}</p>
             ) : null}
           </section>
 
@@ -296,7 +296,7 @@ export default function EditProfilePage() {
 
             {/* Display name */}
             <div>
-              <label htmlFor="display-name" className="block text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-plum/60">
+              <label htmlFor="display-name" className="block text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-mute">
                 Display name
               </label>
               <input
@@ -310,17 +310,17 @@ export default function EditProfilePage() {
                 className="mt-2 w-full rounded-2xl border border-rose/12 bg-white/70 px-4 py-3 text-sm text-ink placeholder-plum/35 outline-none transition focus:border-[#ef5f8a]/40 focus:ring-2 focus:ring-[#ef5f8a]/12 disabled:opacity-50"
               />
               {fieldErrors.display_name ? (
-                <p className="mt-1.5 text-xs text-[#c04b72]">{fieldErrors.display_name}</p>
+                <p className="mt-1.5 text-xs text-error">{fieldErrors.display_name}</p>
               ) : null}
             </div>
 
             {/* Username */}
             <div>
-              <label htmlFor="username" className="block text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-plum/60">
+              <label htmlFor="username" className="block text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-mute">
                 Username
               </label>
               <div className="relative mt-2">
-                <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-sm text-plum/40">
+                <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-sm text-mute">
                   @
                 </span>
                 <input
@@ -345,17 +345,17 @@ export default function EditProfilePage() {
               </div>
               <UsernameHint status={usernameStatus} />
               {fieldErrors.username ? (
-                <p className="mt-1.5 text-xs text-[#c04b72]">{fieldErrors.username}</p>
+                <p className="mt-1.5 text-xs text-error">{fieldErrors.username}</p>
               ) : null}
             </div>
 
             {/* Bio */}
             <div>
               <div className="flex items-baseline justify-between">
-                <label htmlFor="bio" className="block text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-plum/60">
+                <label htmlFor="bio" className="block text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-mute">
                   Bio
                 </label>
-                <span className={`text-[0.68rem] tabular-nums ${bioRemaining < 20 ? "text-[#c04b72]" : "text-plum/40"}`}>
+                <span className={`text-[0.68rem] tabular-nums ${bioRemaining < 20 ? "text-error" : "text-mute"}`}>
                   {bioRemaining}
                 </span>
               </div>
@@ -373,14 +373,14 @@ export default function EditProfilePage() {
                 className="mt-2 w-full resize-none rounded-2xl border border-rose/12 bg-white/70 px-4 py-3 text-sm text-ink placeholder-plum/35 outline-none transition focus:border-[#ef5f8a]/40 focus:ring-2 focus:ring-[#ef5f8a]/12 disabled:opacity-50"
               />
               {fieldErrors.bio ? (
-                <p className="mt-1.5 text-xs text-[#c04b72]">{fieldErrors.bio}</p>
+                <p className="mt-1.5 text-xs text-error">{fieldErrors.bio}</p>
               ) : null}
             </div>
           </section>
 
           {/* ── Error banner ──────────────────────────────────────────────── */}
           {saveError ? (
-            <div className="mb-4 rounded-[1.25rem] border border-rose/25 bg-[#fff3f7] px-4 py-3 text-sm text-[#c04b72]">
+            <div className="mb-4 rounded-[1.25rem] border border-rose/25 bg-pink-soft px-4 py-3 text-sm text-error">
               {saveError}
             </div>
           ) : null}
@@ -390,7 +390,7 @@ export default function EditProfilePage() {
             <button
               type="submit"
               disabled={isSaving || usernameStatus === "taken" || avatarUploading}
-              className="w-full rounded-[1.5rem] bg-gradient-to-r from-[#ef6c96] to-[#f493b0] px-5 py-4 text-sm font-semibold text-white shadow-[0_8px_20px_rgba(244,106,147,0.28)] transition hover:brightness-[0.97] disabled:cursor-not-allowed disabled:opacity-60"
+              className="btn-primary w-full"
             >
               {saveStatus === "saving" ? "Saving…" : saveStatus === "saved" ? "Saved!" : "Save changes"}
             </button>

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -46,14 +46,14 @@ function Avatar({
       <img
         src={src}
         alt="Your profile photo"
-        className={`${dim} rounded-full border-2 border-rose/20 object-cover shadow-[0_8px_24px_rgba(244,106,147,0.16)]`}
+        className={`${dim} rounded-full border-2 border-line object-cover`}
       />
     );
   }
 
   return (
     <div
-      className={`${dim} flex items-center justify-center rounded-full border-2 border-rose/20 bg-gradient-to-br from-[#fce4ec] to-[#f8bbd0] font-semibold text-[#c0476e] shadow-[0_8px_24px_rgba(244,106,147,0.14)]`}
+      className={`${dim} flex items-center justify-center rounded-full border-2 border-line bg-pink-soft font-semibold text-ink-soft`}
     >
       {initial}
     </div>
@@ -68,7 +68,7 @@ function StatPill({ value, label }: { value: number; label: string }) {
       <span className="font-display text-2xl leading-none tracking-[-0.04em] text-ink">
         {value.toLocaleString()}
       </span>
-      <span className="text-[0.68rem] uppercase tracking-[0.18em] text-plum/52">{label}</span>
+      <span className="text-[0.68rem] uppercase tracking-[0.18em] text-mute">{label}</span>
     </div>
   );
 }
@@ -175,7 +175,7 @@ export default function ProfilePage() {
       <main className="px-4 py-6 sm:px-6">
         <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-2xl items-center justify-center">
           <section className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-            <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+            <p className="font-display text-5xl text-pink-deep">OOTD</p>
             <h1 className="mt-4 text-3xl text-ink">Loading your profile</h1>
           </section>
         </div>
@@ -197,10 +197,10 @@ export default function ProfilePage() {
         {/* ── Top bar ────────────────────────────────────────────────────── */}
         <header className="mb-6 flex items-start justify-between gap-3">
           <div>
-            <p className="font-display text-[3.4rem] leading-none tracking-[-0.08em] text-[#f09ab4]">
+            <p className="font-display text-[3.4rem] leading-none text-pink-deep">
               OOTD
             </p>
-            <p className="mt-1 text-sm text-plum/54">@{username}</p>
+            <p className="mt-1 text-sm text-mute">@{username}</p>
           </div>
 
           <div className="flex items-center gap-2 pt-1">
@@ -270,14 +270,14 @@ export default function ProfilePage() {
                 {displayName}
               </h1>
               {username ? (
-                <p className="mt-0.5 text-sm text-plum/58">@{username}</p>
+                <p className="mt-0.5 text-sm text-mute">@{username}</p>
               ) : null}
               {bio ? (
-                <p className="mt-3 text-sm leading-6 text-plum/72">{bio}</p>
+                <p className="mt-3 text-sm leading-6 text-ink-soft">{bio}</p>
               ) : (
                 <Link
                   href="/profile/edit"
-                  className="mt-3 inline-block text-sm text-[#ef5f8a] hover:underline"
+                  className="mt-3 inline-block text-sm text-pink-deep hover:underline"
                 >
                   Add a bio →
                 </Link>
@@ -297,7 +297,7 @@ export default function ProfilePage() {
 
         {/* ── Error state ─────────────────────────────────────────────────── */}
         {errorMessage ? (
-          <div className="mb-5 rounded-[1.25rem] border border-rose/25 bg-[#fff3f7] px-4 py-3 text-sm text-[#c04b72]">
+          <div className="mb-5 rounded-[1.25rem] border border-rose/25 bg-pink-soft px-4 py-3 text-sm text-error">
             {errorMessage}
           </div>
         ) : null}
@@ -308,7 +308,7 @@ export default function ProfilePage() {
             <h2 className="font-display text-xl tracking-[-0.02em] text-ink">Your looks</h2>
             <Link
               href="/upload"
-              className="inline-flex items-center gap-1.5 rounded-full border border-rose/15 bg-white px-4 py-2 text-[0.78rem] font-semibold text-[#ef5f8a] shadow-[0_8px_20px_rgba(244,106,147,0.07)] transition hover:border-rose/28"
+              className="inline-flex items-center gap-1.5 rounded-full border border-rose/15 bg-white px-4 py-2 text-[0.78rem] font-semibold text-pink-deep transition hover:border-rose/28"
             >
               <svg aria-hidden="true" viewBox="0 0 24 24" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M12 5v14" />
@@ -335,8 +335,8 @@ export default function ProfilePage() {
                 </div>
               ) : searchResults.length === 0 ? (
                 <div className="soft-panel px-5 py-8 text-center">
-                  <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-plum/52">No results</p>
-                  <p className="mt-2 text-sm text-plum/65">Nothing matched &ldquo;{searchQuery}&rdquo;.</p>
+                  <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-mute">No results</p>
+                  <p className="mt-2 text-sm text-mute">Nothing matched &ldquo;{searchQuery}&rdquo;.</p>
                 </div>
               ) : (
                 <div className="grid grid-cols-2 gap-3 sm:gap-4">
@@ -358,16 +358,16 @@ export default function ProfilePage() {
 
           {status === "ready" && outfits.length === 0 && !isSearching ? (
             <div className="soft-panel px-6 py-10 text-center">
-              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-plum/52">
+              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-mute">
                 Nothing yet
               </p>
               <h2 className="mt-3 text-3xl text-ink">Start your style archive</h2>
-              <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-plum/68">
+              <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-ink-soft">
                 Upload your first outfit and it will live here, forever ready to revisit.
               </p>
               <Link
                 href="/upload"
-                className="mt-6 inline-block rounded-[1.2rem] bg-gradient-to-r from-[#ef6c96] to-[#f493b0] px-6 py-3.5 text-sm font-semibold text-white transition hover:brightness-[0.98]"
+                className="mt-6 inline-block btn-primary"
               >
                 Upload your first look
               </Link>

--- a/apps/web/app/search/page.tsx
+++ b/apps/web/app/search/page.tsx
@@ -39,7 +39,7 @@ function UserRow({
           className="h-11 w-11 shrink-0 rounded-full border border-plum/10 object-cover"
         />
       ) : (
-        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-plum/12 bg-gradient-to-br from-[#fce4ec] to-[#f8bbd0] text-sm font-semibold text-[#c0476e]">
+        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-plum/12 bg-pink-soft text-sm font-semibold text-ink-soft">
           {getInitial(user.display_name, user.username)}
         </div>
       )}
@@ -49,9 +49,9 @@ function UserRow({
           {user.display_name ?? user.username ?? "Unknown"}
         </p>
         {user.username ? (
-          <p className="text-[0.68rem] text-plum/52">@{user.username}</p>
+          <p className="text-[0.68rem] text-mute">@{user.username}</p>
         ) : null}
-        <p className="text-[0.65rem] uppercase tracking-[0.14em] text-plum/40">
+        <p className="text-[0.65rem] uppercase tracking-[0.14em] text-mute">
           {followerCount.toLocaleString()} {followerCount === 1 ? "follower" : "followers"}
         </p>
       </div>
@@ -59,10 +59,10 @@ function UserRow({
       <button
         type="button"
         onClick={following ? onUnfollow : onFollow}
-        className={`shrink-0 rounded-full px-4 py-1.5 text-[0.75rem] font-semibold transition ${
+        className={`shrink-0 rounded-full px-4 py-1.5 text-[0.75rem] font-medium lowercase transition ${
           following
-            ? "border border-rose/15 bg-white text-plum hover:border-rose/28"
-            : "bg-gradient-to-r from-[#ef6c96] to-[#f493b0] text-white hover:brightness-[0.97]"
+            ? "border border-line bg-white text-ink-soft hover:border-pink-deep"
+            : "bg-ink text-paper hover:opacity-90"
         }`}
       >
         {following ? "Following" : "Follow"}
@@ -74,13 +74,13 @@ function UserRow({
 function UserRowSkeleton() {
   return (
     <div className="flex items-center gap-3 py-3">
-      <div className="h-11 w-11 shrink-0 animate-pulse rounded-full bg-[#ffe8ef]" />
+      <div className="h-11 w-11 shrink-0 animate-pulse rounded-full bg-pink-soft" />
       <div className="flex-1 space-y-2">
-        <div className="h-3 w-32 animate-pulse rounded-full bg-[#ffe8ef]" />
-        <div className="h-2.5 w-20 animate-pulse rounded-full bg-[#fff3f7]" />
-        <div className="h-2 w-16 animate-pulse rounded-full bg-[#fff6f9]" />
+        <div className="h-3 w-32 animate-pulse rounded-full bg-pink-soft" />
+        <div className="h-2.5 w-20 animate-pulse rounded-full bg-pink-soft" />
+        <div className="h-2 w-16 animate-pulse rounded-full bg-line/60" />
       </div>
-      <div className="h-7 w-20 animate-pulse rounded-full bg-[#ffe8ef]" />
+      <div className="h-7 w-20 animate-pulse rounded-full bg-pink-soft" />
     </div>
   );
 }
@@ -194,7 +194,7 @@ export default function SearchPage() {
       <main className="px-4 py-6 sm:px-6">
         <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-lg items-center justify-center">
           <section className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-            <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+            <p className="font-display text-5xl text-pink-deep">OOTD</p>
             <h1 className="mt-4 text-3xl text-ink">Loading</h1>
           </section>
         </div>
@@ -210,10 +210,10 @@ export default function SearchPage() {
 
         {/* ── Header ─────────────────────────────────────────────────────── */}
         <header className="mb-5">
-          <p className="font-display text-[3.4rem] leading-none tracking-[-0.08em] text-[#f09ab4]">
+          <p className="font-display text-[3.4rem] leading-none text-pink-deep">
             OOTD
           </p>
-          <p className="mt-1 text-sm text-plum/54">Find people</p>
+          <p className="mt-1 text-sm text-mute">Find people</p>
         </header>
 
         {/* ── Search bar ─────────────────────────────────────────────────── */}
@@ -227,7 +227,7 @@ export default function SearchPage() {
 
         {/* ── Section label ──────────────────────────────────────────────── */}
         {!isSearching ? (
-          <p className="mb-1 text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-plum/42">
+          <p className="mb-1 text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-mute">
             People you may know
           </p>
         ) : null}
@@ -246,10 +246,10 @@ export default function SearchPage() {
           {/* Search empty */}
           {isSearching && searchStatus === "done" && searchResults.length === 0 ? (
             <div className="py-10 text-center">
-              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-plum/42">
+              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-mute">
                 No results
               </p>
-              <p className="mt-2 text-sm text-plum/60">
+              <p className="mt-2 text-sm text-mute">
                 No users found for &ldquo;{query}&rdquo;.
               </p>
             </div>
@@ -267,10 +267,10 @@ export default function SearchPage() {
           {/* Suggested empty */}
           {!isSearching && !suggestedLoading && suggested.length === 0 ? (
             <div className="py-10 text-center">
-              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-plum/42">
+              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-mute">
                 Nothing yet
               </p>
-              <p className="mt-2 text-sm text-plum/60">
+              <p className="mt-2 text-sm text-mute">
                 Search to find people to follow.
               </p>
             </div>

--- a/apps/web/app/upload/page.tsx
+++ b/apps/web/app/upload/page.tsx
@@ -21,11 +21,11 @@ export default function UploadPage() {
       <main className="px-4 py-6 sm:px-6 lg:px-10">
         <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-5xl items-center justify-center">
           <section className="soft-panel w-full max-w-xl px-6 py-10 text-center sm:px-8">
-            <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-plum/70">
+            <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-ink-soft">
               Upload flow
             </p>
             <h1 className="mt-4 text-4xl text-ink">Opening your upload studio</h1>
-            <p className="mt-4 text-sm leading-6 text-plum/82">
+            <p className="mt-4 text-sm leading-6 text-ink-soft">
               We&apos;re checking your session before we load the outfit builder.
             </p>
           </section>
@@ -41,13 +41,13 @@ export default function UploadPage() {
       <div className="mx-auto max-w-6xl">
         <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
           <div>
-            <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-plum/70">
+            <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-ink-soft">
               Outfit upload
             </p>
             <h1 className="mt-2 text-4xl text-ink sm:text-5xl">
               Build the look before you post the memory.
             </h1>
-            <p className="mt-3 max-w-2xl text-sm leading-6 text-plum/82 sm:text-base">
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-ink-soft sm:text-base">
               Hi, {displayName}. Add the photo, tag what you wore, and send the outfit
               straight into your vault in one clean flow.
             </p>

--- a/apps/web/app/upload/page.tsx
+++ b/apps/web/app/upload/page.tsx
@@ -12,7 +12,7 @@ export default function UploadPage() {
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
-      router.replace("/login");
+      router.replace("/login?next=/upload");
     }
   }, [isAuthenticated, isLoading, router]);
 

--- a/apps/web/app/vault/page.tsx
+++ b/apps/web/app/vault/page.tsx
@@ -194,7 +194,7 @@ export default function VaultPage() {
       <main className="px-4 py-6 sm:px-6 lg:px-10">
         <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-5xl items-center justify-center">
           <section className="soft-panel w-full max-w-xl px-6 py-10 text-center sm:px-8">
-            <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+            <p className="font-display text-5xl text-pink-deep">OOTD</p>
             <h1 className="mt-4 text-4xl text-ink">Checking your session</h1>
           </section>
         </div>
@@ -211,10 +211,10 @@ export default function VaultPage() {
         <header className="mb-5">
           <div className="mb-4 flex items-center justify-between gap-3">
             <div>
-              <p className="font-display text-[3.4rem] leading-none tracking-[-0.08em] text-[#f09ab4]">
+              <p className="font-display text-[3.4rem] leading-none text-pink-deep">
                 OOTD
               </p>
-              <p className="mt-1 text-sm text-plum/54">{displayName}&rsquo;s vault</p>
+              <p className="mt-1 text-sm text-mute">{displayName}&rsquo;s vault</p>
             </div>
 
             <div className="flex items-center gap-2">
@@ -252,8 +252,8 @@ export default function VaultPage() {
               </div>
             ) : searchResults.length === 0 ? (
               <div className="soft-panel px-6 py-10 text-center">
-                <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-plum/52">No results</p>
-                <p className="mt-3 text-sm leading-6 text-plum/68">
+                <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-mute">No results</p>
+                <p className="mt-3 text-sm leading-6 text-ink-soft">
                   Nothing in your vault matched &ldquo;{query}&rdquo;.
                 </p>
               </div>
@@ -278,7 +278,7 @@ export default function VaultPage() {
           /* ── Vault grid ─────────────────────────────────────────── */
           <section>
             {errorMessage && vaultStatus !== "loading" ? (
-              <div className="mb-5 rounded-[1.25rem] border border-rose/25 bg-[#fff3f7] px-4 py-3 text-sm text-[#c04b72]">
+              <div className="mb-5 rounded-[1.25rem] border border-rose/25 bg-pink-soft px-4 py-3 text-sm text-error">
                 {errorMessage}
               </div>
             ) : null}
@@ -291,12 +291,12 @@ export default function VaultPage() {
 
             {vaultStatus === "ready" && outfits.length === 0 ? (
               <div className="soft-panel p-6 sm:p-8">
-                <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-plum/58">Empty vault</p>
+                <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-mute">Empty vault</p>
                 <h2 className="mt-4 max-w-2xl text-4xl leading-tight text-ink sm:text-5xl">
                   Your archive is ready. It just needs your first look.
                 </h2>
                 <div className="mt-6 grid gap-3 sm:grid-cols-2">
-                  <Link href="/upload" className="rounded-[1.2rem] bg-gradient-to-r from-[#ef6c96] to-[#f493b0] px-5 py-4 text-center text-sm font-semibold text-white transition hover:brightness-[0.98]">
+                  <Link href="/upload" className="btn-primary">
                     Upload your first look
                   </Link>
                   <Link href="/feed" className="rounded-[1.2rem] border border-rose/12 bg-white px-5 py-4 text-center text-sm font-semibold text-plum transition hover:border-rose/22">

--- a/apps/web/components/auth/auth-form.tsx
+++ b/apps/web/components/auth/auth-form.tsx
@@ -98,16 +98,11 @@ export function AuthForm({ mode }: AuthFormProps) {
   }
 
   return (
-    <div className="soft-panel rounded-[2.1rem] px-6 py-7 sm:px-7 sm:py-8">
-      <h2 className="text-center font-sans text-[2.15rem] font-semibold tracking-[-0.04em] text-ink">
-        {formCopy.title}
-      </h2>
-      <p className="mt-2 text-center text-sm text-plum/55">{formCopy.intro}</p>
-
-      <form className="mt-8 grid gap-4" onSubmit={handleSubmit} noValidate>
+    <div className="soft-panel px-6 py-7 sm:px-7 sm:py-8">
+      <form className="grid gap-5" onSubmit={handleSubmit} noValidate>
         {mode === "signup" ? (
           <Field
-            label="Username"
+            label="username"
             name="username"
             placeholder="@closetmaincharacter"
             value={values.username}
@@ -117,7 +112,7 @@ export function AuthForm({ mode }: AuthFormProps) {
         ) : null}
 
         <Field
-          label="Email"
+          label="email"
           name="email"
           type="email"
           placeholder="you@example.com"
@@ -127,10 +122,10 @@ export function AuthForm({ mode }: AuthFormProps) {
         />
 
         <Field
-          label="Password"
+          label="password"
           name="password"
           type="password"
-          placeholder="At least 8 characters"
+          placeholder="at least 8 characters"
           value={values.password}
           error={errors.password}
           onChange={(value) => setValue("password", value)}
@@ -138,10 +133,10 @@ export function AuthForm({ mode }: AuthFormProps) {
 
         {mode === "signup" ? (
           <Field
-            label="Confirm password"
+            label="confirm password"
             name="confirmPassword"
             type="password"
-            placeholder="Repeat your password"
+            placeholder="repeat your password"
             value={values.confirmPassword}
             error={errors.confirmPassword}
             onChange={(value) => setValue("confirmPassword", value)}
@@ -159,11 +154,11 @@ export function AuthForm({ mode }: AuthFormProps) {
         <button
           type="submit"
           disabled={submitState.status === "submitting" || isLoading}
-          className="mt-2 rounded-[1rem] bg-gradient-to-r from-[#ef6c96] to-[#f06e8f] px-5 py-4 text-sm font-semibold text-white transition hover:brightness-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+          className="btn-primary w-full"
         >
           {submitState.status === "submitting" || isLoading
-            ? "Working..."
-            : formCopy.submitLabel}
+            ? "working..."
+            : mode === "login" ? "log in" : "create account"}
         </button>
       </form>
     </div>
@@ -190,35 +185,38 @@ function Field({
   type = "text"
 }: FieldProps) {
   return (
-    <label className={`field-shell ${error ? "border-rose/80 bg-rose/10" : ""}`}>
-      <span className="field-label">{label}</span>
-      <input
-        className="field-input"
-        name={name}
-        type={type}
-        value={value}
-        placeholder={placeholder}
-        autoComplete={
-          name === "email"
-            ? "email"
-            : name === "password"
-              ? "current-password"
-              : name === "confirmPassword"
-                ? "new-password"
-                : name === "username"
-                  ? "username"
-                  : undefined
-        }
-        aria-invalid={Boolean(error)}
-        aria-describedby={error ? `${name}-error` : undefined}
-        onChange={(event) => onChange(event.target.value)}
-      />
+    <div>
+      <label className="field-label" htmlFor={name}>{label}</label>
+      <div className={`field-shell ${error ? "border-error/60 bg-error/5" : ""}`}>
+        <input
+          id={name}
+          className="field-input"
+          name={name}
+          type={type}
+          value={value}
+          placeholder={placeholder}
+          autoComplete={
+            name === "email"
+              ? "email"
+              : name === "password"
+                ? "current-password"
+                : name === "confirmPassword"
+                  ? "new-password"
+                  : name === "username"
+                    ? "username"
+                    : undefined
+          }
+          aria-invalid={Boolean(error)}
+          aria-describedby={error ? `${name}-error` : undefined}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      </div>
       {error ? (
-        <span id={`${name}-error`} className="mt-2 block text-xs text-[#9c425d]">
+        <span id={`${name}-error`} className="mt-1.5 block text-xs text-error">
           {error}
         </span>
       ) : null}
-    </label>
+    </div>
   );
 }
 
@@ -231,11 +229,11 @@ function StatusBanner({
 }) {
   const toneClasses =
     tone === "success"
-      ? "border-emerald-200 bg-emerald-50 text-emerald-900"
-      : "border-rose/25 bg-rose/10 text-[#7f2947]";
+      ? "border-success/25 bg-success/8 text-success"
+      : "border-error/25 bg-error/8 text-error";
 
   return (
-    <div className={`rounded-[1rem] border px-4 py-3 text-sm ${toneClasses}`}>
+    <div className={`rounded-md border px-4 py-3 text-sm ${toneClasses}`}>
       {message}
     </div>
   );

--- a/apps/web/components/auth/auth-shell.tsx
+++ b/apps/web/components/auth/auth-shell.tsx
@@ -9,12 +9,14 @@ type AuthShellProps = {
 
 const shellCopy = {
   login: {
+    heading: "log in",
     eyebrow: "welcome back.",
     alternateLabel: "need an account?",
     alternateHref: "/signup",
     alternateCta: "sign up"
   },
   signup: {
+    heading: "create account",
     eyebrow: "start saving your fits.",
     alternateLabel: "already have an account?",
     alternateHref: "/login",
@@ -34,6 +36,9 @@ export function AuthShell({ mode, children }: AuthShellProps) {
         </p>
 
         <div className="w-full">
+          <h1 className="mb-1 text-center font-display text-3xl tracking-[-0.02em] text-ink">
+            {copy.heading}
+          </h1>
           <p className="mb-6 text-center text-sm text-mute">{copy.eyebrow}</p>
 
           {children}

--- a/apps/web/components/auth/auth-shell.tsx
+++ b/apps/web/components/auth/auth-shell.tsx
@@ -9,22 +9,16 @@ type AuthShellProps = {
 
 const shellCopy = {
   login: {
-    eyebrow: "Welcome back.",
-    title: "Soft pink, simple, and ready to wear.",
-    description:
-      "Log in through a screen that feels polished and easy instead of busy or technical.",
-    alternateLabel: "Need an account?",
+    eyebrow: "welcome back.",
+    alternateLabel: "need an account?",
     alternateHref: "/signup",
-    alternateCta: "Create account"
+    alternateCta: "sign up"
   },
   signup: {
-    eyebrow: "Start saving your outfits.",
-    title: "Build the archive your camera roll never became.",
-    description:
-      "Create your account and keep the first step light, direct, and easy to understand.",
-    alternateLabel: "Already have an account?",
+    eyebrow: "start saving your fits.",
+    alternateLabel: "already have an account?",
     alternateHref: "/login",
-    alternateCta: "Log in"
+    alternateCta: "log in"
   }
 } as const;
 
@@ -32,31 +26,23 @@ export function AuthShell({ mode, children }: AuthShellProps) {
   const copy = shellCopy[mode];
 
   return (
-    <main className="relative min-h-screen overflow-hidden px-4 py-8 sm:px-6">
-      <div className="absolute inset-x-0 top-0 h-64 bg-[radial-gradient(circle_at_top,_rgba(242,196,206,0.72),_transparent_62%)]" />
-      <div className="absolute right-[-4rem] top-20 h-40 w-40 rounded-full bg-rose/20 blur-3xl" />
-      <div className="absolute left-[-3rem] bottom-16 h-36 w-36 rounded-full bg-blush/30 blur-3xl" />
-
-      <div className="relative mx-auto flex min-h-[calc(100vh-4rem)] max-w-md flex-col items-center justify-center">
-        <p className="bg-gradient-to-r from-[#f0a6bb] via-[#ef6c96] to-[#f7a8bc] bg-clip-text pb-8 text-center font-display text-7xl tracking-[-0.08em] text-transparent sm:text-8xl">
+    <main className="min-h-screen px-4 py-12 sm:px-6">
+      <div className="mx-auto flex min-h-[calc(100vh-6rem)] max-w-sm flex-col items-center justify-center">
+        {/* Wordmark */}
+        <p className="pb-8 text-center font-display text-7xl text-pink-deep sm:text-8xl">
           OOTD
         </p>
 
         <div className="w-full">
-          <div className="mb-5 text-center">
-            <p className="text-sm text-plum/65">{copy.eyebrow}</p>
-            <p className="mx-auto mt-3 max-w-sm text-sm leading-6 text-plum/58">
-              {copy.description}
-            </p>
-          </div>
+          <p className="mb-6 text-center text-sm text-mute">{copy.eyebrow}</p>
 
           {children}
 
-          <p className="mt-5 text-center text-sm text-plum/72">
+          <p className="mt-5 text-center text-sm text-mute">
             {copy.alternateLabel}{" "}
             <Link
               href={copy.alternateHref}
-              className="font-medium text-[#ef5f8a] transition hover:text-[#de4e7a]"
+              className="font-medium text-ink-soft underline-offset-2 transition hover:text-ink hover:underline"
             >
               {copy.alternateCta}
             </Link>

--- a/apps/web/components/chrome/mobile-nav.tsx
+++ b/apps/web/components/chrome/mobile-nav.tsx
@@ -12,7 +12,7 @@ function HomeIcon({ active }: { active: boolean }) {
     <svg
       aria-hidden="true"
       viewBox="0 0 24 24"
-      className={`h-5 w-5 ${active ? "text-[#f46a93]" : "text-plum/60"}`}
+      className={`h-5 w-5 ${active ? "text-ink" : "text-mute"}`}
       fill="none"
       stroke="currentColor"
       strokeWidth="1.8"
@@ -30,7 +30,7 @@ function BoardsIcon({ active }: { active: boolean }) {
     <svg
       aria-hidden="true"
       viewBox="0 0 24 24"
-      className={`h-5 w-5 ${active ? "text-[#f46a93]" : "text-plum/60"}`}
+      className={`h-5 w-5 ${active ? "text-ink" : "text-mute"}`}
       fill="none"
       stroke="currentColor"
       strokeWidth="1.8"
@@ -50,7 +50,7 @@ function ProfileIcon({ active }: { active: boolean }) {
     <svg
       aria-hidden="true"
       viewBox="0 0 24 24"
-      className={`h-5 w-5 ${active ? "text-[#f46a93]" : "text-plum/60"}`}
+      className={`h-5 w-5 ${active ? "text-ink" : "text-mute"}`}
       fill="none"
       stroke="currentColor"
       strokeWidth="1.8"
@@ -68,7 +68,7 @@ function VaultIcon({ active }: { active: boolean }) {
     <svg
       aria-hidden="true"
       viewBox="0 0 24 24"
-      className={`h-5 w-5 ${active ? "text-[#f46a93]" : "text-plum/60"}`}
+      className={`h-5 w-5 ${active ? "text-ink" : "text-mute"}`}
       fill="none"
       stroke="currentColor"
       strokeWidth="1.8"
@@ -96,12 +96,13 @@ function NavItem({
   return (
     <Link
       href={href}
-      className="flex min-w-[56px] flex-col items-center gap-1 rounded-full px-3 py-2 text-[0.72rem] font-medium text-plum/72 transition hover:text-plum"
+      className={`flex min-w-[56px] flex-col items-center gap-1 px-3 py-2 text-[0.7rem] font-medium lowercase transition ${active ? "text-ink" : "text-mute hover:text-ink-soft"}`}
     >
       {icon}
-      <span className={active ? "text-[#f46a93]" : ""}>{label}</span>
+      <span>{label}</span>
+      {/* 4px pink-deep active dot per checkd spec */}
       <span
-        className={`h-1.5 w-1.5 rounded-full bg-[#f46a93] transition ${
+        className={`h-[3px] w-[3px] rounded-full bg-pink-deep transition ${
           active ? "opacity-100" : "opacity-0"
         }`}
       />
@@ -113,19 +114,19 @@ export function MobileNav({ active }: MobileNavProps) {
   return (
     <nav className="fixed inset-x-0 bottom-4 z-40 flex justify-center px-4">
       <div className="mobile-dock">
-        <NavItem href="/feed" label="Home" active={active === "home"} icon={<HomeIcon active={active === "home"} />} />
-        <NavItem href="/boards" label="Boards" active={active === "boards"} icon={<BoardsIcon active={active === "boards"} />} />
+        <NavItem href="/feed" label="home" active={active === "home"} icon={<HomeIcon active={active === "home"} />} />
+        <NavItem href="/boards" label="boards" active={active === "boards"} icon={<BoardsIcon active={active === "boards"} />} />
 
-        {/* Center upload FAB — pops above the dock */}
+        {/* Center upload FAB — ink circle, pops above the dock */}
         <Link
           href="/upload"
-          aria-label="Upload outfit"
-          className="-mt-6 flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br from-[#ef6c96] to-[#f493b0] shadow-[0_8px_28px_rgba(244,106,147,0.45)] transition hover:brightness-[0.97] active:scale-[0.96]"
+          aria-label="post a fit"
+          className="-mt-6 flex h-14 w-14 items-center justify-center rounded-full bg-ink shadow-lift transition hover:opacity-90 active:scale-[0.96]"
         >
           <svg
             aria-hidden="true"
             viewBox="0 0 24 24"
-            className="h-6 w-6 text-white"
+            className="h-6 w-6 text-paper"
             fill="none"
             stroke="currentColor"
             strokeWidth="2.2"
@@ -137,8 +138,8 @@ export function MobileNav({ active }: MobileNavProps) {
           </svg>
         </Link>
 
-        <NavItem href="/vault" label="Vault" active={active === "vault"} icon={<VaultIcon active={active === "vault"} />} />
-        <NavItem href="/profile" label="Profile" active={active === "profile"} icon={<ProfileIcon active={active === "profile"} />} />
+        <NavItem href="/vault" label="vault" active={active === "vault"} icon={<VaultIcon active={active === "vault"} />} />
+        <NavItem href="/profile" label="me" active={active === "profile"} icon={<ProfileIcon active={active === "profile"} />} />
       </div>
     </nav>
   );

--- a/apps/web/components/chrome/search-bar.tsx
+++ b/apps/web/components/chrome/search-bar.tsx
@@ -20,7 +20,7 @@ export function SearchBar({ placeholder, value, onChange, onClear }: SearchBarPr
       <svg
         aria-hidden="true"
         viewBox="0 0 24 24"
-        className="h-4 w-4 shrink-0 text-plum/40"
+        className="h-4 w-4 shrink-0 text-mute"
         fill="none"
         stroke="currentColor"
         strokeWidth="1.8"
@@ -37,7 +37,7 @@ export function SearchBar({ placeholder, value, onChange, onClear }: SearchBarPr
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        className="search-input min-w-0 flex-1 bg-transparent outline-none placeholder:text-plum/38"
+        className="search-input min-w-0 flex-1 bg-transparent outline-none placeholder:text-mute"
         aria-label={placeholder}
       />
 
@@ -50,7 +50,7 @@ export function SearchBar({ placeholder, value, onChange, onClear }: SearchBarPr
             onClear?.();
             inputRef.current?.focus();
           }}
-          className="shrink-0 rounded-full p-0.5 text-plum/40 transition hover:text-plum"
+          className="shrink-0 rounded-full p-0.5 text-mute transition hover:text-plum"
           aria-label="Clear search"
         >
           <svg viewBox="0 0 24 24" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">

--- a/apps/web/components/outfits/comments-sheet.tsx
+++ b/apps/web/components/outfits/comments-sheet.tsx
@@ -51,7 +51,7 @@ function CommentRow({ comment, isOwn, editing, onStartEdit, onCancelEdit, onSave
           className="h-8 w-8 shrink-0 rounded-full border border-plum/10 object-cover"
         />
       ) : (
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-plum/12 bg-gradient-to-br from-[#fce4ec] to-[#f8bbd0] text-xs font-semibold text-[#c0476e]">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-plum/12 bg-pink-soft text-xs font-semibold text-ink-soft">
           {getInitial(comment.author.display_name ?? comment.author.username)}
         </div>
       )}
@@ -61,7 +61,7 @@ function CommentRow({ comment, isOwn, editing, onStartEdit, onCancelEdit, onSave
           <span className="text-xs font-semibold text-ink">
             {comment.author.display_name ?? comment.author.username ?? "Someone"}
           </span>
-          <span className="text-[0.65rem] text-plum/42">{formatCommentDate(comment.created_at)}</span>
+          <span className="text-[0.65rem] text-mute">{formatCommentDate(comment.created_at)}</span>
         </div>
 
         {editing ? (
@@ -70,14 +70,14 @@ function CommentRow({ comment, isOwn, editing, onStartEdit, onCancelEdit, onSave
               value={editBody}
               onChange={(e) => setEditBody(e.target.value)}
               rows={2}
-              className="w-full resize-none rounded-xl border border-rose/15 bg-white px-3 py-2 text-sm text-ink outline-none focus:border-[#ef5f8a]/40 focus:ring-2 focus:ring-[#ef5f8a]/10"
+              className="w-full resize-none rounded-xl border border-line bg-white px-3 py-2 text-sm text-ink outline-none focus:border-pink-deep"
             />
             <div className="flex gap-2">
               <button
                 type="button"
                 onClick={() => void handleSave()}
                 disabled={saving || !editBody.trim()}
-                className="rounded-full bg-gradient-to-r from-[#ef6c96] to-[#f493b0] px-3 py-1 text-xs font-semibold text-white disabled:opacity-50"
+                className="rounded-full bg-ink px-3 py-1 text-xs font-medium lowercase text-paper transition hover:opacity-90 disabled:opacity-50"
               >
                 {saving ? "Saving…" : "Save"}
               </button>
@@ -91,15 +91,15 @@ function CommentRow({ comment, isOwn, editing, onStartEdit, onCancelEdit, onSave
             </div>
           </div>
         ) : (
-          <p className="mt-0.5 text-sm leading-6 text-plum/80">{comment.body}</p>
+          <p className="mt-0.5 text-sm leading-6 text-ink-soft">{comment.body}</p>
         )}
 
         {isOwn && !editing ? (
           <div className="mt-1 flex gap-3">
-            <button type="button" onClick={onStartEdit} className="text-[0.65rem] text-plum/42 hover:text-plum/70 transition">
+            <button type="button" onClick={onStartEdit} className="text-[0.65rem] text-mute hover:text-ink-soft transition">
               Edit
             </button>
-            <button type="button" onClick={() => void onDelete()} className="text-[0.65rem] text-[#c04b72]/60 hover:text-[#c04b72] transition">
+            <button type="button" onClick={() => void onDelete()} className="text-[0.65rem] text-error/60 hover:text-error transition">
               Delete
             </button>
           </div>
@@ -208,7 +208,7 @@ export function CommentsSheet({ outfitId, onClose }: CommentsSheetProps) {
           <button
             type="button"
             onClick={onClose}
-            className="flex h-8 w-8 items-center justify-center rounded-full border border-rose/12 text-plum/50 transition hover:border-rose/22 hover:text-plum"
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-rose/12 text-mute transition hover:border-rose/22 hover:text-plum"
           >
             <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
               <path d="M18 6 6 18M6 6l12 12" />
@@ -222,19 +222,19 @@ export function CommentsSheet({ outfitId, onClose }: CommentsSheetProps) {
             <li className="flex flex-col gap-3 py-4">
               {Array.from({ length: 3 }).map((_, i) => (
                 <div key={i} className="flex gap-3">
-                  <div className="h-8 w-8 shrink-0 animate-pulse rounded-full bg-[#ffe8ef]" />
+                  <div className="h-8 w-8 shrink-0 animate-pulse rounded-full bg-pink-soft" />
                   <div className="flex-1 space-y-2 pt-1">
-                    <div className="h-2.5 w-24 animate-pulse rounded-full bg-[#ffe8ef]" />
-                    <div className="h-3 w-full animate-pulse rounded-full bg-[#fff3f7]" />
-                    <div className="h-3 w-3/4 animate-pulse rounded-full bg-[#fff3f7]" />
+                    <div className="h-2.5 w-24 animate-pulse rounded-full bg-pink-soft" />
+                    <div className="h-3 w-full animate-pulse rounded-full bg-pink-soft" />
+                    <div className="h-3 w-3/4 animate-pulse rounded-full bg-pink-soft" />
                   </div>
                 </div>
               ))}
             </li>
           ) : comments.length === 0 ? (
             <li className="py-10 text-center">
-              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-plum/40">No comments yet</p>
-              <p className="mt-2 text-sm text-plum/55">Be the first to say something.</p>
+              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-mute">No comments yet</p>
+              <p className="mt-2 text-sm text-mute">Be the first to say something.</p>
             </li>
           ) : (
             <>
@@ -252,7 +252,7 @@ export function CommentsSheet({ outfitId, onClose }: CommentsSheetProps) {
               ))}
               {cursor ? <div ref={sentinelRef} className="h-px" /> : null}
               {loadingMore ? (
-                <li className="py-3 text-center text-xs text-plum/40">Loading more…</li>
+                <li className="py-3 text-center text-xs text-mute">Loading more…</li>
               ) : null}
             </>
           )}
@@ -278,12 +278,12 @@ export function CommentsSheet({ outfitId, onClose }: CommentsSheetProps) {
                 placeholder="Add a comment…"
                 rows={1}
                 disabled={submitting}
-                className="min-h-[2.5rem] flex-1 resize-none rounded-2xl border border-rose/12 bg-white/80 px-4 py-2.5 text-sm text-ink placeholder-plum/35 outline-none transition focus:border-[#ef5f8a]/40 focus:ring-2 focus:ring-[#ef5f8a]/10 disabled:opacity-50"
+                className="min-h-[2.5rem] flex-1 resize-none rounded-xl border border-line bg-white px-4 py-2.5 text-sm text-ink outline-none transition focus:border-pink-deep disabled:opacity-50 placeholder:text-mute"
               />
               <button
                 type="submit"
                 disabled={!newBody.trim() || submitting}
-                className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-[#ef6c96] to-[#f493b0] text-white shadow-[0_4px_12px_rgba(244,106,147,0.3)] transition hover:brightness-[0.97] disabled:cursor-not-allowed disabled:opacity-50"
+                className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-ink text-paper transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
                 aria-label="Post comment"
               >
                 <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
@@ -294,7 +294,7 @@ export function CommentsSheet({ outfitId, onClose }: CommentsSheetProps) {
             </div>
           </form>
         ) : (
-          <p className="shrink-0 border-t border-rose/8 px-6 py-4 text-center text-xs text-plum/50">
+          <p className="shrink-0 border-t border-rose/8 px-6 py-4 text-center text-xs text-mute">
             Log in to leave a comment.
           </p>
         )}

--- a/apps/web/components/outfits/outfit-card.tsx
+++ b/apps/web/components/outfits/outfit-card.tsx
@@ -174,9 +174,9 @@ export function OutfitCard({
   return (
     <Link
       href={href}
-      className="group overflow-hidden rounded-[1.75rem] border border-rose/10 bg-white shadow-[0_18px_42px_rgba(244,106,147,0.08)] transition hover:-translate-y-1 hover:border-rose/20"
+      className="group overflow-hidden rounded-xl border border-line bg-white transition hover:-translate-y-0.5 hover:border-pink-deep"
     >
-      <div className="relative overflow-hidden bg-cream/65">
+      <div className="relative overflow-hidden bg-pink-soft/30">
         <img
           src={outfit.imageUrl}
           alt={outfit.caption?.trim() || "Outfit card photo"}
@@ -184,11 +184,11 @@ export function OutfitCard({
         />
 
         {showAccentMarker ? (
-          <div className="pointer-events-none absolute right-3 top-3 flex h-7 w-7 items-center justify-center rounded-full border border-white/55 bg-white/72 backdrop-blur">
+          <div className="pointer-events-none absolute right-2.5 top-2.5 flex h-6 w-6 items-center justify-center rounded-full bg-white/85 backdrop-blur">
             <svg
               aria-hidden="true"
               viewBox="0 0 24 24"
-              className="h-3.5 w-3.5 text-white drop-shadow-[0_1px_2px_rgba(0,0,0,0.18)]"
+              className="h-3 w-3 text-ink-soft"
               fill="none"
               stroke="currentColor"
               strokeWidth="1.9"
@@ -201,9 +201,9 @@ export function OutfitCard({
         ) : null}
 
         {toneClasses && toneLabel ? (
-          <div className="pointer-events-none absolute left-4 top-4">
+          <div className="pointer-events-none absolute left-3 top-3">
             <span
-              className={`inline-flex items-center rounded-full border px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.16em] backdrop-blur ${toneClasses.border} ${toneClasses.background} ${toneClasses.text}`}
+              className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-[0.6rem] font-medium lowercase backdrop-blur ${toneClasses.border} ${toneClasses.background} ${toneClasses.text}`}
             >
               {toneLabel}
             </span>
@@ -215,11 +215,11 @@ export function OutfitCard({
             type="button"
             onClick={onLike}
             aria-label={liked ? "Unlike" : "Like"}
-            className="absolute bottom-3 right-3 flex items-center gap-1.5 rounded-full border border-white/40 bg-white/80 px-2.5 py-1.5 backdrop-blur transition hover:bg-white/95"
+            className="absolute bottom-2.5 right-2.5 flex items-center gap-1 rounded-full border border-white/50 bg-white/85 px-2 py-1.5 backdrop-blur transition hover:bg-white"
           >
             <svg
               viewBox="0 0 24 24"
-              className={`h-3.5 w-3.5 transition ${liked ? "text-[#ef5f8a]" : "text-plum/50"}`}
+              className={`h-3.5 w-3.5 transition ${liked ? "text-pink-deep" : "text-mute"}`}
               fill={liked ? "currentColor" : "none"}
               stroke="currentColor"
               strokeWidth="2"
@@ -229,7 +229,7 @@ export function OutfitCard({
               <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
             </svg>
             {likeCount !== undefined && likeCount > 0 ? (
-              <span className={`text-[0.64rem] font-semibold tabular-nums ${liked ? "text-[#ef5f8a]" : "text-plum/60"}`}>
+              <span className={`text-[0.6rem] font-medium tabular-nums ${liked ? "text-ink-soft" : "text-mute"}`}>
                 {likeCount.toLocaleString()}
               </span>
             ) : null}
@@ -237,48 +237,48 @@ export function OutfitCard({
         ) : null}
       </div>
 
-      <div className={`px-4 py-4 sm:px-5 sm:py-5 ${showCaption ? "space-y-4" : "space-y-2"}`}>
+      <div className={`px-3.5 py-3.5 ${showCaption ? "space-y-3" : "space-y-2"}`}>
         {showAuthor ? (
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2.5">
             {outfit.author?.profileImageUrl ? (
               <img
                 src={outfit.author.profileImageUrl}
                 alt={getAuthorLabel(outfit.author)}
-                className="h-11 w-11 rounded-full border border-plum/12 object-cover"
+                className="h-8 w-8 rounded-full border border-line object-cover"
               />
             ) : (
-              <div className="flex h-11 w-11 items-center justify-center rounded-full border border-plum/14 bg-brand-glow text-sm font-semibold text-plum">
+              <div className="flex h-8 w-8 items-center justify-center rounded-full border border-pink bg-pink-soft font-display text-sm italic text-ink-soft">
                 {getAuthorInitial(outfit)}
               </div>
             )}
 
             <div className="min-w-0">
-              <p className="truncate text-sm font-semibold text-ink">
+              <p className="truncate text-xs font-medium text-ink">
                 {getAuthorLabel(outfit.author)}
               </p>
-              <p className="text-[0.68rem] uppercase tracking-[0.18em] text-plum/54">
+              <p className="text-[0.65rem] text-mute">
                 {dateLabel}
               </p>
             </div>
           </div>
         ) : (
           <div className="flex items-center justify-between gap-3">
-            <p className="text-[0.68rem] uppercase tracking-[0.18em] text-plum/54">{dateLabel}</p>
+            <p className="text-[0.65rem] text-mute">{dateLabel}</p>
             {!toneClasses && toneLabel ? (
-              <span className="rounded-full border border-rose/12 bg-[#fff4f7] px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.16em] text-[#ef5f8a]">
+              <span className="rounded-full border border-line bg-pink-soft px-2.5 py-0.5 text-[0.6rem] font-medium lowercase text-ink-soft">
                 {toneLabel}
               </span>
             ) : null}
           </div>
         )}
 
-        <div className={showCaption ? "space-y-2" : "space-y-1"}>
+        <div className={showCaption ? "space-y-1.5" : "space-y-1"}>
           {showCaption ? (
-            <p className="line-clamp-2 text-sm leading-6 text-plum/84">{caption}</p>
+            <p className="line-clamp-2 font-display text-sm italic leading-snug text-ink-soft">{caption}</p>
           ) : null}
 
           {metadataLine ? (
-            <p className="line-clamp-1 text-[0.68rem] uppercase tracking-[0.16em] text-plum/54">
+            <p className="line-clamp-1 text-[0.65rem] lowercase text-mute">
               {metadataLine}
             </p>
           ) : null}
@@ -294,28 +294,27 @@ export function OutfitCardSkeleton({
   showAuthor?: boolean;
 }) {
   return (
-    <article className="overflow-hidden rounded-[1.75rem] border border-rose/10 bg-white shadow-[0_18px_42px_rgba(244,106,147,0.06)]">
-      <div className="aspect-[4/5] w-full animate-pulse bg-[linear-gradient(120deg,_rgba(255,236,242,0.8),_rgba(255,255,255,0.98),_rgba(250,216,225,0.62))]" />
-      <div className="space-y-4 px-4 py-4 sm:px-5 sm:py-5">
+    <article className="overflow-hidden rounded-xl border border-line bg-white">
+      <div className="aspect-[4/5] w-full animate-pulse bg-pink-soft" />
+      <div className="space-y-3 px-3.5 py-3.5">
         {showAuthor ? (
-          <div className="flex items-center gap-3">
-            <div className="h-11 w-11 animate-pulse rounded-full bg-[#ffe8ef]" />
-            <div className="min-w-0 flex-1 space-y-2">
-              <div className="h-3 w-24 animate-pulse rounded-full bg-[#ffe8ef]" />
-              <div className="h-2.5 w-20 animate-pulse rounded-full bg-[#fff3f7]" />
+          <div className="flex items-center gap-2.5">
+            <div className="h-8 w-8 animate-pulse rounded-full bg-line" />
+            <div className="min-w-0 flex-1 space-y-1.5">
+              <div className="h-2.5 w-24 animate-pulse rounded-full bg-line" />
+              <div className="h-2 w-16 animate-pulse rounded-full bg-line/60" />
             </div>
           </div>
         ) : (
           <div className="flex items-center justify-between gap-3">
-            <div className="h-2.5 w-20 animate-pulse rounded-full bg-[#fff3f7]" />
-            <div className="h-6 w-20 animate-pulse rounded-full bg-[#ffe8ef]" />
+            <div className="h-2 w-16 animate-pulse rounded-full bg-line/60" />
+            <div className="h-5 w-16 animate-pulse rounded-full bg-line" />
           </div>
         )}
 
-        <div className="space-y-2">
-          <div className="h-3 w-full animate-pulse rounded-full bg-[#ffe8ef]" />
-          <div className="h-3 w-4/5 animate-pulse rounded-full bg-[#fff3f7]" />
-          <div className="h-2.5 w-1/3 animate-pulse rounded-full bg-[#fff6f9]" />
+        <div className="space-y-1.5">
+          <div className="h-2.5 w-full animate-pulse rounded-full bg-line" />
+          <div className="h-2.5 w-4/5 animate-pulse rounded-full bg-line/70" />
         </div>
       </div>
     </article>

--- a/apps/web/components/outfits/outfit-detail-view.tsx
+++ b/apps/web/components/outfits/outfit-detail-view.tsx
@@ -97,9 +97,9 @@ export function OutfitDetailView({ id }: { id: string }) {
     return (
       <main className="flex min-h-screen items-center justify-center px-4">
         <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-          <p className="font-display text-5xl tracking-[-0.08em] text-[#f09ab4]">OOTD</p>
+          <p className="font-display text-5xl text-pink-deep">OOTD</p>
           <h1 className="mt-4 text-3xl text-ink">Outfit not found</h1>
-          <p className="mt-3 text-sm leading-6 text-plum/68">This look may have been removed.</p>
+          <p className="mt-3 text-sm leading-6 text-ink-soft">This look may have been removed.</p>
           <Link href="/feed" className="mt-6 inline-block rounded-[1.2rem] border border-rose/15 bg-white px-5 py-3 text-sm font-semibold text-plum transition hover:border-rose/25">
             Back to feed
           </Link>
@@ -123,7 +123,7 @@ export function OutfitDetailView({ id }: { id: string }) {
             <button
               type="button"
               onClick={() => router.back()}
-              className="flex items-center gap-1.5 text-sm text-plum/58 transition hover:text-plum"
+              className="flex items-center gap-1.5 text-sm text-mute transition hover:text-plum"
             >
               <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="m15 18-6-6 6-6" />
@@ -134,7 +134,7 @@ export function OutfitDetailView({ id }: { id: string }) {
             <button
               type="button"
               onClick={() => setShowShare(true)}
-              className="flex items-center gap-2 rounded-full border border-rose/15 bg-white px-4 py-2.5 text-[0.78rem] font-semibold text-plum shadow-[0_8px_20px_rgba(244,106,147,0.07)] transition hover:border-rose/28"
+              className="flex items-center gap-2 rounded-full border border-rose/15 bg-white px-4 py-2.5 text-[0.78rem] font-semibold text-plum transition hover:border-rose/28"
             >
               <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round">
                 <circle cx="18" cy="5" r="3" />
@@ -177,10 +177,10 @@ export function OutfitDetailView({ id }: { id: string }) {
               {/* Author */}
               {status === "loading" ? (
                 <div className="soft-panel flex animate-pulse items-center gap-3 px-5 py-4">
-                  <div className="h-11 w-11 rounded-full bg-[#ffe8ef]" />
+                  <div className="h-11 w-11 rounded-full bg-pink-soft" />
                   <div className="flex-1 space-y-2">
-                    <div className="h-3.5 w-28 rounded-full bg-[#ffe8ef]" />
-                    <div className="h-3 w-20 rounded-full bg-[#fff3f7]" />
+                    <div className="h-3.5 w-28 rounded-full bg-pink-soft" />
+                    <div className="h-3 w-20 rounded-full bg-pink-soft" />
                   </div>
                 </div>
               ) : outfit?.owner ? (
@@ -195,7 +195,7 @@ export function OutfitDetailView({ id }: { id: string }) {
                       className="h-11 w-11 rounded-full border border-plum/10 object-cover"
                     />
                   ) : (
-                    <div className="flex h-11 w-11 items-center justify-center rounded-full border border-plum/14 bg-gradient-to-br from-[#fce4ec] to-[#f8bbd0] text-sm font-semibold text-[#c0476e]">
+                    <div className="flex h-11 w-11 items-center justify-center rounded-full border border-plum/14 bg-pink-soft text-sm font-semibold text-ink-soft">
                       {(outfit.owner.display_name ?? outfit.owner.username ?? "?").charAt(0).toUpperCase()}
                     </div>
                   )}
@@ -204,7 +204,7 @@ export function OutfitDetailView({ id }: { id: string }) {
                       {outfit.owner.display_name ?? outfit.owner.username}
                     </p>
                     {outfit.owner.username ? (
-                      <p className="text-[0.7rem] text-plum/50">@{outfit.owner.username}</p>
+                      <p className="text-[0.7rem] text-mute">@{outfit.owner.username}</p>
                     ) : null}
                   </div>
                   <svg viewBox="0 0 24 24" className="ml-auto h-4 w-4 shrink-0 text-plum/30" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -217,30 +217,30 @@ export function OutfitDetailView({ id }: { id: string }) {
               <div className="soft-panel px-5 py-5 space-y-4">
                 {status === "loading" ? (
                   <div className="space-y-3">
-                    <div className="h-4 w-full rounded-full bg-[#ffe8ef]" />
-                    <div className="h-4 w-4/5 rounded-full bg-[#fff3f7]" />
-                    <div className="h-3 w-1/3 rounded-full bg-[#fff6f9]" />
+                    <div className="h-4 w-full rounded-full bg-pink-soft" />
+                    <div className="h-4 w-4/5 rounded-full bg-pink-soft" />
+                    <div className="h-3 w-1/3 rounded-full bg-line/60" />
                   </div>
                 ) : (
                   <>
                     {outfit?.caption ? (
-                      <p className="text-sm leading-7 text-plum/84">{outfit.caption}</p>
+                      <p className="text-sm leading-7 text-ink-soft">{outfit.caption}</p>
                     ) : null}
 
                     {outfit?.event_name ? (
-                      <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-plum/52">
+                      <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-mute">
                         {outfit.event_name}
                       </p>
                     ) : null}
 
                     {dateLabel ? (
-                      <p className="text-[0.7rem] uppercase tracking-[0.18em] text-plum/42">{dateLabel}</p>
+                      <p className="text-[0.7rem] uppercase tracking-[0.18em] text-mute">{dateLabel}</p>
                     ) : null}
 
                     {outfit?.vibe_check_text ? (
-                      <div className="rounded-[1rem] border border-rose/10 bg-[#fff8fb] px-4 py-3">
-                        <p className="mb-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[#ef5f8a]">Vibe check</p>
-                        <p className="text-sm leading-6 text-plum/80">{outfit.vibe_check_text}</p>
+                      <div className="rounded-[1rem] border border-rose/10 bg-pink-soft px-4 py-3">
+                        <p className="mb-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-pink-deep">Vibe check</p>
+                        <p className="text-sm leading-6 text-ink-soft">{outfit.vibe_check_text}</p>
                       </div>
                     ) : null}
                   </>
@@ -250,13 +250,13 @@ export function OutfitDetailView({ id }: { id: string }) {
               {/* Clothing items */}
               {status === "ready" && outfit && outfit.clothing_items.length > 0 ? (
                 <div className="soft-panel px-5 py-5">
-                  <p className="mb-3 text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-plum/48">Pieces</p>
+                  <p className="mb-3 text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-mute">Pieces</p>
                   <ul className="space-y-3">
                     {outfit.clothing_items.map((item) => (
                       <li key={item.id} className="flex items-start justify-between gap-3">
                         <div className="min-w-0">
                           <p className="truncate text-sm font-semibold text-ink capitalize">{item.category}</p>
-                          <p className="text-[0.7rem] text-plum/52">
+                          <p className="text-[0.7rem] text-mute">
                             {[item.brand, item.color].filter(Boolean).join(" · ")}
                           </p>
                         </div>
@@ -265,7 +265,7 @@ export function OutfitDetailView({ id }: { id: string }) {
                             href={item.link_url}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="shrink-0 rounded-full border border-rose/15 px-3 py-1 text-[0.68rem] font-semibold text-[#ef5f8a] transition hover:border-rose/28"
+                            className="shrink-0 rounded-full border border-rose/15 px-3 py-1 text-[0.68rem] font-semibold text-pink-deep transition hover:border-rose/28"
                           >
                             Shop
                           </a>
@@ -284,7 +284,7 @@ export function OutfitDetailView({ id }: { id: string }) {
                   disabled={likeLoading || !isAuthenticated}
                   className={`flex flex-1 items-center justify-center gap-2 rounded-[1.2rem] border py-3.5 text-sm font-semibold transition disabled:cursor-default ${
                     liked
-                      ? "border-[#f6a9be] bg-[#fff1f6] text-[#ef5f8a]"
+                      ? "border-[#f6a9be] bg-pink-soft text-pink-deep"
                       : "border-rose/15 bg-white text-plum hover:border-rose/28"
                   }`}
                 >
@@ -308,7 +308,7 @@ export function OutfitDetailView({ id }: { id: string }) {
                 <button
                   type="button"
                   onClick={() => setShowShare(true)}
-                  className="flex aspect-square items-center justify-center rounded-[1.2rem] border border-rose/15 bg-white p-3.5 text-plum/60 transition hover:border-rose/28 hover:text-plum"
+                  className="flex aspect-square items-center justify-center rounded-[1.2rem] border border-rose/15 bg-white p-3.5 text-mute transition hover:border-rose/28 hover:text-plum"
                   aria-label="Share"
                 >
                   <svg viewBox="0 0 24 24" className="h-4.5 w-4.5" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round">
@@ -323,7 +323,7 @@ export function OutfitDetailView({ id }: { id: string }) {
                 {isOwn ? (
                   <Link
                     href="/vault"
-                    className="flex aspect-square items-center justify-center rounded-[1.2rem] border border-rose/15 bg-white p-3.5 text-plum/60 transition hover:border-rose/28 hover:text-plum"
+                    className="flex aspect-square items-center justify-center rounded-[1.2rem] border border-rose/15 bg-white p-3.5 text-mute transition hover:border-rose/28 hover:text-plum"
                     aria-label="View in vault"
                   >
                     <svg viewBox="0 0 24 24" className="h-4.5 w-4.5" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round">

--- a/apps/web/components/outfits/story-card-sheet.tsx
+++ b/apps/web/components/outfits/story-card-sheet.tsx
@@ -46,7 +46,7 @@ export function StoryCardSheet({ outfitId, onClose }: StoryCardSheetProps) {
           <button
             type="button"
             onClick={onClose}
-            className="flex h-8 w-8 items-center justify-center rounded-full border border-rose/12 text-plum/50 transition hover:border-rose/22 hover:text-plum"
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-rose/12 text-mute transition hover:border-rose/22 hover:text-plum"
           >
             <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M18 6 6 18M6 6l12 12" />
@@ -75,7 +75,7 @@ export function StoryCardSheet({ outfitId, onClose }: StoryCardSheetProps) {
           <button
             type="button"
             onClick={handleDownload}
-            className="flex w-full items-center gap-3 rounded-[1.2rem] bg-gradient-to-r from-[#ef6c96] to-[#f493b0] px-5 py-3.5 text-sm font-semibold text-white transition hover:brightness-[0.98]"
+            className="btn-primary flex w-full items-center gap-3"
           >
             <svg viewBox="0 0 24 24" className="h-4.5 w-4.5 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />

--- a/apps/web/components/upload/upload-flow.tsx
+++ b/apps/web/components/upload/upload-flow.tsx
@@ -368,13 +368,13 @@ export function UploadFlow() {
     <section className="soft-panel overflow-hidden">
       <div className="grid gap-8 lg:grid-cols-[0.32fr_0.68fr]">
         <aside className="bg-brand-glow px-5 py-6 sm:px-7 sm:py-8 lg:px-8 lg:py-10">
-          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-plum/70">
+          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-ink-soft">
             Four-step flow
           </p>
           <h2 className="mt-3 text-4xl leading-tight text-ink">
             Build the outfit once, then reuse it everywhere.
           </h2>
-          <p className="mt-4 text-sm leading-6 text-plum/82">
+          <p className="mt-4 text-sm leading-6 text-ink-soft">
             This upload flow posts the same structured payload the backend uses for the
             vault, feed, event boards, and AI features.
           </p>
@@ -402,7 +402,7 @@ export function UploadFlow() {
                   }`}
                 >
                   <div className="flex items-center justify-between gap-3">
-                    <span className="text-xs font-semibold uppercase tracking-[0.24em] text-plum/72">
+                    <span className="text-xs font-semibold uppercase tracking-[0.24em] text-ink-soft">
                       Step {step.id}
                     </span>
                     <span
@@ -411,14 +411,14 @@ export function UploadFlow() {
                           ? "bg-plum text-white"
                           : isComplete
                             ? "bg-emerald-50 text-emerald-900"
-                            : "bg-white/75 text-plum/70"
+                            : "bg-white/75 text-ink-soft"
                       }`}
                     >
                       {isComplete ? "Done" : step.label}
                     </span>
                   </div>
                   <p className="mt-3 text-lg text-ink">{step.title}</p>
-                  <p className="mt-2 text-sm leading-6 text-plum/80">{step.hint}</p>
+                  <p className="mt-2 text-sm leading-6 text-ink-soft">{step.hint}</p>
                 </button>
               );
             })}
@@ -428,11 +428,11 @@ export function UploadFlow() {
         <div className="px-5 py-6 sm:px-7 sm:py-8 lg:px-8 lg:py-10">
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div>
-              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-plum/70">
+              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-ink-soft">
                 {currentConfig.label}
               </p>
               <h3 className="mt-2 text-4xl text-ink">{currentConfig.title}</h3>
-              <p className="mt-3 max-w-2xl text-sm leading-6 text-plum/82">
+              <p className="mt-3 max-w-2xl text-sm leading-6 text-ink-soft">
                 {currentConfig.hint}
               </p>
             </div>
@@ -465,11 +465,11 @@ export function UploadFlow() {
                     ) : (
                       <div className="flex aspect-[4/5] items-center justify-center bg-[radial-gradient(circle_at_top,_rgba(230,170,184,0.2),_transparent_45%),linear-gradient(180deg,_#fff8f5_0%,_#f8eef1_100%)] px-8 text-center">
                         <div>
-                          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-plum/70">
+                          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-ink-soft">
                             Step 1
                           </p>
                           <h4 className="mt-3 text-3xl text-ink">Choose the hero image</h4>
-                          <p className="mt-3 text-sm leading-6 text-plum/80">
+                          <p className="mt-3 text-sm leading-6 text-ink-soft">
                             Pick the photo that best captures the whole look. You can swap
                             it later before submitting.
                           </p>
@@ -499,17 +499,17 @@ export function UploadFlow() {
                 </div>
 
                 <div className="rounded-[1.75rem] border border-plum/12 bg-white/75 p-5">
-                  <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-plum/70">
+                  <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-ink-soft">
                     Photo note
                   </p>
                   <h4 className="mt-3 text-2xl text-ink">Use the version you would actually post</h4>
-                  <p className="mt-3 text-sm leading-6 text-plum/80">
+                  <p className="mt-3 text-sm leading-6 text-ink-soft">
                     The preview here drives the later review card, feed card, and story
                     export surfaces.
                   </p>
 
                   {photo ? (
-                    <div className="mt-5 rounded-[1.25rem] border border-plum/12 bg-cream/70 px-4 py-4 text-sm leading-6 text-plum/82">
+                    <div className="mt-5 rounded-[1.25rem] border border-plum/12 bg-cream/70 px-4 py-4 text-sm leading-6 text-ink-soft">
                       <p className="font-semibold text-ink">{photo.name}</p>
                       <p>{(photo.size / 1024 / 1024).toFixed(2)} MB</p>
                     </div>
@@ -531,7 +531,7 @@ export function UploadFlow() {
                   >
                     <div className="mb-4 flex items-center justify-between gap-3">
                       <div>
-                        <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-plum/70">
+                        <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-ink-soft">
                           Item {index + 1}
                         </p>
                         <p className="mt-1 text-sm text-plum/78">display_order: {index}</p>
@@ -541,7 +541,7 @@ export function UploadFlow() {
                         type="button"
                         onClick={() => removeItem(item.id)}
                         disabled={items.length === 1}
-                        className="rounded-[1rem] border border-plum/15 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-plum/75 transition hover:bg-cream/65 disabled:cursor-not-allowed disabled:opacity-45"
+                        className="rounded-[1rem] border border-plum/15 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-ink-soft transition hover:bg-cream/65 disabled:cursor-not-allowed disabled:opacity-45"
                       >
                         Remove
                       </button>
@@ -646,7 +646,7 @@ export function UploadFlow() {
                   </label>
                 </div>
 
-                <div className="rounded-[1.5rem] border border-plum/12 bg-cream/55 px-4 py-4 text-sm leading-6 text-plum/80">
+                <div className="rounded-[1.5rem] border border-plum/12 bg-cream/55 px-4 py-4 text-sm leading-6 text-ink-soft">
                   Context is optional now, but these fields make the vault, event boards,
                   and AI features much more useful later.
                 </div>
@@ -673,7 +673,7 @@ export function UploadFlow() {
 
                 <div className="grid gap-4">
                   <section className="rounded-[1.75rem] border border-plum/12 bg-white/78 p-5">
-                    <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-plum/70">
+                    <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-ink-soft">
                       Tagged items
                     </p>
                     <div className="mt-4 grid gap-3">
@@ -682,7 +682,7 @@ export function UploadFlow() {
                           key={item.id}
                           className="rounded-[1.25rem] border border-plum/10 bg-cream/55 px-4 py-3"
                         >
-                          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-plum/70">
+                          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-ink-soft">
                             Item {index + 1}
                           </p>
                           <p className="mt-2 text-sm text-ink">
@@ -696,10 +696,10 @@ export function UploadFlow() {
                   </section>
 
                   <section className="rounded-[1.75rem] border border-plum/12 bg-white/78 p-5">
-                    <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-plum/70">
+                    <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-ink-soft">
                       Metadata
                     </p>
-                    <div className="mt-4 grid gap-3 text-sm leading-6 text-plum/82">
+                    <div className="mt-4 grid gap-3 text-sm leading-6 text-ink-soft">
                       <p>
                         <span className="font-semibold text-ink">Caption:</span>{" "}
                         {metadata.caption.trim() || "None yet"}
@@ -716,10 +716,10 @@ export function UploadFlow() {
                   </section>
 
                   <section className="rounded-[1.75rem] border border-plum/12 bg-cream/65 p-5">
-                    <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-plum/70">
+                    <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-ink-soft">
                       Submit mode
                     </p>
-                    <p className="mt-3 text-sm leading-6 text-plum/82">
+                    <p className="mt-3 text-sm leading-6 text-ink-soft">
                       Submitting sends your image plus structured metadata to the real
                       create-outfit endpoint.
                     </p>
@@ -787,7 +787,7 @@ function StatusBanner({
   const toneClasses =
     tone === "success"
       ? "border-emerald-200 bg-emerald-50 text-emerald-900"
-      : "border-rose/25 bg-rose/10 text-[#7f2947]";
+      : "border-rose/25 bg-rose/10 text-error";
 
   return (
     <div className={`rounded-[1.25rem] border px-4 py-3 text-sm ${toneClasses} ${className}`}>

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -9,28 +9,38 @@ const config = {
   theme: {
     extend: {
       colors: {
-        ink: "#24151C",
-        plum: "#6B3955",
-        mauve: "#8B5873",
-        blush: "#F2C4CE",
-        cream: "#FFF8F5",
-        mist: "#F7EEF1",
-        rose: "#E6AAB8",
-        gold: "#D7B26D"
+        // checkd design tokens
+        ink: "#1a1416",
+        "ink-soft": "#4a3f43",
+        mute: "#8a7a80",
+        pink: "#F8C8DC",
+        "pink-soft": "#FDEDF3",
+        "pink-deep": "#E8A8C0",
+        line: "#efe4e8",
+        paper: "#faf7f5",
+        // Semantic states — pink is decorative only, never for states
+        success: "#3a8a5e",
+        error: "#c4452f",
+        warn: "#b8842b",
+        // Legacy aliases mapped to new token values
+        plum: "#4a3f43",
+        rose: "#efe4e8",
+        cream: "#faf7f5",
+        blush: "#F8C8DC",
+        mist: "#FDEDF3",
+        mauve: "#8a7a80",
+        gold: "#b8842b"
       },
       boxShadow: {
-        card: "0 24px 80px rgba(51, 24, 37, 0.16)"
+        card: "0 1px 0 0 #efe4e8",
+        lift: "0 4px 16px rgba(26,20,22,0.06)"
       },
       backgroundImage: {
-        "brand-glow": "radial-gradient(circle at top, rgba(230, 170, 184, 0.42), transparent 42%), radial-gradient(circle at bottom left, rgba(107, 57, 85, 0.18), transparent 36%)"
+        "brand-glow": "linear-gradient(135deg, #FDEDF3 0%, #faf7f5 100%)"
       },
       fontFamily: {
-        display: [
-          "var(--font-display)"
-        ],
-        sans: [
-          "var(--font-sans)"
-        ]
+        display: ["var(--font-display)"],
+        sans: ["var(--font-sans)"]
       }
     }
   },

--- a/apps/web/tests/smoke.spec.ts
+++ b/apps/web/tests/smoke.spec.ts
@@ -109,16 +109,17 @@ test.describe("public routes", () => {
   test("landing page links to auth screens", async ({ page }) => {
     await page.goto("/");
 
+    // Heading text reflects the checkd redesign copy
     await expect(
       page.getByRole("heading", {
-        name: /your personal style archive/i
+        name: /your daily fit/i
       })
     ).toBeVisible();
-    await expect(page.getByRole("link", { name: /create your account/i })).toHaveAttribute(
+    await expect(page.getByRole("link", { name: /get started/i })).toHaveAttribute(
       "href",
       "/signup"
     );
-    await expect(page.getByRole("link", { name: /log in/i })).toHaveAttribute("href", "/login");
+    await expect(page.getByRole("link", { name: /^log in$/i })).toHaveAttribute("href", "/login");
   });
 
   test("login and signup pages render their forms", async ({ page }) => {


### PR DESCRIPTION
## Summary

- Replaces the old color/font system with the **checkd 8-token palette** (ink, ink-soft, mute, pink, pink-soft, pink-deep, line, paper) and legacy aliases for backward compat
- Swaps Cormorant Garamond + Manrope for **Instrument Serif italic** (display) + **Inter** (sans)
- Rewrites `globals.css` component classes: `soft-panel`, `btn-primary`, `btn-secondary`, `field-shell`, `field-label`, `icon-button`
- Strips all pink gradient buttons → `bg-ink text-paper` pill buttons with lowercase labels
- Removes decorative blobs and radial gradients; body is flat `paper` (#faf7f5)
- Outfit cards, auth forms, mobile nav, boards, profile pages, explore, search, onboarding — all updated to checkd spec
- Build verified: 15 routes, 0 TypeScript errors

## Test plan

- [ ] Auth flow (login / signup) — labels visible, forms clean
- [ ] Feed, vault tabs — lowercase labels, ink active state
- [ ] Outfit card — Instrument Serif italic caption, pink-deep heart
- [ ] Profile page + edit profile
- [ ] Boards list + board detail + join invite
- [ ] Mobile nav — ink active icon, pink-deep dot, ink upload FAB
- [ ] Landing page — Instrument Serif wordmark, btn-primary / btn-secondary CTAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)