### PR TITLE
feat: design brief compliance — token cleanup, desktop nav, copy, polish

### DIFF
--- a/apps/web/app/boards/[id]/page.tsx
+++ b/apps/web/app/boards/[id]/page.tsx
@@ -48,7 +48,7 @@ function InviteCopy({ code }: { code: string }) {
   }
 
   return (
-    <div className="flex items-center gap-2 rounded-[1.2rem] border border-rose/12 bg-white px-4 py-3">
+    <div className="flex items-center gap-2 rounded-[1.2rem] border border-line bg-white px-4 py-3">
       <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0 text-pink-deep" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
         <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
         <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
@@ -184,9 +184,9 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
         <div className="mx-auto flex min-h-[60vh] max-w-2xl items-center justify-center">
           <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
             <p className="font-display text-5xl text-pink-deep">checkd</p>
-            <h1 className="mt-4 text-3xl text-ink">Board expired</h1>
+            <h1 className="mt-4 text-3xl text-ink">board expired</h1>
             <p className="mt-3 text-sm leading-6 text-ink-soft">This board has passed its event date and is no longer active.</p>
-            <Link href="/boards" className="mt-6 inline-block rounded-[1.2rem] border border-rose/15 bg-white px-5 py-3 text-sm font-semibold text-plum transition hover:border-rose/25">
+            <Link href="/boards" className="mt-6 inline-flex items-center justify-center rounded-[1.2rem] border border-line bg-white px-5 py-3 text-sm font-semibold text-ink-soft transition hover:border-pink-deep/25">
               Back to boards
             </Link>
           </div>
@@ -202,9 +202,9 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
         <div className="mx-auto flex min-h-[60vh] max-w-2xl items-center justify-center">
           <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
             <p className="font-display text-5xl text-pink-deep">checkd</p>
-            <h1 className="mt-4 text-3xl text-ink">Board not found</h1>
+            <h1 className="mt-4 text-3xl text-ink">board not found</h1>
             <p className="mt-3 text-sm leading-6 text-ink-soft">{errorMessage ?? "This board doesn't exist or you're not a member."}</p>
-            <Link href="/boards" className="mt-6 inline-block rounded-[1.2rem] border border-rose/15 bg-white px-5 py-3 text-sm font-semibold text-plum transition hover:border-rose/25">
+            <Link href="/boards" className="mt-6 inline-flex items-center justify-center rounded-[1.2rem] border border-line bg-white px-5 py-3 text-sm font-semibold text-ink-soft transition hover:border-pink-deep/25">
               Back to boards
             </Link>
           </div>
@@ -219,13 +219,13 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
   const expiryLabel = board ? formatExpiry(board.expires_at) : "";
 
   return (
-    <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8">
+    <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8 lg:pb-0 lg:pt-20">
       <div className="mx-auto max-w-3xl">
 
         {/* Top bar */}
         <header className="mb-6 flex items-start justify-between gap-3">
           <div>
-            <Link href="/boards" className="flex items-center gap-1.5 text-sm text-mute transition hover:text-plum">
+            <Link href="/boards" className="flex items-center gap-1.5 text-sm text-mute transition hover:text-ink">
               <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="m15 18-6-6 6-6" />
               </svg>
@@ -252,14 +252,14 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
                   <p className="mt-1 text-sm text-mute">{eventLabel}</p>
                 ) : null}
               </div>
-              <span className="shrink-0 rounded-full border border-rose/15 bg-pink-soft px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.16em] text-pink-deep">
+              <span className="shrink-0 rounded-full border border-line bg-pink-soft px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.16em] text-pink-deep">
                 {expiryLabel}
               </span>
             </div>
 
             {/* Members */}
             {members.length > 0 ? (
-              <div className="mt-4 flex items-center gap-3 border-t border-rose/8 pt-4">
+              <div className="mt-4 flex items-center gap-3 border-t border-line/60 pt-4">
                 <MemberStrip members={members} />
                 <span className="text-[0.72rem] text-mute">
                   {members.length} {members.length === 1 ? "member" : "members"}
@@ -276,7 +276,7 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
             ) : null}
 
             {/* Leave / delete */}
-            <div className="mt-4 flex gap-2 border-t border-rose/8 pt-4">
+            <div className="mt-4 flex gap-2 border-t border-line/60 pt-4">
               {isCreator ? (
                 <Link
                   href="/boards"
@@ -307,10 +307,10 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
         {/* Outfits section */}
         <section>
           <div className="mb-4 flex items-center justify-between">
-            <h2 className="font-display text-xl tracking-[-0.02em] text-ink">Looks</h2>
+            <h2 className="font-display text-xl tracking-[-0.02em] text-ink">looks</h2>
             <Link
-              href={`/upload?board=${id}`}
-              className="inline-flex items-center gap-1.5 rounded-full border border-rose/15 bg-white px-4 py-2 text-[0.78rem] font-semibold text-pink-deep transition hover:border-rose/28"
+              href={`/boards/${id}/upload`}
+              className="inline-flex items-center gap-1.5 rounded-full border border-line bg-white px-4 py-2 text-[0.78rem] font-semibold text-ink transition hover:border-pink-deep"
             >
               <svg viewBox="0 0 24 24" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M12 5v14M5 12h14" />
@@ -327,11 +327,11 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
 
           {status === "ready" && outfits.length === 0 ? (
             <div className="soft-panel px-6 py-10 text-center">
-              <h2 className="text-2xl text-ink">No looks yet</h2>
+              <h2 className="text-2xl text-ink">no looks yet</h2>
               <p className="mt-3 text-sm leading-6 text-ink-soft">Be the first to post an outfit to this board.</p>
               <Link
-                href={`/upload?board=${id}`}
-                className="mt-5 inline-block btn-primary"
+                href={`/boards/${id}/upload`}
+                className="mt-5 btn-primary"
               >
                 Add the first look
               </Link>
@@ -349,7 +349,7 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
                     type="button"
                     onClick={() => void handleLoadMore()}
                     disabled={isLoadingMore}
-                    className="rounded-full border border-rose/12 bg-white px-5 py-3 text-sm font-semibold text-plum transition hover:border-rose/22 disabled:opacity-50"
+                    className="rounded-full border border-line bg-white px-5 py-3 text-sm font-semibold text-ink-soft transition hover:border-pink-deep/25 disabled:opacity-50"
                   >
                     {isLoadingMore ? "Loading…" : "Load more"}
                   </button>

--- a/apps/web/app/boards/[id]/upload/page.tsx
+++ b/apps/web/app/boards/[id]/upload/page.tsx
@@ -1,0 +1,353 @@
+"use client";
+
+import Link from "next/link";
+import { use, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiClient } from "@/lib/api-client";
+import { useAuth } from "@/lib/auth-context";
+
+type Step = 1 | 2;
+type SubmitStatus = "idle" | "uploading" | "error";
+type BoardStatus = "loading" | "ready" | "not-member" | "expired" | "error";
+
+export default function BoardUploadPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const router = useRouter();
+  const { isAuthenticated, isLoading } = useAuth();
+
+  const [boardStatus, setBoardStatus] = useState<BoardStatus>("loading");
+  const [step, setStep] = useState<Step>(1);
+  const [photo, setPhoto] = useState<File | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [caption, setCaption] = useState("");
+  const [submitStatus, setSubmitStatus] = useState<SubmitStatus>("idle");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) router.replace("/login");
+  }, [isAuthenticated, isLoading, router]);
+
+  // Pre-check board membership + expiry before showing upload UI
+  useEffect(() => {
+    if (isLoading || !isAuthenticated) return;
+    let active = true;
+
+    apiClient.boards.get(id).then((result) => {
+      if (!active) return;
+      if (result.ok) {
+        setBoardStatus("ready");
+        return;
+      }
+      if (result.status === 403) { setBoardStatus("not-member"); return; }
+      if (result.status === 410) { setBoardStatus("expired"); return; }
+      setBoardStatus("error");
+    });
+
+    return () => { active = false; };
+  }, [id, isAuthenticated, isLoading]);
+
+  function handleFile(file: File) {
+    setPhoto(file);
+    setPreview(URL.createObjectURL(file));
+  }
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) handleFile(file);
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    const file = e.dataTransfer.files?.[0];
+    if (file && file.type.startsWith("image/")) handleFile(file);
+  }
+
+  async function handlePost() {
+    if (!photo) return;
+    setSubmitStatus("uploading");
+    setErrorMsg(null);
+
+    const createResult = await apiClient.outfits.create({
+      image: photo,
+      metadata: { caption: caption.trim() || undefined, clothing_items: [] },
+    });
+
+    if (!createResult.ok) {
+      setErrorMsg(createResult.message);
+      setSubmitStatus("error");
+      return;
+    }
+
+    const addResult = await apiClient.boards.addOutfit(id, createResult.data.id);
+
+    if (!addResult.ok) {
+      if (addResult.status === 403) { setBoardStatus("not-member"); return; }
+      if (addResult.status === 410) { setBoardStatus("expired"); return; }
+      setErrorMsg(addResult.message);
+      setSubmitStatus("error");
+      return;
+    }
+
+    router.replace(`/boards/${id}`);
+  }
+
+  if (isLoading || !isAuthenticated) return null;
+
+  // ── Error states ──────────────────────────────────────────────────────────────
+
+  if (boardStatus === "loading") {
+    return (
+      <main className="flex min-h-screen items-center justify-center px-4">
+        <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
+          <p className="font-display text-5xl text-pink-deep">checkd</p>
+          <h1 className="mt-4 text-2xl text-ink">loading board…</h1>
+        </div>
+      </main>
+    );
+  }
+
+  if (boardStatus === "not-member") {
+    return (
+      <main className="flex min-h-screen items-center justify-center px-4">
+        <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
+          <p className="font-display text-5xl text-pink-deep">checkd</p>
+          <h1 className="mt-4 text-2xl text-ink">not a member</h1>
+          <p className="mt-3 text-sm leading-6 text-ink-soft">
+            You need to join this board before you can post to it.
+          </p>
+          <Link
+            href="/boards"
+            className="mt-6 inline-flex items-center justify-center rounded-[1.2rem] border border-line bg-white px-5 py-3 text-sm font-semibold text-ink-soft transition hover:border-pink-deep/25"
+          >
+            Back to boards
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  if (boardStatus === "expired") {
+    return (
+      <main className="flex min-h-screen items-center justify-center px-4">
+        <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
+          <p className="font-display text-5xl text-pink-deep">checkd</p>
+          <h1 className="mt-4 text-2xl text-ink">board expired</h1>
+          <p className="mt-3 text-sm leading-6 text-ink-soft">
+            This board has passed its event date and is no longer accepting new posts.
+          </p>
+          <Link
+            href={`/boards/${id}`}
+            className="mt-6 inline-flex items-center justify-center rounded-[1.2rem] border border-line bg-white px-5 py-3 text-sm font-semibold text-ink-soft transition hover:border-pink-deep/25"
+          >
+            View board
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  if (boardStatus === "error") {
+    return (
+      <main className="flex min-h-screen items-center justify-center px-4">
+        <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
+          <p className="font-display text-5xl text-pink-deep">checkd</p>
+          <h1 className="mt-4 text-2xl text-ink">something went wrong</h1>
+          <p className="mt-3 text-sm leading-6 text-ink-soft">
+            Couldn&rsquo;t load this board. Try again.
+          </p>
+          <Link
+            href="/boards"
+            className="mt-6 inline-flex items-center justify-center rounded-[1.2rem] border border-line bg-white px-5 py-3 text-sm font-semibold text-ink-soft transition hover:border-pink-deep/25"
+          >
+            Back to boards
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  // ── Upload flow ───────────────────────────────────────────────────────────────
+
+  return (
+    <main className="flex min-h-screen flex-col bg-paper">
+
+      {/* Topbar */}
+      <div
+        className="flex items-center justify-between border-b border-line bg-paper"
+        style={{ padding: "12px 20px" }}
+      >
+        <Link
+          href={`/boards/${id}`}
+          className="text-sm text-ink-soft transition hover:text-ink"
+        >
+          ‹ back
+        </Link>
+
+        <div className="flex items-center gap-1.5">
+          {([1, 2] as Step[]).map((s) => (
+            <span
+              key={s}
+              className="rounded-full transition-all duration-300"
+              style={{
+                height: 6,
+                width: step === s ? 20 : 6,
+                background: step === s ? "var(--ink)" : "var(--line)",
+              }}
+            />
+          ))}
+        </div>
+
+        <span className="text-[11px] text-mute" style={{ minWidth: 24, textAlign: "right" }}>
+          {step}/2
+        </span>
+      </div>
+
+      {/* Body */}
+      <div className="flex flex-1 flex-col px-5 pb-28 pt-8">
+
+        {/* Step 1: photo + caption */}
+        {step === 1 ? (
+          <>
+            <h1 className="font-display text-[2rem] leading-tight text-ink">add a look</h1>
+            <p className="mt-1 text-sm text-mute">post your outfit to this board.</p>
+
+            <div
+              className="relative mt-6 flex items-center justify-center overflow-hidden rounded-[1.75rem] border-2 border-dashed border-line bg-pink-soft transition hover:border-pink-deep"
+              style={{ aspectRatio: "3/4", cursor: "pointer" }}
+              onClick={() => fileInputRef.current?.click()}
+              onDrop={handleDrop}
+              onDragOver={(e) => e.preventDefault()}
+            >
+              {preview ? (
+                <>
+                  <img src={preview} alt="Preview" className="h-full w-full object-cover" />
+                  <div className="absolute inset-0 flex flex-col items-center justify-center bg-ink/30 opacity-0 transition hover:opacity-100">
+                    <svg viewBox="0 0 24 24" className="h-8 w-8 text-paper" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                      <polyline points="17 8 12 3 7 8" />
+                      <line x1="12" y1="3" x2="12" y2="15" />
+                    </svg>
+                    <span className="mt-2 text-sm font-medium text-paper">change photo</span>
+                  </div>
+                </>
+              ) : (
+                <div className="flex flex-col items-center gap-3 text-center">
+                  <svg viewBox="0 0 24 24" className="h-10 w-10 text-pink-deep" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                    <polyline points="17 8 12 3 7 8" />
+                    <line x1="12" y1="3" x2="12" y2="15" />
+                  </svg>
+                  <div>
+                    <p className="text-sm font-medium text-ink">tap to choose photo</p>
+                    <p className="mt-0.5 text-xs text-mute">or drag and drop</p>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              capture="environment"
+              className="sr-only"
+              onChange={handleFileChange}
+            />
+
+            <div className="mt-5">
+              <label className="field-label" htmlFor="caption">
+                caption <span className="font-normal normal-case tracking-normal text-mute">(optional)</span>
+              </label>
+              <textarea
+                id="caption"
+                value={caption}
+                onChange={(e) => setCaption(e.target.value)}
+                placeholder="what's the vibe?"
+                maxLength={500}
+                rows={3}
+                className="w-full resize-none rounded-2xl border border-line bg-white px-4 py-3 text-sm text-ink outline-none transition focus:border-pink-deep focus:ring-2 focus:ring-pink/40"
+              />
+            </div>
+          </>
+        ) : null}
+
+        {/* Step 2: review */}
+        {step === 2 ? (
+          <>
+            <h1 className="font-display text-[2rem] leading-tight text-ink">looking good.</h1>
+            <p className="mt-1 text-sm text-mute">review before posting to the board.</p>
+
+            <div className="mt-6 overflow-hidden rounded-[1.75rem] border border-line bg-white">
+              {preview ? (
+                <img src={preview} alt="Preview" className="w-full object-cover" style={{ maxHeight: 380 }} />
+              ) : null}
+              {caption ? (
+                <div className="px-5 py-4">
+                  <p className="text-sm text-ink">{caption}</p>
+                </div>
+              ) : (
+                <div className="px-5 py-3">
+                  <p className="text-xs italic text-mute">no caption</p>
+                </div>
+              )}
+            </div>
+
+            {errorMsg ? (
+              <div className="mt-4 rounded-2xl border border-pink-deep/30 bg-pink-soft px-4 py-3 text-sm text-error">
+                {errorMsg}
+              </div>
+            ) : null}
+          </>
+        ) : null}
+      </div>
+
+      {/* Bottom action bar */}
+      <div
+        className="fixed inset-x-0 bottom-0 flex items-center gap-3 border-t border-line bg-paper"
+        style={{ padding: "12px 20px 28px" }}
+      >
+        {step === 1 ? (
+          <>
+            <Link
+              href={`/boards/${id}`}
+              className="flex h-11 w-11 items-center justify-center rounded-full border border-line bg-white text-mute transition hover:border-pink-deep"
+            >
+              <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round">
+                <path d="m15 18-6-6 6-6" />
+              </svg>
+            </Link>
+            <button
+              type="button"
+              disabled={!photo}
+              onClick={() => setStep(2)}
+              className="btn-primary flex-1 disabled:opacity-40"
+            >
+              looks good
+            </button>
+          </>
+        ) : (
+          <>
+            <button
+              type="button"
+              onClick={() => { setSubmitStatus("idle"); setErrorMsg(null); setStep(1); }}
+              className="flex h-11 w-11 items-center justify-center rounded-full border border-line bg-white text-mute transition hover:border-pink-deep"
+            >
+              <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round">
+                <path d="m15 18-6-6 6-6" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              disabled={submitStatus === "uploading"}
+              onClick={() => void handlePost()}
+              className="btn-primary flex-1 disabled:opacity-50"
+            >
+              {submitStatus === "uploading" ? "posting…" : "post to board"}
+            </button>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/boards/join/[code]/page.tsx
+++ b/apps/web/app/boards/join/[code]/page.tsx
@@ -75,7 +75,7 @@ export default function JoinBoardPage({ params }: { params: Promise<{ code: stri
       <main className="flex min-h-screen items-center justify-center px-4">
         <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
           <p className="font-display text-5xl text-pink-deep">checkd</p>
-          <h1 className="mt-4 text-2xl text-ink">Loading invite…</h1>
+          <h1 className="mt-4 text-2xl text-ink">loading invite…</h1>
         </div>
       </main>
     );
@@ -87,13 +87,13 @@ export default function JoinBoardPage({ params }: { params: Promise<{ code: stri
       <main className="flex min-h-screen items-center justify-center px-4">
         <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
           <p className="font-display text-5xl text-pink-deep">checkd</p>
-          <h1 className="mt-4 text-2xl text-ink">Invite not found</h1>
+          <h1 className="mt-4 text-2xl text-ink">invite not found</h1>
           <p className="mt-3 text-sm leading-6 text-ink-soft">
             This invite link is invalid or the board no longer exists.
           </p>
           <Link
             href="/feed"
-            className="mt-6 inline-block rounded-[1.2rem] border border-rose/15 bg-white px-5 py-3 text-sm font-semibold text-plum transition hover:border-rose/25"
+            className="mt-6 inline-flex items-center justify-center rounded-[1.2rem] border border-line bg-white px-5 py-3 text-sm font-semibold text-ink-soft transition hover:border-pink-deep/25"
           >
             Go to feed
           </Link>
@@ -117,7 +117,7 @@ export default function JoinBoardPage({ params }: { params: Promise<{ code: stri
         <div className="soft-panel overflow-hidden">
           {/* Coloured header */}
           <div className="bg-pink-soft px-6 pt-6 pb-5">
-            <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-rose/15 bg-white/80 text-pink-deep">
+            <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-line bg-white/80 text-pink-deep">
               <svg viewBox="0 0 24 24" className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
                 <rect x="4" y="4" width="6.5" height="6.5" rx="1.4" />
                 <rect x="13.5" y="4" width="6.5" height="6.5" rx="1.4" />
@@ -140,7 +140,7 @@ export default function JoinBoardPage({ params }: { params: Promise<{ code: stri
             ) : null}
 
             <div className="mt-4 flex items-center gap-3">
-              <span className={`rounded-full px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.16em] ${expired ? "bg-rose/8 text-mute" : "bg-pink-soft text-pink-deep"}`}>
+              <span className={`rounded-full px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.16em] ${expired ? "bg-line/40 text-mute" : "bg-pink-soft text-pink-deep"}`}>
                 {expiryLabel}
               </span>
               <span className="text-[0.72rem] text-mute">
@@ -149,13 +149,13 @@ export default function JoinBoardPage({ params }: { params: Promise<{ code: stri
             </div>
 
             {joinError ? (
-              <p className="mt-4 rounded-[1rem] border border-rose/25 bg-pink-soft px-4 py-3 text-sm text-error">{joinError}</p>
+              <p className="mt-4 rounded-[1rem] border border-pink-deep/25 bg-pink-soft px-4 py-3 text-sm text-error">{joinError}</p>
             ) : null}
 
             {/* CTA */}
             <div className="mt-6 space-y-3">
               {expired ? (
-                <p className="rounded-[1.2rem] border border-rose/12 bg-pink-soft px-5 py-3.5 text-center text-sm font-semibold text-error">
+                <p className="rounded-[1.2rem] border border-line bg-pink-soft px-5 py-3.5 text-center text-sm font-semibold text-error">
                   This board has expired
                 </p>
               ) : (
@@ -165,15 +165,15 @@ export default function JoinBoardPage({ params }: { params: Promise<{ code: stri
                   disabled={joining}
                   className="btn-primary w-full"
                 >
-                  {joining ? "Joining…" : isAuthenticated ? "Join board" : "Sign in to join"}
+                  {joining ? "joining…" : isAuthenticated ? "join board" : "sign in to join"}
                 </button>
               )}
 
               <Link
                 href="/feed"
-                className="block rounded-[1.2rem] border border-rose/12 bg-white py-3.5 text-center text-sm font-semibold text-plum transition hover:border-rose/22"
+                className="block rounded-[1.2rem] border border-line bg-white py-3.5 text-center text-sm font-semibold text-ink-soft transition hover:border-pink-deep/25"
               >
-                Maybe later
+                maybe later
               </Link>
             </div>
           </div>

--- a/apps/web/app/boards/page.tsx
+++ b/apps/web/app/boards/page.tsx
@@ -59,11 +59,11 @@ function CreateBoardModal({ onClose, onCreate }: {
     <div className="fixed inset-0 z-50 flex items-end justify-center bg-[rgba(36,21,28,0.38)] px-4 pb-4 sm:items-center sm:pb-0 backdrop-blur-sm">
       <div className="soft-panel w-full max-w-md px-6 py-7">
         <div className="mb-5 flex items-center justify-between">
-          <h2 className="font-display text-2xl tracking-[-0.03em] text-ink">New board</h2>
+          <h2 className="font-display text-2xl tracking-[-0.03em] text-ink">new board</h2>
           <button
             type="button"
             onClick={onClose}
-            className="flex h-8 w-8 items-center justify-center rounded-full border border-rose/12 text-mute transition hover:border-rose/22 hover:text-plum"
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-line text-mute transition hover:border-pink-deep/25 hover:text-ink"
           >
             <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M18 6 6 18M6 6l12 12" />
@@ -104,14 +104,14 @@ function CreateBoardModal({ onClose, onCreate }: {
           </div>
 
           {error ? (
-            <p className="rounded-[1rem] border border-rose/25 bg-pink-soft px-4 py-3 text-sm text-error">{error}</p>
+            <p className="rounded-[1rem] border border-pink-deep/25 bg-pink-soft px-4 py-3 text-sm text-error">{error}</p>
           ) : null}
 
           <div className="flex gap-3 pt-1">
             <button
               type="button"
               onClick={onClose}
-              className="flex-1 rounded-[1.2rem] border border-rose/12 bg-white py-3.5 text-sm font-semibold text-plum transition hover:border-rose/22"
+              className="flex-1 rounded-[1.2rem] border border-line bg-white py-3.5 text-sm font-semibold text-ink-soft transition hover:border-pink-deep/25"
             >
               Cancel
             </button>
@@ -139,11 +139,11 @@ function BoardCard({ board }: { board: Board }) {
   return (
     <Link
       href={`/boards/${board.id}`}
-      className={`group block overflow-hidden rounded-[1.75rem] border bg-white transition hover:-translate-y-0.5 hover:border-rose/22 ${expired ? "border-rose/8 opacity-60" : "border-rose/10"}`}
+      className={`group block overflow-hidden rounded-[1.75rem] border bg-white transition hover:-translate-y-0.5 hover:border-pink-deep/25 ${expired ? "border-line/40 opacity-60" : "border-line"}`}
     >
       <div className="bg-pink-soft px-5 pt-5 pb-4">
         <div className="flex items-start justify-between gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-rose/15 bg-white/80 text-pink-deep">
+          <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-line bg-white/80 text-pink-deep">
             <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
               <rect x="4" y="4" width="6.5" height="6.5" rx="1.4" />
               <rect x="13.5" y="4" width="6.5" height="6.5" rx="1.4" />
@@ -151,7 +151,7 @@ function BoardCard({ board }: { board: Board }) {
               <rect x="13.5" y="13.5" width="6.5" height="6.5" rx="1.4" />
             </svg>
           </div>
-          <span className={`rounded-full px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.16em] ${expired ? "bg-rose/10 text-mute" : "bg-white/80 text-pink-deep"}`}>
+          <span className={`rounded-full px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.16em] ${expired ? "bg-line/40 text-mute" : "bg-white/80 text-pink-deep"}`}>
             {expiryLabel}
           </span>
         </div>
@@ -226,7 +226,7 @@ export default function BoardsPage() {
 
   return (
     <>
-      <main className="pb-28">
+      <main className="pb-28 lg:pb-0 lg:pt-16">
         <div className="mx-auto max-w-3xl">
 
           {/* Topbar — matches design 03.01 */}
@@ -273,14 +273,14 @@ export default function BoardsPage() {
           <div className="px-4 sm:px-5">
 
           {errorMessage ? (
-            <div className="mb-5 rounded-[1.25rem] border border-rose/25 bg-pink-soft px-4 py-3 text-sm text-error">{errorMessage}</div>
+            <div className="mb-5 rounded-[1.25rem] border border-pink-deep/25 bg-pink-soft px-4 py-3 text-sm text-error">{errorMessage}</div>
           ) : null}
 
           {/* Loading skeletons */}
           {status === "loading" ? (
             <div className="grid gap-4 sm:grid-cols-2">
               {[1, 2, 3].map((i) => (
-                <div key={i} className="animate-pulse overflow-hidden rounded-[1.75rem] border border-rose/10 bg-white">
+                <div key={i} className="animate-pulse overflow-hidden rounded-[1.75rem] border border-line bg-white">
                   <div className="h-20 bg-[linear-gradient(120deg,_rgba(255,236,242,0.8),_rgba(255,255,255,0.98))]" />
                   <div className="space-y-2 px-5 py-4">
                     <div className="h-4 w-2/3 rounded-full bg-pink-soft" />
@@ -294,7 +294,7 @@ export default function BoardsPage() {
           {/* Empty state */}
           {status === "ready" && boards.length === 0 ? (
             <section className="soft-panel px-6 py-10 text-center">
-              <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl border border-rose/12 bg-pink-soft text-pink-deep">
+              <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl border border-line bg-pink-soft text-pink-deep">
                 <svg viewBox="0 0 24 24" className="h-7 w-7" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
                   <rect x="4" y="4" width="6.5" height="6.5" rx="1.4" />
                   <rect x="13.5" y="4" width="6.5" height="6.5" rx="1.4" />
@@ -302,7 +302,7 @@ export default function BoardsPage() {
                   <rect x="13.5" y="13.5" width="6.5" height="6.5" rx="1.4" />
                 </svg>
               </div>
-              <h2 className="mt-5 text-3xl text-ink">No boards yet</h2>
+              <h2 className="mt-5 text-3xl text-ink">no boards yet</h2>
               <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-ink-soft">
                 Boards are private spaces for an event — create one and invite your crew to post their looks together.
               </p>

--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -72,12 +72,12 @@ function UserChip({
   const initial = (user.display_name?.trim() || user.username?.trim() || "?").charAt(0).toUpperCase();
 
   return (
-    <div className="flex shrink-0 items-center gap-2 rounded-[1.25rem] border border-rose/10 bg-white px-3 py-2">
+    <div className="flex shrink-0 items-center gap-2 rounded-[1.25rem] border border-line bg-white px-3 py-2">
       {user.profile_image_url ? (
         <img
           src={user.profile_image_url}
           alt={user.username ?? ""}
-          className="h-8 w-8 shrink-0 rounded-full border border-plum/10 object-cover"
+          className="h-8 w-8 shrink-0 rounded-full border border-line object-cover"
         />
       ) : (
         <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-pink-soft text-xs font-semibold text-ink-soft">
@@ -127,7 +127,7 @@ function WhoToFollowRail({
           ? Array.from({ length: 4 }).map((_, i) => (
               <div
                 key={i}
-                className="flex h-12 w-44 shrink-0 animate-pulse items-center gap-2 rounded-[1.25rem] border border-rose/10 bg-pink-soft px-3"
+                className="flex h-12 w-44 shrink-0 animate-pulse items-center gap-2 rounded-[1.25rem] border border-line bg-pink-soft px-3"
               />
             ))
           : users.map((user) => (
@@ -245,7 +245,7 @@ export default function ExplorePage() {
   }
 
   return (
-    <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8">
+    <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8 lg:pb-0 lg:pt-20">
       <div className="mx-auto max-w-3xl">
 
         {/* ── Header ─────────────────────────────────────────────────────── */}
@@ -253,7 +253,7 @@ export default function ExplorePage() {
           <div className="mb-4 flex items-center justify-between gap-3">
             <div>
               <p className="font-display text-[2.2rem] leading-none text-pink-deep">
-            checkd
+                checkd
               </p>
               <p className="mt-1 text-sm text-mute">Explore</p>
             </div>
@@ -303,10 +303,10 @@ export default function ExplorePage() {
               <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-mute">
                 Nothing yet
               </p>
-              <h2 className="mt-3 text-2xl text-ink">Follow some people to see outfits here</h2>
+              <h2 className="mt-3 text-2xl text-ink">follow some people to see outfits here</h2>
               <Link
                 href="/search"
-                className="mt-5 inline-block btn-primary"
+                className="mt-5 btn-primary"
               >
                 Find people to follow
               </Link>
@@ -341,7 +341,7 @@ export default function ExplorePage() {
               <button
                 type="button"
                 onClick={() => router.refresh()}
-                className="mt-4 rounded-full border border-rose/12 bg-white px-4 py-2.5 text-sm font-semibold text-plum transition hover:border-rose/22"
+                className="mt-4 rounded-full border border-line bg-white px-4 py-2.5 text-sm font-semibold text-ink-soft transition hover:border-pink-deep/25"
               >
                 Refresh
               </button>

--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -140,7 +140,7 @@ function BoardActivityCard({
       <OutfitCard outfit={toBoardCardData(outfit)} showAuthor />
       {/* Board name badge */}
       <div className="pointer-events-none absolute left-3 bottom-[4.5rem] right-3">
-        <span className="inline-flex max-w-full items-center gap-1.5 truncate rounded-full border border-plum/10 bg-white/88 px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.14em] text-ink-soft backdrop-blur">
+        <span className="inline-flex max-w-full items-center gap-1.5 truncate rounded-full border border-line bg-white/88 px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.14em] text-ink-soft backdrop-blur">
           <svg viewBox="0 0 24 24" className="h-3 w-3 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <rect x="4" y="4" width="6.5" height="6.5" rx="1.4" />
             <rect x="13.5" y="4" width="6.5" height="6.5" rx="1.4" />
@@ -220,17 +220,17 @@ function VaultFeedTab({ displayName }: { displayName: string }) {
       <section className="soft-panel p-6 sm:p-8">
         <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-mute">Empty feed</p>
         <h2 className="mt-4 max-w-2xl text-4xl leading-tight text-ink sm:text-5xl">
-          Your feed is ready. It just needs people.
+          your feed is ready. it just needs people.
         </h2>
         <p className="mt-4 max-w-2xl text-sm leading-7 text-ink-soft sm:text-base">
           Once you follow people, their outfits will land here newest first. Until then, keep building your own archive.
         </p>
         <div className="mt-6 grid gap-3 sm:grid-cols-2">
           <Link href="/upload" className="btn-primary">
-            Upload your next outfit
+            upload your next outfit
           </Link>
-          <Link href="/vault" className="rounded-[1.2rem] border border-rose/12 bg-white px-5 py-4 text-center text-sm font-semibold text-plum transition hover:border-rose/22">
-            Browse your vault
+          <Link href="/vault" className="rounded-[1.2rem] border border-line bg-white px-5 py-4 text-center text-sm font-semibold text-ink-soft transition hover:border-pink-deep/25">
+            browse your vault
           </Link>
         </div>
       </section>
@@ -370,11 +370,11 @@ function BoardsActivityTab() {
     return (
       <section className="soft-panel p-6 sm:p-8">
         <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-mute">No boards yet</p>
-        <h2 className="mt-4 text-4xl leading-tight text-ink">Join a board to see activity here</h2>
+        <h2 className="mt-4 text-4xl leading-tight text-ink">join a board to see activity here</h2>
         <p className="mt-4 text-sm leading-7 text-ink-soft">
           Boards are where you coordinate looks with friends for events. Get an invite link from someone to join.
         </p>
-        <Link href="/boards" className="mt-6 inline-block btn-primary">
+        <Link href="/boards" className="mt-6 btn-primary">
           Go to boards
         </Link>
       </section>
@@ -401,12 +401,12 @@ function BoardsActivityTab() {
               href={`/boards/${section.board.id}`}
               className="shrink-0 text-[0.72rem] font-semibold text-pink-deep hover:underline"
             >
-              View board →
+              view board →
             </Link>
           </div>
 
           {section.outfits.length === 0 ? (
-            <p className="rounded-2xl border border-rose/10 bg-white/70 px-4 py-5 text-sm text-mute">
+            <p className="rounded-2xl border border-line bg-white/70 px-4 py-5 text-sm text-mute">
               No outfits posted yet.
             </p>
           ) : (
@@ -464,7 +464,7 @@ export default function FeedPage() {
   }
 
   return (
-    <main className="pb-28">
+    <main className="pb-28 lg:pb-0 lg:pt-16">
       <div className="mx-auto max-w-7xl">
 
         {/* ── Topbar ─────────────────────────────────────────────────── */}
@@ -486,33 +486,35 @@ export default function FeedPage() {
 
           <div className="flex items-center" style={{ gap: 6 }}>
             {/* Explore */}
-            <button
-              type="button"
+            <Link
+              href="/explore"
               aria-label="Explore"
-              className="flex items-center justify-center rounded-full border border-line bg-white text-mute"
+              className="flex items-center justify-center rounded-full border border-line bg-white text-mute transition hover:border-pink-deep hover:text-ink"
               style={{ width: 36, height: 36 }}
             >
               <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round">
                 <circle cx="12" cy="12" r="9" /><path d="m14.5 9.5-5 2-2 5 5-2 2-5z" />
               </svg>
-            </button>
+            </Link>
             {/* Search */}
-            <button
-              type="button"
+            <Link
+              href="/search"
               aria-label="Search"
-              className="flex items-center justify-center rounded-full border border-line bg-white text-mute"
+              className="flex items-center justify-center rounded-full border border-line bg-white text-mute transition hover:border-pink-deep hover:text-ink"
               style={{ width: 36, height: 36 }}
             >
               <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round">
                 <circle cx="11" cy="11" r="7" /><path d="m21 21-4.35-4.35" />
               </svg>
-            </button>
-            {/* Bell */}
+            </Link>
+            {/* Bell — notification center coming soon */}
             <button
               type="button"
               aria-label="Notifications"
-              className="flex items-center justify-center rounded-full border border-line bg-white text-mute"
+              title="Notifications coming soon"
+              className="flex items-center justify-center rounded-full border border-line bg-white text-mute opacity-50"
               style={{ width: 36, height: 36 }}
+              disabled
             >
               <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round">
                 <path d="M6.5 10a5.5 5.5 0 1 1 11 0c0 5 2 6 2 6h-15s2-1 2-6" /><path d="M10 19a2 2 0 0 0 4 0" />

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -44,7 +44,20 @@ a {
   h3,
   h4 {
     font-family: var(--font-display), serif;
+    text-wrap: pretty;
   }
+}
+
+/* Focus rings — 1.5px pink-deep, 2px offset */
+:focus-visible {
+  outline: 1.5px solid var(--pink-deep);
+  outline-offset: 2px;
+}
+
+/* Instant press feedback on interactive elements */
+button:active:not(:disabled),
+[role="button"]:active:not(:disabled) {
+  opacity: 0.78;
 }
 
 @layer components {
@@ -95,6 +108,17 @@ a {
   /* Bottom nav dock */
   .mobile-dock {
     @apply flex w-full max-w-sm items-center justify-between rounded-xl border border-line bg-white px-3 py-2;
+  }
+
+  /* Skeleton stripe — 45° diagonal pink stripes over pink-soft */
+  .skeleton-stripe {
+    background: repeating-linear-gradient(
+      45deg,
+      var(--pink-soft) 0px,
+      var(--pink-soft) 12px,
+      #f3dde9 12px,
+      #f3dde9 24px
+    );
   }
 
   /* Primary CTA */

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Instrument_Serif, Inter } from "next/font/google";
 import type { ReactNode } from "react";
 import { AuthProvider } from "@/lib/auth-context";
+import { DesktopNav } from "@/components/chrome/desktop-nav";
 import "./globals.css";
 
 const display = Instrument_Serif({
@@ -30,7 +31,10 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${display.variable} ${sans.variable}`}>
       <body>
-        <AuthProvider>{children}</AuthProvider>
+        <AuthProvider>
+          <DesktopNav />
+          {children}
+        </AuthProvider>
       </body>
     </html>
   );

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { apiClient, type UserSearchResult } from "@/lib/api-client";
 import { useAuth } from "@/lib/auth-context";
 
-const STORAGE_KEY = "ootd_onboarded";
+const STORAGE_KEY = "checkd_onboarded";
 type FollowMap = Record<string, { following: boolean }>;
 
 function getInitial(displayName?: string | null, username?: string | null) {
@@ -46,7 +46,7 @@ function StepWelcome({ onNext }: { onNext: () => void }) {
       <h1 className="mt-8 text-3xl leading-tight text-ink sm:text-4xl">
         your fit diary<br />starts here.
       </h1>
-      <p className="mt-4 max-w-xs text-sm leading-6 text-plum/64">
+      <p className="mt-4 max-w-xs text-sm leading-6 text-ink-soft/70">
         Log every look, revisit your style history, and see how your taste evolves — one outfit at a time.
       </p>
       <button
@@ -79,7 +79,7 @@ function UserSuggestionRow({
         <img
           src={user.profile_image_url}
           alt={user.display_name ?? user.username ?? ""}
-          className="h-11 w-11 shrink-0 rounded-full border border-plum/10 object-cover"
+          className="h-11 w-11 shrink-0 rounded-full border border-line object-cover"
         />
       ) : (
         <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-pink-soft text-sm font-semibold text-ink-soft">
@@ -137,12 +137,12 @@ function StepFollow({
 
   return (
     <div className="w-full">
-      <h2 className="text-2xl text-ink">Find people to follow</h2>
+      <h2 className="text-2xl text-ink">find people to follow</h2>
       <p className="mt-1.5 text-sm text-mute">
         See what the community is wearing. You can always find more later.
       </p>
 
-      <div className="mt-5 divide-y divide-rose/6">
+      <div className="mt-5 divide-y divide-line/40">
         {loading
           ? Array.from({ length: 5 }).map((_, i) => (
               <div key={i} className="flex items-center gap-3 py-3">
@@ -182,7 +182,7 @@ function StepUpload({ onDone }: { onDone: () => void }) {
   return (
     <div className="flex flex-col items-center text-center">
       {/* Decorative outfit frame */}
-      <div className="flex h-36 w-28 items-center justify-center rounded-[1.75rem] border-2 border-dashed border-rose/25 bg-pink-soft">
+      <div className="flex h-36 w-28 items-center justify-center rounded-[1.75rem] border-2 border-dashed border-pink-deep/25 bg-pink-soft">
         <svg viewBox="0 0 24 24" className="h-10 w-10 text-pink-deep" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
           <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
           <polyline points="17 8 12 3 7 8" />
@@ -193,7 +193,7 @@ function StepUpload({ onDone }: { onDone: () => void }) {
       <h2 className="mt-7 text-2xl leading-tight text-ink sm:text-3xl">
         Upload your first fit
       </h2>
-      <p className="mt-3 max-w-xs text-sm leading-6 text-plum/64">
+      <p className="mt-3 max-w-xs text-sm leading-6 text-ink-soft/70">
         Drop your outfit photo and get an instant vibe check — our AI will tag your style and kick off your archive.
       </p>
 
@@ -207,7 +207,7 @@ function StepUpload({ onDone }: { onDone: () => void }) {
       <button
         type="button"
         onClick={onDone}
-        className="mt-3 text-sm text-mute transition hover:text-plum"
+        className="mt-3 text-sm text-mute transition hover:text-ink"
       >
         Maybe later
       </button>
@@ -279,7 +279,7 @@ export default function OnboardingPage() {
         <button
           type="button"
           onClick={skip}
-          className="text-[0.8rem] text-plum/46 transition hover:text-plum"
+          className="text-[0.8rem] text-mute/60 transition hover:text-ink"
         >
           Skip
         </button>

--- a/apps/web/app/profile/[username]/page.tsx
+++ b/apps/web/app/profile/[username]/page.tsx
@@ -166,13 +166,13 @@ export default function PublicProfilePage({
         <div className="mx-auto flex min-h-[60vh] max-w-2xl items-center justify-center">
           <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
             <p className="font-display text-5xl text-pink-deep">checkd</p>
-            <h1 className="mt-4 text-3xl text-ink">Profile not found</h1>
+            <h1 className="mt-4 text-3xl text-ink">profile not found</h1>
             <p className="mt-3 text-sm leading-6 text-ink-soft">
               @{username} doesn&apos;t exist or may have changed their username.
             </p>
             <Link
               href="/feed"
-              className="mt-6 inline-block rounded-[1.2rem] border border-rose/15 bg-white px-5 py-3 text-sm font-semibold text-plum transition hover:border-rose/25"
+              className="mt-6 inline-flex items-center justify-center rounded-[1.2rem] border border-line bg-white px-5 py-3 text-sm font-semibold text-ink-soft transition hover:border-pink-deep/25"
             >
               Back to feed
             </Link>
@@ -188,7 +188,7 @@ export default function PublicProfilePage({
   const avatarSrc = profile?.profile_image_url;
 
   return (
-    <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8">
+    <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8 lg:pb-0 lg:pt-20">
       <div className="mx-auto max-w-3xl">
 
         {/* ── Top bar ────────────────────────────────────────────────────── */}
@@ -197,7 +197,7 @@ export default function PublicProfilePage({
             <button
               type="button"
               onClick={() => router.back()}
-              className="flex items-center gap-2 text-sm text-mute transition hover:text-plum"
+              className="flex items-center gap-2 text-sm text-mute transition hover:text-ink"
             >
               <svg
                 aria-hidden="true"
@@ -265,7 +265,7 @@ export default function PublicProfilePage({
                 ) : (
                   <Link
                     href="/login"
-                    className="mt-4 inline-block rounded-full bg-ink px-5 py-2 text-sm font-medium lowercase text-paper transition hover:opacity-90"
+                    className="mt-4 inline-flex items-center justify-center rounded-full bg-ink px-5 py-2 text-sm font-medium lowercase text-paper transition hover:opacity-90"
                   >
                     follow
                   </Link>
@@ -274,11 +274,11 @@ export default function PublicProfilePage({
             </div>
 
             {/* Stats row */}
-            <div className="mt-6 flex items-center justify-around border-t border-rose/8 pt-5">
+            <div className="mt-6 flex items-center justify-around border-t border-line/50 pt-5">
               <StatPill value={outfits.length} label="Outfits" />
-              <div className="h-8 w-px bg-rose/10" />
+              <div className="h-8 w-px bg-line/50" />
               <StatPill value={followerCount} label="Followers" />
-              <div className="h-8 w-px bg-rose/10" />
+              <div className="h-8 w-px bg-line/50" />
               <StatPill value={profile?.following_count ?? 0} label="Following" />
             </div>
           </section>
@@ -300,7 +300,7 @@ export default function PublicProfilePage({
 
           {status === "ready" && outfits.length === 0 ? (
             <div className="soft-panel px-6 py-10 text-center">
-              <h2 className="text-2xl text-ink">No looks yet</h2>
+              <h2 className="text-2xl text-ink">no looks yet</h2>
               <p className="mt-3 text-sm leading-6 text-ink-soft">
                 @{username} hasn&apos;t uploaded any outfits yet.
               </p>
@@ -326,7 +326,7 @@ export default function PublicProfilePage({
                     type="button"
                     onClick={() => void handleLoadMore()}
                     disabled={isLoadingMore}
-                    className="rounded-full border border-rose/12 bg-white px-5 py-3 text-sm font-semibold text-plum transition hover:border-rose/22 disabled:cursor-not-allowed disabled:opacity-50"
+                    className="rounded-full border border-line bg-white px-5 py-3 text-sm font-semibold text-ink-soft transition hover:border-pink-deep/25 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {isLoadingMore ? "Loading more..." : "Load more looks"}
                   </button>

--- a/apps/web/app/profile/edit/page.tsx
+++ b/apps/web/app/profile/edit/page.tsx
@@ -249,7 +249,7 @@ export default function EditProfilePage() {
   const isSaving = saveStatus === "saving";
 
   return (
-    <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8">
+    <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8 lg:pb-0 lg:pt-20">
       <div className="mx-auto max-w-lg">
 
         {/* ── Top bar ─────────────────────────────────────────────────────── */}
@@ -272,7 +272,7 @@ export default function EditProfilePage() {
 
         {/* ── Title ───────────────────────────────────────────────────────── */}
         <div className="mb-6">
-          <h1 className="font-display text-3xl tracking-[-0.03em] text-ink">Edit profile</h1>
+          <h1 className="font-display text-3xl tracking-[-0.03em] text-ink">edit profile</h1>
           <p className="mt-1 text-sm text-mute">Changes are visible on your public profile</p>
         </div>
 
@@ -307,7 +307,7 @@ export default function EditProfilePage() {
                 placeholder="Your name"
                 maxLength={60}
                 disabled={isSaving}
-                className="mt-2 w-full rounded-2xl border border-rose/12 bg-white/70 px-4 py-3 text-sm text-ink placeholder-plum/35 outline-none transition focus:border-[#ef5f8a]/40 focus:ring-2 focus:ring-[#ef5f8a]/12 disabled:opacity-50"
+                className="mt-2 w-full rounded-2xl border border-line bg-white/70 px-4 py-3 text-sm text-ink placeholder:text-mute/40 outline-none transition focus:border-pink-deep/40 focus:ring-2 focus:ring-pink-deep/12 disabled:opacity-50"
               />
               {fieldErrors.display_name ? (
                 <p className="mt-1.5 text-xs text-error">{fieldErrors.display_name}</p>
@@ -334,10 +334,10 @@ export default function EditProfilePage() {
                   placeholder="yourhandle"
                   maxLength={30}
                   disabled={isSaving}
-                  className="w-full rounded-2xl border border-rose/12 bg-white/70 py-3 pl-8 pr-4 text-sm text-ink placeholder-plum/35 outline-none transition focus:border-[#ef5f8a]/40 focus:ring-2 focus:ring-[#ef5f8a]/12 disabled:opacity-50"
+                  className="w-full rounded-2xl border border-line bg-white/70 py-3 pl-8 pr-4 text-sm text-ink placeholder:text-mute/40 outline-none transition focus:border-pink-deep/40 focus:ring-2 focus:ring-pink-deep/12 disabled:opacity-50"
                 />
                 {usernameStatus === "checking" ? (
-                  <svg className="absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-plum/35" viewBox="0 0 24 24" fill="none">
+                  <svg className="absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-mute/40" viewBox="0 0 24 24" fill="none">
                     <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" />
                     <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
                   </svg>
@@ -370,7 +370,7 @@ export default function EditProfilePage() {
                 placeholder="A little about your style…"
                 rows={3}
                 disabled={isSaving}
-                className="mt-2 w-full resize-none rounded-2xl border border-rose/12 bg-white/70 px-4 py-3 text-sm text-ink placeholder-plum/35 outline-none transition focus:border-[#ef5f8a]/40 focus:ring-2 focus:ring-[#ef5f8a]/12 disabled:opacity-50"
+                className="mt-2 w-full resize-none rounded-2xl border border-line bg-white/70 px-4 py-3 text-sm text-ink placeholder:text-mute/40 outline-none transition focus:border-pink-deep/40 focus:ring-2 focus:ring-pink-deep/12 disabled:opacity-50"
               />
               {fieldErrors.bio ? (
                 <p className="mt-1.5 text-xs text-error">{fieldErrors.bio}</p>
@@ -380,7 +380,7 @@ export default function EditProfilePage() {
 
           {/* ── Error banner ──────────────────────────────────────────────── */}
           {saveError ? (
-            <div className="mb-4 rounded-[1.25rem] border border-rose/25 bg-pink-soft px-4 py-3 text-sm text-error">
+            <div className="mb-4 rounded-[1.25rem] border border-pink-deep/25 bg-pink-soft px-4 py-3 text-sm text-error">
               {saveError}
             </div>
           ) : null}
@@ -399,7 +399,7 @@ export default function EditProfilePage() {
               type="button"
               onClick={() => router.back()}
               disabled={isSaving}
-              className="w-full rounded-[1.5rem] border border-plum/12 bg-white/80 px-5 py-4 text-sm font-semibold text-plum transition hover:bg-white disabled:opacity-50"
+              className="w-full rounded-[1.5rem] border border-line bg-white/80 px-5 py-4 text-sm font-semibold text-ink-soft transition hover:bg-white disabled:opacity-50"
             >
               Cancel
             </button>

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -9,6 +9,7 @@ import { OutfitCard, OutfitCardSkeleton, type OutfitCardData } from "@/component
 import { useAuth } from "@/lib/auth-context";
 
 type PageStatus = "idle" | "loading" | "ready" | "error";
+type ProfileTab = "fits" | "tagged" | "saved" | "about";
 
 function toCardData(outfit: OutfitResponse): OutfitCardData {
   return {
@@ -40,6 +41,8 @@ export default function ProfilePage() {
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<ProfileTab>("fits");
+  const [shareCopied, setShareCopied] = useState(false);
 
   // Redirect if not authed
   useEffect(() => {
@@ -124,8 +127,15 @@ export default function ProfilePage() {
   const followerCount = profile?.follower_count ?? 0;
   const followingCount = profile?.following_count ?? 0;
 
+  async function handleShare() {
+    const url = `${window.location.origin}/profile/${username}`;
+    await navigator.clipboard.writeText(url);
+    setShareCopied(true);
+    setTimeout(() => setShareCopied(false), 2000);
+  }
+
   return (
-    <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8">
+    <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8 lg:pb-0 lg:pt-20">
       <div className="mx-auto max-w-3xl">
 
         {/* ── Top bar — @username + ⋯ per design ─────────────────────────── */}
@@ -238,93 +248,181 @@ export default function ProfilePage() {
             </Link>
             <button
               type="button"
+              onClick={() => void handleShare()}
               className="flex flex-1 items-center justify-center rounded-full border border-line text-ink transition hover:border-ink"
               style={{ height: 36, fontSize: 12 }}
             >
-              share
+              {shareCopied ? "copied!" : "share"}
             </button>
-            <button
-              type="button"
+            <Link
+              href="/wrapped"
               className="flex flex-1 items-center justify-center rounded-full border border-line text-ink transition hover:border-ink"
               style={{ height: 36, fontSize: 12 }}
             >
               wrapped ✦
-            </button>
+            </Link>
           </div>
         </section>
 
         {/* ── Profile tabs ─────────────────────────────────────────────── */}
         <div className="flex border-b border-line">
-          {["fits", "tagged", "saved", "about"].map((tab, i) => (
-            <button
-              key={tab}
-              type="button"
-              className={`flex-1 py-[11px] text-center text-[12px] font-medium transition ${i === 0 ? "border-b-[1.5px] border-ink text-ink" : "text-mute hover:text-ink"}`}
-              style={{ marginBottom: i === 0 ? -1 : 0 }}
-            >
-              {tab}
-            </button>
-          ))}
+          {(["fits", "tagged", "saved", "about"] as ProfileTab[]).map((tab) => {
+            const isActive = activeTab === tab;
+            return (
+              <button
+                key={tab}
+                type="button"
+                onClick={() => setActiveTab(tab)}
+                className={`flex-1 py-[11px] text-center text-[12px] font-medium transition ${isActive ? "border-b-[1.5px] border-ink text-ink" : "text-mute hover:text-ink"}`}
+                style={{ marginBottom: isActive ? -1 : 0 }}
+              >
+                {tab}
+              </button>
+            );
+          })}
         </div>
 
         {/* ── Error state ─────────────────────────────────────────────────── */}
         {errorMessage ? (
-          <div className="mb-5 rounded-[1.25rem] border border-rose/25 bg-pink-soft px-4 py-3 text-sm text-error">
+          <div className="mb-5 rounded-[1.25rem] border border-pink-deep/30 bg-pink-soft px-4 py-3 text-sm text-error">
             {errorMessage}
           </div>
         ) : null}
 
-        {/* ── Outfit grid — 3-col, 2px gap, matches design vault-grid ─────── */}
-        <section>
-          {status === "loading" ? (
-            <div className="grid grid-cols-3 gap-0.5 pt-0.5">
-              {Array.from({ length: 9 }).map((_, i) => (
-                <OutfitCardSkeleton key={i} showAuthor={false} />
-              ))}
-            </div>
-          ) : null}
-
-          {status === "ready" && outfits.length === 0 ? (
-            <div className="px-6 py-10 text-center">
-              <p className="font-display text-2xl text-ink">start your archive</p>
-              <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-ink-soft">
-                upload your first outfit and it will live here.
-              </p>
-              <Link href="/upload" className="mt-6 inline-block btn-primary">
-                upload your first look
-              </Link>
-            </div>
-          ) : null}
-
-          {status === "ready" && outfits.length > 0 ? (
-            <>
+        {/* ── Tab: fits ───────────────────────────────────────────────────── */}
+        {activeTab === "fits" ? (
+          <section>
+            {status === "loading" ? (
               <div className="grid grid-cols-3 gap-0.5 pt-0.5">
-                {outfits.map((outfit) => (
-                  <OutfitCard
-                    key={outfit.id}
-                    outfit={toCardData(outfit)}
-                    showAuthor={false}
-                    showCaption={false}
-                    showAccentMarker
-                  />
+                {Array.from({ length: 9 }).map((_, i) => (
+                  <OutfitCardSkeleton key={i} showAuthor={false} />
                 ))}
               </div>
+            ) : null}
 
-              {nextCursor ? (
-                <div className="mt-8 flex justify-center">
-                  <button
-                    type="button"
-                    onClick={() => void handleLoadMore()}
-                    disabled={isLoadingMore}
-                    className="rounded-full border border-line bg-white px-5 py-3 text-sm font-medium text-ink-soft transition hover:border-pink-deep disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    {isLoadingMore ? "loading..." : "load more"}
-                  </button>
+            {status === "ready" && outfits.length === 0 ? (
+              <div className="px-6 py-10 text-center">
+                <p className="font-display text-2xl text-ink">start your archive</p>
+                <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-ink-soft">
+                  upload your first outfit and it will live here.
+                </p>
+                <Link href="/upload" className="mt-6 btn-primary">
+                  upload your first look
+                </Link>
+              </div>
+            ) : null}
+
+            {status === "ready" && outfits.length > 0 ? (
+              <>
+                <div className="grid grid-cols-3 gap-0.5 pt-0.5">
+                  {outfits.map((outfit) => (
+                    <OutfitCard
+                      key={outfit.id}
+                      outfit={toCardData(outfit)}
+                      showAuthor={false}
+                      showCaption={false}
+                      showAccentMarker
+                    />
+                  ))}
                 </div>
-              ) : null}
-            </>
-          ) : null}
-        </section>
+
+                {nextCursor ? (
+                  <div className="mt-8 flex justify-center">
+                    <button
+                      type="button"
+                      onClick={() => void handleLoadMore()}
+                      disabled={isLoadingMore}
+                      className="rounded-full border border-line bg-white px-5 py-3 text-sm font-medium text-ink-soft transition hover:border-pink-deep disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {isLoadingMore ? "loading..." : "load more"}
+                    </button>
+                  </div>
+                ) : null}
+              </>
+            ) : null}
+          </section>
+        ) : null}
+
+        {/* ── Tab: tagged ─────────────────────────────────────────────────── */}
+        {activeTab === "tagged" ? (
+          <div className="px-6 py-12 text-center">
+            <div
+              className="mx-auto flex items-center justify-center rounded-2xl bg-pink-soft"
+              style={{ width: 56, height: 56 }}
+            >
+              <svg viewBox="0 0 24 24" className="h-6 w-6 text-pink-deep" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" />
+                <line x1="7" y1="7" x2="7.01" y2="7" />
+              </svg>
+            </div>
+            <p className="font-display mt-5 text-2xl text-ink">tagged looks</p>
+            <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-ink-soft">
+              when friends tag you in their outfits, they&apos;ll show up here.
+            </p>
+          </div>
+        ) : null}
+
+        {/* ── Tab: saved ──────────────────────────────────────────────────── */}
+        {activeTab === "saved" ? (
+          <div className="px-6 py-12 text-center">
+            <div
+              className="mx-auto flex items-center justify-center rounded-2xl bg-pink-soft"
+              style={{ width: 56, height: 56 }}
+            >
+              <svg viewBox="0 0 24 24" className="h-6 w-6 text-pink-deep" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+              </svg>
+            </div>
+            <p className="font-display mt-5 text-2xl text-ink">saved looks</p>
+            <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-ink-soft">
+              outfits you&apos;ve liked will live here for easy reference.
+            </p>
+          </div>
+        ) : null}
+
+        {/* ── Tab: about ──────────────────────────────────────────────────── */}
+        {activeTab === "about" ? (
+          <div className="px-5 py-6 space-y-4">
+            {/* Bio */}
+            <div className="rounded-2xl border border-line bg-white px-5 py-4">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-mute">bio</p>
+              {bio ? (
+                <p className="mt-2 text-sm leading-6 text-ink">{bio}</p>
+              ) : (
+                <Link href="/profile/edit" className="mt-2 inline-block text-sm text-pink-deep hover:underline">
+                  add a bio →
+                </Link>
+              )}
+            </div>
+
+            {/* Stats */}
+            <div className="rounded-2xl border border-line bg-white px-5 py-4">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-mute">stats</p>
+              <div className="mt-3 grid grid-cols-3 divide-x divide-line">
+                {[
+                  { label: "fits", value: outfits.length + (nextCursor ? "+" : "") },
+                  { label: "followers", value: followerCount },
+                  { label: "following", value: followingCount },
+                ].map(({ label, value }) => (
+                  <div key={label} className="px-3 text-center first:pl-0 last:pr-0">
+                    <div className="text-lg font-medium text-ink">{value}</div>
+                    <div className="text-[10px] uppercase tracking-[0.16em] text-mute">{label}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Member since */}
+            {profile?.created_at ? (
+              <div className="rounded-2xl border border-line bg-white px-5 py-4">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-mute">member since</p>
+                <p className="mt-2 text-sm text-ink">
+                  {new Intl.DateTimeFormat("en-US", { month: "long", year: "numeric" }).format(new Date(profile.created_at))}
+                </p>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
       </div>
 
       <MobileNav active="me" />

--- a/apps/web/app/search/page.tsx
+++ b/apps/web/app/search/page.tsx
@@ -36,10 +36,10 @@ function UserRow({
         <img
           src={user.profile_image_url}
           alt={user.display_name ?? user.username ?? ""}
-          className="h-11 w-11 shrink-0 rounded-full border border-plum/10 object-cover"
+          className="h-11 w-11 shrink-0 rounded-full border border-line object-cover"
         />
       ) : (
-        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-plum/12 bg-pink-soft text-sm font-semibold text-ink-soft">
+        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-line bg-pink-soft text-sm font-semibold text-ink-soft">
           {getInitial(user.display_name, user.username)}
         </div>
       )}
@@ -205,7 +205,7 @@ export default function SearchPage() {
   const displayList = isSearching ? searchResults : suggested;
 
   return (
-    <main className="px-4 pb-28 pt-6 sm:px-6">
+    <main className="px-4 pb-28 pt-6 sm:px-6 lg:pb-0 lg:pt-20">
       <div className="mx-auto max-w-lg">
 
         {/* ── Header ─────────────────────────────────────────────────────── */}
@@ -233,7 +233,7 @@ export default function SearchPage() {
         ) : null}
 
         {/* ── Results ────────────────────────────────────────────────────── */}
-        <section className="soft-panel divide-y divide-rose/6 px-5">
+        <section className="soft-panel divide-y divide-line/40 px-5">
           {/* Searching skeleton */}
           {isSearching && searchStatus === "searching" ? (
             <>

--- a/apps/web/app/vault/page.tsx
+++ b/apps/web/app/vault/page.tsx
@@ -16,6 +16,28 @@ const INITIAL_PAGE_SIZE = 12;
 
 type VaultStatus = "idle" | "loading" | "ready" | "error";
 type LikeMap = Record<string, { liked: boolean; count: number }>;
+type FilterChip = "all" | "brown" | "formal" | "streetwear";
+
+function matchesFilter(outfit: OutfitResponse, filter: FilterChip): boolean {
+  if (filter === "all") return true;
+  const items = outfit.clothing_items ?? [];
+  if (filter === "brown") {
+    return items.some((i) => i.color?.toLowerCase().includes("brown"));
+  }
+  if (filter === "formal") {
+    return (
+      items.some((i) => i.category?.toLowerCase().includes("formal")) ||
+      outfit.vibe_check_tone?.toLowerCase().includes("formal") === true
+    );
+  }
+  if (filter === "streetwear") {
+    return (
+      items.some((i) => i.category?.toLowerCase().includes("streetwear")) ||
+      outfit.vibe_check_tone?.toLowerCase().includes("streetwear") === true
+    );
+  }
+  return true;
+}
 
 function toCardData(outfit: OutfitResponse): OutfitCardData {
   return {
@@ -55,6 +77,7 @@ export default function VaultPage() {
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [loadingMore, setLoadingMore] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [activeFilter, setActiveFilter] = useState<FilterChip>("all");
 
   // Like state
   const [likes, setLikes] = useState<LikeMap>({});
@@ -173,7 +196,7 @@ export default function VaultPage() {
   const displayName = user?.display_name ?? user?.username ?? "you";
 
   return (
-    <main className="pb-28">
+    <main className="pb-28 lg:pb-0 lg:pt-16">
       <div className="mx-auto max-w-7xl">
         {/* vault topbar — checkd wordmark (ink 30px) + search + filter */}
         <div
@@ -187,26 +210,16 @@ export default function VaultPage() {
             checkd
           </p>
           <div className="flex items-center" style={{ gap: 6 }}>
-            <button
-              type="button"
+            <Link
+              href="/search"
               aria-label="Search"
-              className="flex items-center justify-center rounded-full border border-line bg-white text-mute"
+              className="flex items-center justify-center rounded-full border border-line bg-white text-mute transition hover:border-pink-deep hover:text-ink"
               style={{ width: 36, height: 36 }}
             >
               <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round">
                 <circle cx="11" cy="11" r="7" /><path d="m21 21-4.35-4.35" />
               </svg>
-            </button>
-            <button
-              type="button"
-              aria-label="Filter"
-              className="flex items-center justify-center rounded-full border border-line bg-white text-mute"
-              style={{ width: 36, height: 36 }}
-            >
-              <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round">
-                <path d="M3 6h18M6 12h12M10 18h4" />
-              </svg>
-            </button>
+            </Link>
           </div>
         </div>
 
@@ -225,20 +238,25 @@ export default function VaultPage() {
           className="flex overflow-x-auto"
           style={{ padding: "4px 20px 12px", gap: 8 }}
         >
-          {["all", "brown", "formal", "streetwear"].map((chip, i) => (
-            <span
-              key={chip}
-              className="flex-shrink-0 inline-flex items-center rounded-full border text-[11px]"
-              style={{
-                padding: "5px 11px",
-                background: i === 0 ? "var(--ink)" : "#fff",
-                borderColor: i === 0 ? "var(--ink)" : "var(--line)",
-                color: i === 0 ? "var(--paper)" : "var(--ink-soft)",
-              }}
-            >
-              {chip}
-            </span>
-          ))}
+          {(["all", "brown", "formal", "streetwear"] as FilterChip[]).map((chip) => {
+            const isActive = activeFilter === chip;
+            return (
+              <button
+                key={chip}
+                type="button"
+                onClick={() => setActiveFilter(chip)}
+                className="flex-shrink-0 inline-flex items-center rounded-full border text-[11px] transition"
+                style={{
+                  padding: "5px 11px",
+                  background: isActive ? "var(--ink)" : "#fff",
+                  borderColor: isActive ? "var(--ink)" : "var(--line)",
+                  color: isActive ? "var(--paper)" : "var(--ink-soft)",
+                }}
+              >
+                {chip}
+              </button>
+            );
+          })}
         </div>
 
         {/* ── Vault grid — 3-col, 2px gap, per design vault-grid ─────── */}
@@ -250,10 +268,32 @@ export default function VaultPage() {
           ) : null}
 
           {vaultStatus === "loading" ? (
-            <div className="grid grid-cols-3 gap-0.5 pt-0.5">
+            <div className="grid grid-cols-3 gap-0.5 pt-0.5 lg:gap-1">
               {Array.from({ length: 9 }).map((_, i) => <OutfitCardSkeleton key={i} showAuthor={false} />)}
             </div>
           ) : null}
+
+          {(() => {
+            const filtered = outfits.filter((o) => matchesFilter(o, activeFilter));
+            if (vaultStatus === "ready" && outfits.length > 0 && filtered.length === 0) {
+              return (
+                <div className="px-5 py-10 text-center">
+                  <p className="font-display text-2xl text-ink">no {activeFilter} looks yet.</p>
+                  <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-ink-soft">
+                    tag clothing items when you upload to use filters.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => setActiveFilter("all")}
+                    className="mt-5 text-sm text-pink-deep hover:underline"
+                  >
+                    show all
+                  </button>
+                </div>
+              );
+            }
+            return null;
+          })()}
 
           {vaultStatus === "ready" && outfits.length === 0 ? (
             <div className="px-5 py-10 text-center">
@@ -261,7 +301,7 @@ export default function VaultPage() {
               <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-ink-soft">
                 it just needs your first look.
               </p>
-              <Link href="/upload" className="mt-6 inline-block btn-primary">
+              <Link href="/upload" className="mt-6 btn-primary">
                 upload your first look
               </Link>
             </div>
@@ -269,8 +309,8 @@ export default function VaultPage() {
 
           {vaultStatus === "ready" && outfits.length > 0 ? (
             <>
-              <div className="grid grid-cols-3 gap-0.5 pt-0.5">
-                {outfits.map((outfit) => (
+              <div className="grid grid-cols-3 gap-0.5 pt-0.5 lg:gap-1">
+                {outfits.filter((o) => matchesFilter(o, activeFilter)).map((outfit) => (
                   <OutfitCard
                     key={outfit.id}
                     outfit={toCardData(outfit)}

--- a/apps/web/components/chrome/desktop-nav.tsx
+++ b/apps/web/components/chrome/desktop-nav.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useAuth } from "@/lib/auth-context";
+
+const AUTH_PATHS = ["/login", "/signup", "/onboarding", "/forgot-password"];
+
+const NAV_LINKS = [
+  { href: "/feed", label: "feed" },
+  { href: "/explore", label: "discover" },
+  { href: "/vault", label: "my vault" },
+  { href: "/boards", label: "boards" },
+];
+
+export function DesktopNav() {
+  const pathname = usePathname();
+  const { user, isAuthenticated } = useAuth();
+
+  if (AUTH_PATHS.some((p) => pathname.startsWith(p)) || pathname === "/") return null;
+
+  return (
+    <nav className="fixed inset-x-0 top-0 z-50 hidden h-16 items-center border-b border-line bg-paper px-8 lg:flex">
+      {/* Left: wordmark + links */}
+      <div className="flex items-center gap-8">
+        <Link
+          href="/feed"
+          className="font-display leading-none text-ink"
+          style={{ fontSize: "2rem", letterSpacing: "-0.01em" }}
+        >
+          checkd
+        </Link>
+        <div className="flex items-center gap-6">
+          {NAV_LINKS.map(({ href, label }) => (
+            <Link
+              key={href}
+              href={href}
+              className={`text-sm transition hover:text-ink ${
+                pathname.startsWith(href) ? "font-medium text-ink" : "text-mute"
+              }`}
+            >
+              {label}
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      {/* Right: search + post CTA + avatar */}
+      <div className="ml-auto flex items-center gap-3">
+        <Link
+          href="/search"
+          className="flex h-9 items-center gap-2 rounded-full bg-pink-soft px-4 text-sm text-mute transition hover:text-ink-soft"
+          style={{ width: 260 }}
+        >
+          <svg
+            viewBox="0 0 24 24"
+            className="h-3.5 w-3.5 shrink-0"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.7"
+            strokeLinecap="round"
+          >
+            <circle cx="11" cy="11" r="7" />
+            <path d="m21 21-4.35-4.35" />
+          </svg>
+          <span>search</span>
+        </Link>
+
+        <Link
+          href="/upload"
+          className="inline-flex h-9 items-center justify-center rounded-full bg-ink px-5 text-[0.8rem] font-medium lowercase text-paper transition hover:opacity-90"
+        >
+          post a fit
+        </Link>
+
+        {isAuthenticated ? (
+          <Link href="/profile" className="shrink-0">
+            {user?.profile_image_url ? (
+              <img
+                src={user.profile_image_url}
+                alt="my profile"
+                className="h-9 w-9 rounded-full border border-line object-cover"
+              />
+            ) : (
+              <div className="flex h-9 w-9 items-center justify-center rounded-full border border-line bg-pink-soft text-sm font-medium text-ink-soft">
+                {(user?.display_name ?? user?.username ?? "?").charAt(0).toUpperCase()}
+              </div>
+            )}
+          </Link>
+        ) : null}
+      </div>
+    </nav>
+  );
+}

--- a/apps/web/components/chrome/mobile-nav.tsx
+++ b/apps/web/components/chrome/mobile-nav.tsx
@@ -115,8 +115,8 @@ function NavItem({
 export function MobileNav({ active }: MobileNavProps) {
   return (
     <nav
-      className="fixed inset-x-0 bottom-0 z-40 flex items-center justify-around border-t border-line bg-paper"
-      style={{ padding: "10px 16px 22px" }}
+      className="fixed inset-x-0 bottom-0 z-40 flex items-center justify-around border-t border-line bg-paper lg:hidden"
+      style={{ padding: "10px 16px max(28px, env(safe-area-inset-bottom))" }}
     >
       <NavItem href="/feed" label="home" active={active === "feed"} icon={<FeedIcon active={active === "feed"} />} />
       <NavItem href="/boards" label="boards" active={active === "boards"} icon={<BoardsIcon active={active === "boards"} />} />

--- a/apps/web/components/outfits/comments-sheet.tsx
+++ b/apps/web/components/outfits/comments-sheet.tsx
@@ -48,10 +48,10 @@ function CommentRow({ comment, isOwn, editing, onStartEdit, onCancelEdit, onSave
         <img
           src={comment.author.profile_image_url}
           alt={comment.author.username ?? ""}
-          className="h-8 w-8 shrink-0 rounded-full border border-plum/10 object-cover"
+          className="h-8 w-8 shrink-0 rounded-full border border-line object-cover"
         />
       ) : (
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-plum/12 bg-pink-soft text-xs font-semibold text-ink-soft">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-line bg-pink-soft text-xs font-semibold text-ink-soft">
           {getInitial(comment.author.display_name ?? comment.author.username)}
         </div>
       )}
@@ -84,7 +84,7 @@ function CommentRow({ comment, isOwn, editing, onStartEdit, onCancelEdit, onSave
               <button
                 type="button"
                 onClick={onCancelEdit}
-                className="rounded-full border border-rose/12 bg-white px-3 py-1 text-xs font-semibold text-plum"
+                className="rounded-full border border-line bg-white px-3 py-1 text-xs font-semibold text-ink-soft"
               >
                 Cancel
               </button>
@@ -203,12 +203,12 @@ export function CommentsSheet({ outfitId, onClose }: CommentsSheetProps) {
       <div className="soft-panel flex w-full max-w-sm flex-col overflow-hidden" style={{ maxHeight: "80vh" }}>
 
         {/* Header */}
-        <div className="flex shrink-0 items-center justify-between border-b border-rose/8 px-6 pb-4 pt-6">
+        <div className="flex shrink-0 items-center justify-between border-b border-line/60 px-6 pb-4 pt-6">
           <h2 className="font-display text-2xl tracking-[-0.03em] text-ink">Comments</h2>
           <button
             type="button"
             onClick={onClose}
-            className="flex h-8 w-8 items-center justify-center rounded-full border border-rose/12 text-mute transition hover:border-rose/22 hover:text-plum"
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-line text-mute transition hover:border-pink-deep/25 hover:text-ink"
           >
             <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
               <path d="M18 6 6 18M6 6l12 12" />
@@ -217,7 +217,7 @@ export function CommentsSheet({ outfitId, onClose }: CommentsSheetProps) {
         </div>
 
         {/* Comment list */}
-        <ul ref={listRef} className="min-h-0 flex-1 overflow-y-auto px-6 divide-y divide-rose/6">
+        <ul ref={listRef} className="min-h-0 flex-1 overflow-y-auto px-6 divide-y divide-line/40">
           {loading ? (
             <li className="flex flex-col gap-3 py-4">
               {Array.from({ length: 3 }).map((_, i) => (
@@ -262,7 +262,7 @@ export function CommentsSheet({ outfitId, onClose }: CommentsSheetProps) {
         {isAuthenticated ? (
           <form
             onSubmit={(e) => void handleSubmit(e)}
-            className="shrink-0 border-t border-rose/8 px-4 py-4"
+            className="shrink-0 border-t border-line/60 px-4 py-4"
           >
             <div className="flex items-end gap-2">
               <textarea
@@ -294,7 +294,7 @@ export function CommentsSheet({ outfitId, onClose }: CommentsSheetProps) {
             </div>
           </form>
         ) : (
-          <p className="shrink-0 border-t border-rose/8 px-6 py-4 text-center text-xs text-mute">
+          <p className="shrink-0 border-t border-line/60 px-6 py-4 text-center text-xs text-mute">
             Log in to leave a comment.
           </p>
         )}

--- a/apps/web/components/outfits/outfit-card.tsx
+++ b/apps/web/components/outfits/outfit-card.tsx
@@ -147,9 +147,9 @@ function getToneClasses(tone?: string | null) {
 
   return (
     TONE_STYLES[normalizedTone] ?? {
-      border: "border-plum/16",
+      border: "border-ink-soft/16",
       background: "bg-white/88",
-      text: "text-plum"
+      text: "text-ink-soft"
     }
   );
 }
@@ -180,6 +180,7 @@ export function OutfitCard({
         <img
           src={outfit.imageUrl}
           alt={outfit.caption?.trim() || "Outfit card photo"}
+          loading="lazy"
           className="aspect-[4/5] w-full object-cover transition duration-300 group-hover:scale-[1.02]"
         />
 
@@ -295,7 +296,7 @@ export function OutfitCardSkeleton({
 }) {
   return (
     <article className="overflow-hidden rounded-xl border border-line bg-white">
-      <div className="aspect-[4/5] w-full animate-pulse bg-pink-soft" />
+      <div className="skeleton-stripe aspect-[4/5] w-full animate-pulse" />
       <div className="space-y-3 px-3.5 py-3.5">
         {showAuthor ? (
           <div className="flex items-center gap-2.5">

--- a/apps/web/components/outfits/outfit-detail-view.tsx
+++ b/apps/web/components/outfits/outfit-detail-view.tsx
@@ -100,7 +100,7 @@ export function OutfitDetailView({ id }: { id: string }) {
           <p className="font-display text-5xl text-pink-deep">checkd</p>
           <h1 className="mt-4 text-3xl text-ink">Outfit not found</h1>
           <p className="mt-3 text-sm leading-6 text-ink-soft">This look may have been removed.</p>
-          <Link href="/feed" className="mt-6 inline-block rounded-[1.2rem] border border-rose/15 bg-white px-5 py-3 text-sm font-semibold text-plum transition hover:border-rose/25">
+          <Link href="/feed" className="mt-6 inline-flex items-center justify-center rounded-[1.2rem] border border-line bg-white px-5 py-3 text-sm font-semibold text-ink-soft transition hover:border-pink-deep/25">
             Back to feed
           </Link>
         </div>
@@ -123,7 +123,7 @@ export function OutfitDetailView({ id }: { id: string }) {
             <button
               type="button"
               onClick={() => router.back()}
-              className="flex items-center gap-1.5 text-sm text-mute transition hover:text-plum"
+              className="flex items-center gap-1.5 text-sm text-mute transition hover:text-ink"
             >
               <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="m15 18-6-6 6-6" />
@@ -134,7 +134,7 @@ export function OutfitDetailView({ id }: { id: string }) {
             <button
               type="button"
               onClick={() => setShowShare(true)}
-              className="flex items-center gap-2 rounded-full border border-rose/15 bg-white px-4 py-2.5 text-[0.78rem] font-semibold text-plum transition hover:border-rose/28"
+              className="flex items-center gap-2 rounded-full border border-line bg-white px-4 py-2.5 text-[0.78rem] font-semibold text-ink-soft transition hover:border-pink-deep/30"
             >
               <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round">
                 <circle cx="18" cy="5" r="3" />
@@ -154,7 +154,7 @@ export function OutfitDetailView({ id }: { id: string }) {
               {status === "loading" ? (
                 <div className="aspect-[4/5] w-full animate-pulse rounded-[2rem] bg-[linear-gradient(120deg,_rgba(255,236,242,0.8),_rgba(255,255,255,0.98),_rgba(250,216,225,0.62))]" />
               ) : (
-                <div className="relative overflow-hidden rounded-[2rem] border border-rose/10 bg-white shadow-[0_24px_60px_rgba(244,106,147,0.12)]">
+                <div className="relative overflow-hidden rounded-[2rem] border border-line bg-white shadow-[0_24px_60px_rgba(244,106,147,0.12)]">
                   <img
                     src={outfit?.image_url}
                     alt={outfit?.caption ?? "Outfit photo"}
@@ -186,16 +186,16 @@ export function OutfitDetailView({ id }: { id: string }) {
               ) : outfit?.owner ? (
                 <Link
                   href={`/profile/${outfit.owner.username}`}
-                  className="soft-panel flex items-center gap-3 px-5 py-4 transition hover:border-rose/18"
+                  className="soft-panel flex items-center gap-3 px-5 py-4 transition hover:border-pink-deep/20"
                 >
                   {outfit.owner.profile_image_url ? (
                     <img
                       src={outfit.owner.profile_image_url}
                       alt={outfit.owner.username ?? ""}
-                      className="h-11 w-11 rounded-full border border-plum/10 object-cover"
+                      className="h-11 w-11 rounded-full border border-line object-cover"
                     />
                   ) : (
-                    <div className="flex h-11 w-11 items-center justify-center rounded-full border border-plum/14 bg-pink-soft text-sm font-semibold text-ink-soft">
+                    <div className="flex h-11 w-11 items-center justify-center rounded-full border border-line bg-pink-soft text-sm font-semibold text-ink-soft">
                       {(outfit.owner.display_name ?? outfit.owner.username ?? "?").charAt(0).toUpperCase()}
                     </div>
                   )}
@@ -207,7 +207,7 @@ export function OutfitDetailView({ id }: { id: string }) {
                       <p className="text-[0.7rem] text-mute">@{outfit.owner.username}</p>
                     ) : null}
                   </div>
-                  <svg viewBox="0 0 24 24" className="ml-auto h-4 w-4 shrink-0 text-plum/30" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <svg viewBox="0 0 24 24" className="ml-auto h-4 w-4 shrink-0 text-mute/40" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                     <path d="m9 18 6-6-6-6" />
                   </svg>
                 </Link>
@@ -238,7 +238,7 @@ export function OutfitDetailView({ id }: { id: string }) {
                     ) : null}
 
                     {outfit?.vibe_check_text ? (
-                      <div className="rounded-[1rem] border border-rose/10 bg-pink-soft px-4 py-3">
+                      <div className="rounded-[1rem] border border-line bg-pink-soft px-4 py-3">
                         <p className="mb-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-pink-deep">Vibe check</p>
                         <p className="text-sm leading-6 text-ink-soft">{outfit.vibe_check_text}</p>
                       </div>
@@ -265,7 +265,7 @@ export function OutfitDetailView({ id }: { id: string }) {
                             href={item.link_url}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="shrink-0 rounded-full border border-rose/15 px-3 py-1 text-[0.68rem] font-semibold text-pink-deep transition hover:border-rose/28"
+                            className="shrink-0 rounded-full border border-line px-3 py-1 text-[0.68rem] font-semibold text-pink-deep transition hover:border-pink-deep/30"
                           >
                             Shop
                           </a>
@@ -285,7 +285,7 @@ export function OutfitDetailView({ id }: { id: string }) {
                   className={`flex flex-1 items-center justify-center gap-2 rounded-[1.2rem] border py-3.5 text-sm font-semibold transition disabled:cursor-default ${
                     liked
                       ? "border-[#f6a9be] bg-pink-soft text-pink-deep"
-                      : "border-rose/15 bg-white text-plum hover:border-rose/28"
+                      : "border-line bg-white text-ink-soft hover:border-pink-deep/30"
                   }`}
                 >
                   <svg viewBox="0 0 24 24" className="h-4.5 w-4.5" fill={liked ? "currentColor" : "none"} stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round">
@@ -297,7 +297,7 @@ export function OutfitDetailView({ id }: { id: string }) {
                 <button
                   type="button"
                   onClick={() => setShowComments(true)}
-                  className="flex flex-1 items-center justify-center gap-2 rounded-[1.2rem] border border-rose/15 bg-white py-3.5 text-sm font-semibold text-plum transition hover:border-rose/28"
+                  className="flex flex-1 items-center justify-center gap-2 rounded-[1.2rem] border border-line bg-white py-3.5 text-sm font-semibold text-ink-soft transition hover:border-pink-deep/30"
                 >
                   <svg viewBox="0 0 24 24" className="h-4.5 w-4.5" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round">
                     <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
@@ -308,7 +308,7 @@ export function OutfitDetailView({ id }: { id: string }) {
                 <button
                   type="button"
                   onClick={() => setShowShare(true)}
-                  className="flex aspect-square items-center justify-center rounded-[1.2rem] border border-rose/15 bg-white p-3.5 text-mute transition hover:border-rose/28 hover:text-plum"
+                  className="flex aspect-square items-center justify-center rounded-[1.2rem] border border-line bg-white p-3.5 text-mute transition hover:border-pink-deep/30 hover:text-ink"
                   aria-label="Share"
                 >
                   <svg viewBox="0 0 24 24" className="h-4.5 w-4.5" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round">
@@ -323,7 +323,7 @@ export function OutfitDetailView({ id }: { id: string }) {
                 {isOwn ? (
                   <Link
                     href="/vault"
-                    className="flex aspect-square items-center justify-center rounded-[1.2rem] border border-rose/15 bg-white p-3.5 text-mute transition hover:border-rose/28 hover:text-plum"
+                    className="flex aspect-square items-center justify-center rounded-[1.2rem] border border-line bg-white p-3.5 text-mute transition hover:border-pink-deep/30 hover:text-ink"
                     aria-label="View in vault"
                   >
                     <svg viewBox="0 0 24 24" className="h-4.5 w-4.5" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round">

--- a/apps/web/components/upload/upload-flow.tsx
+++ b/apps/web/components/upload/upload-flow.tsx
@@ -117,6 +117,11 @@ export function UploadFlow() {
       event.target.value = "";
       return;
     }
+    if (nextFile.size > 20 * 1024 * 1024) {
+      setErrorState({ photo: "Photo is too large (max 20 MB).", form: "Choose a photo under 20 MB." });
+      event.target.value = "";
+      return;
+    }
     setPhoto(nextFile);
     setErrors(createEmptyErrors());
   }
@@ -272,7 +277,7 @@ export function UploadFlow() {
         {/* Error/success banners */}
         {errors.form ? (
           <div
-            className="border border-rose/25 bg-pink-soft text-error"
+            className="border border-pink-deep/25 bg-pink-soft text-error"
             style={{ borderRadius: "1rem", padding: "10px 14px", fontSize: 13, marginBottom: 16 }}
           >
             {errors.form}
@@ -280,7 +285,7 @@ export function UploadFlow() {
         ) : null}
         {submitState.status === "error" ? (
           <div
-            className="border border-rose/25 bg-pink-soft text-error"
+            className="border border-pink-deep/25 bg-pink-soft text-error"
             style={{ borderRadius: "1rem", padding: "10px 14px", fontSize: 13, marginBottom: 16 }}
           >
             {submitState.message}
@@ -560,7 +565,7 @@ export function UploadFlow() {
             className="flex flex-1 items-center justify-center bg-ink text-paper transition hover:opacity-90"
             style={{ borderRadius: "99px", height: 48, fontSize: 15, fontWeight: 600 }}
           >
-            continue
+            {currentStep === 1 ? "looks good" : currentStep === 2 ? "add context" : "review it"}
           </button>
         ) : (
           <button
@@ -603,7 +608,7 @@ function InputField({
         {label}
         {optional ? <span className="ml-1 font-normal normal-case tracking-normal text-mute">(optional)</span> : null}
       </p>
-      <div className={`field-shell ${error ? "border-rose/60 bg-rose/5" : ""}`}>
+      <div className={`field-shell ${error ? "border-error/60 bg-error/5" : ""}`}>
         <input
           type={type}
           className="field-input"

--- a/apps/web/tests/smoke.spec.ts
+++ b/apps/web/tests/smoke.spec.ts
@@ -156,8 +156,8 @@ test.describe("protected routes", () => {
     // step 1 heading is now "add your photo" (font-display, no h-role — use text match)
     await expect(page.getByText(/add your photo/i)).toBeVisible();
 
-    // continue button now just says "continue"
-    await page.getByRole("button", { name: /^continue$/i }).click();
+    // step 1 advance button says "looks good"
+    await page.getByRole("button", { name: /^looks good$/i }).click();
 
     // updated error copy from the new upload-flow
     await expect(page.getByText(/a photo is required/i)).toBeVisible();
@@ -178,14 +178,14 @@ test.describe("protected routes", () => {
       buffer: Buffer.from("fake image bytes")
     });
 
-    // all navigation now uses a single "continue" button
-    await page.getByRole("button", { name: /^continue$/i }).click();
+    // step 1 → "looks good", step 2 → "add context", step 3 → "review it"
+    await page.getByRole("button", { name: /^looks good$/i }).click();
     // step 2 — fill category
     await page.getByPlaceholder(/top, trousers, shoes/i).fill("Dress");
-    await page.getByRole("button", { name: /^continue$/i }).click();
+    await page.getByRole("button", { name: /^add context$/i }).click();
     // step 3 — fill caption
     await page.getByPlaceholder(/what was the vibe/i).fill("Smoke test fit");
-    await page.getByRole("button", { name: /^continue$/i }).click();
+    await page.getByRole("button", { name: /^review it$/i }).click();
     // step 4 — submit; button now says "post outfit"
     await page.getByRole("button", { name: /post outfit/i }).click();
 


### PR DESCRIPTION
## Summary

- **Token cleanup**: Replace all stale `plum`/`rose/*` color tokens with canonical checkd tokens (`ink-soft`, `line`, `pink-deep`) across outfit cards, comments, search, onboarding, profile, boards, feed, explore, vault, and upload flow
- **Desktop nav**: New `DesktopNav` component at `≥1024px` with brand wordmark, nav links, search pill, "post a fit" CTA, and avatar — replaces bottom tab bar on desktop; all pages updated with `lg:pt-16/20 lg:pb-0` for correct clearance
- **Issue #110**: `boards/[id]/upload` page with board pre-check on mount; 403 → "not a member" state, 410 → "board expired" state
- **Global polish**: Focus rings (`1.5px pink-deep`, offset 2px), `text-wrap: pretty` on headings, instant button press feedback, safe-area inset on tab bar
- **Copy**: Replace "continue" with brand-voice step labels ("looks good", "add context", "review it"); enforce lowercase on all display headings and empty states throughout the app
- **Upload**: 20MB file size limit enforced on photo pick
- **Skeletons**: Diagonal 45° stripe pattern on `OutfitCardSkeleton` photo area per brief §07
- **Images**: `loading="lazy"` on all outfit card photos; vault grid gap corrected (2px mobile, 4px desktop)

## Test plan

- [ ] Mobile: tab bar visible, safe-area inset works on notched devices
- [ ] Desktop (≥1024px): top nav shows, tab bar hidden, page content clears nav
- [ ] Upload flow: step labels read "looks good" → "add context" → "review it" → "post outfit"; file >20MB shows error
- [ ] Board upload: 403 shows "not a member", 410 shows "board expired" before reaching upload UI
- [ ] All interactive elements show focus ring on keyboard navigation
- [ ] No stale `plum`/`rose` tokens remain in the codebase