### PR TITLE
feat: board outfit author field (#131) + GET /outfits/explore (#136)

### DIFF
--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -171,7 +171,7 @@ export default function ExplorePage() {
     let active = true;
     setGridStatus("loading");
 
-    apiClient.outfits.getFeed({ limit: PAGE_SIZE }).then((result) => {
+    apiClient.outfits.getExplore({ limit: PAGE_SIZE }).then((result) => {
       if (!active) return;
       if (!result.ok) { setGridStatus("error"); return; }
       setOutfits(result.data.outfits);
@@ -201,7 +201,7 @@ export default function ExplorePage() {
     if (!nextCursor || loadingMore || gridStatus !== "ready") return;
     setLoadingMore(true);
 
-    const result = await apiClient.outfits.getFeed({ cursor: nextCursor, limit: PAGE_SIZE });
+    const result = await apiClient.outfits.getExplore({ cursor: nextCursor, limit: PAGE_SIZE });
     if (result.ok) {
       setOutfits((prev) => [...prev, ...result.data.outfits]);
       setNextCursor(result.data.next_cursor ?? null);

--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import {
   apiClient,
   type Board,
+  type BoardOutfitResponse,
   type FeedOutfitResponse,
   type OutfitResponse,
 } from "@/lib/api-client";
@@ -24,7 +25,7 @@ type Status = "idle" | "loading" | "ready" | "error";
 
 type BoardSection = {
   board: Board;
-  outfits: OutfitResponse[];
+  outfits: BoardOutfitResponse[];
   cursor: string | null;
   status: Status;
   loadingMore: boolean;
@@ -48,7 +49,7 @@ function toVaultCardData(outfit: FeedOutfitResponse): OutfitCardData {
   };
 }
 
-function toBoardCardData(outfit: OutfitResponse): OutfitCardData {
+function toBoardCardData(outfit: BoardOutfitResponse): OutfitCardData {
   return {
     id: outfit.id,
     imageUrl: outfit.image_url,
@@ -57,11 +58,10 @@ function toBoardCardData(outfit: OutfitResponse): OutfitCardData {
     wornOn: outfit.worn_on,
     createdAt: outfit.created_at,
     vibeTone: outfit.vibe_check_tone,
-    // TODO: OutfitOut from GET /boards/{id}/outfits does not include author.
-    // Need backend to add `author: { id, username, profile_image_url }` to
-    // OutfitOut (matching the FeedAuthor shape) so "who uploaded" can be shown
-    // on each board activity card. Until then, author is omitted here.
-    author: null,
+    author: {
+      username: outfit.author.username,
+      profileImageUrl: outfit.author.profile_image_url,
+    },
   };
 }
 
@@ -123,12 +123,12 @@ function BoardActivityCard({
   outfit,
   boardName,
 }: {
-  outfit: OutfitResponse;
+  outfit: BoardOutfitResponse;
   boardName: string;
 }) {
   return (
     <div className="relative">
-      <OutfitCard outfit={toBoardCardData(outfit)} showAuthor={false} />
+      <OutfitCard outfit={toBoardCardData(outfit)} showAuthor />
       {/* Board name badge */}
       <div className="pointer-events-none absolute left-3 bottom-[4.5rem] right-3">
         <span className="inline-flex max-w-full items-center gap-1.5 truncate rounded-full border border-plum/10 bg-white/88 px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.14em] text-plum/70 backdrop-blur">

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -203,8 +203,13 @@ export type BoardMember = {
   joined_at: string;
 };
 
+/** Board outfit — same as OutfitResponse but includes the uploader's author info */
+export type BoardOutfitResponse = OutfitResponse & {
+  author: FeedAuthor;
+};
+
 export type BoardOutfitPage = {
-  outfits: OutfitResponse[];
+  outfits: BoardOutfitResponse[];
   next_cursor: string | null;
 };
 
@@ -521,6 +526,19 @@ export const outfitApiClient = {
     return sendRequest<FeedPageResponse>(`/outfits/feed${query ? `?${query}` : ""}`, {
       requiresAuth: true,
       successMessage: "Loaded feed."
+    });
+  },
+
+  async getExplore(input?: {
+    cursor?: string;
+    limit?: number;
+  }): Promise<ApiResult<FeedPageResponse>> {
+    const params = new URLSearchParams();
+    if (input?.cursor) params.set("cursor", input.cursor);
+    if (input?.limit) params.set("limit", String(input.limit));
+    const query = params.toString();
+    return sendRequest<FeedPageResponse>(`/outfits/explore${query ? `?${query}` : ""}`, {
+      successMessage: "Loaded explore."
     });
   },
 

--- a/services/api/app/crud/outfit.py
+++ b/services/api/app/crud/outfit.py
@@ -170,3 +170,31 @@ def get_feed(
         next_cursor = outfits[-1].created_at.isoformat()
 
     return outfits, next_cursor
+
+
+def get_explore(
+    db: Session,
+    cursor: str | None = None,
+    limit: int = 20,
+) -> tuple[list[Outfit], str | None]:
+    """
+    All outfits on the platform, newest first.
+    No user filter — public explore feed. Cursor-paginated.
+    """
+    query = db.query(Outfit)
+
+    if cursor:
+        try:
+            cursor_dt = datetime.fromisoformat(cursor.replace(" ", "+"))
+        except ValueError:
+            raise HTTPException(status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid cursor.")
+        query = query.filter(Outfit.created_at < cursor_dt)
+
+    outfits = query.order_by(Outfit.created_at.desc()).limit(limit + 1).all()
+
+    next_cursor = None
+    if len(outfits) > limit:
+        outfits = outfits[:limit]
+        next_cursor = outfits[-1].created_at.isoformat()
+
+    return outfits, next_cursor

--- a/services/api/app/routers/boards.py
+++ b/services/api/app/routers/boards.py
@@ -20,11 +20,10 @@ from app.models.user import User
 from app.schemas.board import (
     BoardMemberOut,
     BoardOut,
-    BoardOutfitPage,
     CreateBoardRequest,
     PinRequest,
 )
-from app.schemas.outfit import OutfitOut
+from app.schemas.outfit import BoardOutfitOut, BoardOutfitPage, FeedAuthor, OutfitOut
 
 router = APIRouter(prefix="/boards", tags=["boards"])
 
@@ -235,14 +234,35 @@ def get_outfits(
     """
     Outfits on a board — pinned first, then newest-added.
     Members only. Cursor-paginated.
+
+    Each outfit includes an `author` field with the uploader's id, username,
+    and profile_image_url (matches the FeedOutfitOut shape).
     """
     _board_or_404(db, board_id)
     _require_member(db, board_id, current_user.id)
     outfits, next_cursor = board_crud.get_board_outfits(db, board_id, cursor, limit)
-    return BoardOutfitPage(
-        outfits=[OutfitOut.model_validate(o) for o in outfits],
-        next_cursor=next_cursor,
-    )
+
+    # Build author cache to avoid N+1 queries
+    author_cache: dict[str, FeedAuthor] = {}
+    items: list[BoardOutfitOut] = []
+
+    for outfit in outfits:
+        cache_key = str(outfit.user_id)
+        if cache_key not in author_cache:
+            author = user_crud.get_by_id(db, outfit.user_id)
+            author_cache[cache_key] = FeedAuthor(
+                id=outfit.user_id,
+                username=author.username if author else None,
+                profile_image_url=author.profile_image_url if author else None,
+            )
+        items.append(
+            BoardOutfitOut(
+                **OutfitOut.model_validate(outfit).model_dump(),
+                author=author_cache[cache_key],
+            )
+        )
+
+    return BoardOutfitPage(outfits=items, next_cursor=next_cursor)
 
 
 @router.delete("/{board_id}/outfits/{outfit_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/services/api/app/routers/outfits.py
+++ b/services/api/app/routers/outfits.py
@@ -12,8 +12,18 @@ from app.crud import social as social_crud
 from app.crud import user as user_crud
 from app.dependencies import get_current_user, get_db, get_optional_user
 from app.models.user import User
-from app.schemas.outfit import FeedAuthor, FeedOutfitOut, FeedPage, OutfitMetadata, OutfitOut, VaultPage
-from app.schemas.outfit import CaptionSuggestionsOut, OutfitDetailOut, OutfitMetadata, OutfitOGOut, OutfitOut, OutfitOwner, VaultPage
+from app.schemas.outfit import (
+    CaptionSuggestionsOut,
+    FeedAuthor,
+    FeedOutfitOut,
+    FeedPage,
+    OutfitDetailOut,
+    OutfitMetadata,
+    OutfitOGOut,
+    OutfitOut,
+    OutfitOwner,
+    VaultPage,
+)
 from app.schemas.social import (
     CommentOut,
     CommentPage,
@@ -109,6 +119,42 @@ def get_feed(
                 profile_image_url=author.profile_image_url if author else None,
             )
 
+        feed_items.append(
+            FeedOutfitOut(
+                **OutfitOut.model_validate(outfit).model_dump(),
+                author=author_cache[cache_key],
+            )
+        )
+
+    return FeedPage(outfits=feed_items, next_cursor=next_cursor)
+
+
+@router.get("/explore", response_model=FeedPage)
+def get_explore(
+    cursor: str | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=50),
+    db: Session = Depends(get_db),
+) -> FeedPage:
+    """
+    All outfits on the platform, newest first. No auth required.
+
+    Returns the same FeedPage shape as /outfits/feed so the frontend
+    can swap the call without any schema changes.
+    """
+    outfits, next_cursor = outfit_crud.get_explore(db, cursor, limit)
+
+    author_cache: dict[str, FeedAuthor] = {}
+    feed_items: list[FeedOutfitOut] = []
+
+    for outfit in outfits:
+        cache_key = str(outfit.user_id)
+        if cache_key not in author_cache:
+            author = user_crud.get_by_id(db, outfit.user_id)
+            author_cache[cache_key] = FeedAuthor(
+                id=outfit.user_id,
+                username=author.username if author else None,
+                profile_image_url=author.profile_image_url if author else None,
+            )
         feed_items.append(
             FeedOutfitOut(
                 **OutfitOut.model_validate(outfit).model_dump(),

--- a/services/api/app/schemas/board.py
+++ b/services/api/app/schemas/board.py
@@ -5,7 +5,7 @@ from datetime import date, datetime
 
 from pydantic import BaseModel, Field
 
-from app.schemas.outfit import OutfitOut
+from app.schemas.outfit import BoardOutfitPage, OutfitOut  # noqa: F401 (re-exported)
 
 
 class CreateBoardRequest(BaseModel):
@@ -37,9 +37,8 @@ class BoardMemberOut(BaseModel):
     model_config = {"from_attributes": True}
 
 
-class BoardOutfitPage(BaseModel):
-    outfits: list[OutfitOut]
-    next_cursor: str | None
+# BoardOutfitPage is defined in schemas.outfit (re-exported above) so the
+# boards router can import it from either location.
 
 
 class PinRequest(BaseModel):

--- a/services/api/app/schemas/outfit.py
+++ b/services/api/app/schemas/outfit.py
@@ -85,6 +85,19 @@ class VaultPage(BaseModel):
 class FeedPage(BaseModel):
     outfits: list[FeedOutfitOut]
     next_cursor: str | None
+
+
+# BoardOutfitOut reuses FeedAuthor — the author is the outfit's original creator
+# (outfit.user_id), same pattern as the personal feed.
+class BoardOutfitOut(OutfitOut):
+    author: FeedAuthor
+
+
+class BoardOutfitPage(BaseModel):
+    outfits: list[BoardOutfitOut]
+    next_cursor: str | None
+
+
 class OutfitOwner(BaseModel):
     id: uuid.UUID
     username: str | None


### PR DESCRIPTION
## Summary

Closes #131 and #136.

**#131 — Author on board outfit responses**
- New `BoardOutfitOut` schema (extends `OutfitOut` with `author: FeedAuthor`)
- `GET /boards/{id}/outfits` now returns `author: { id, username, profile_image_url }` for each outfit (same shape as the personal feed)
- Author lookup uses the same N+1 cache pattern as `GET /outfits/feed`
- Frontend: `BoardOutfitResponse` type added to `api-client.ts`; `feed/page.tsx` TODO resolved — board activity cards now show the uploader avatar + username

**#136 — Public explore endpoint**
- `GET /outfits/explore` — all platform outfits, newest first, cursor-paginated, no auth required
- Returns the same `FeedPage` shape as `/outfits/feed` (reuses `FeedOutfitResponse`)
- Frontend: `apiClient.outfits.getExplore()` added; `explore/page.tsx` swapped from `getFeed` to `getExplore`

## Test plan

- [ ] `GET /boards/{id}/outfits` returns `author.username` on each outfit
- [ ] Board activity cards in feed show uploader info
- [ ] `GET /outfits/explore` works without auth token (curl test)
- [ ] `GET /outfits/explore` is cursor-paginated and returns most recent outfits
- [ ] Explore page loads outfits from all users (not just followed)
- [ ] Build: `npm run build` in `apps/web` passes (0 TS errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)