### PR TITLE
feat: checkd v2 redesign + notification system (#81)

### DIFF
--- a/services/api/alembic/versions/20260508_c5d6e7f8_add_notifications.py
+++ b/services/api/alembic/versions/20260508_c5d6e7f8_add_notifications.py
@@ -16,9 +16,15 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # Guard against the type already existing (e.g. from a failed partial run or
+    # a test DB that was only partially rolled back).
     op.execute(
+        "DO $$ BEGIN "
+        "IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'notificationtype') THEN "
         "CREATE TYPE notificationtype AS ENUM "
-        "('follow', 'like', 'comment', 'board_join', 'board_outfit')"
+        "('follow', 'like', 'comment', 'board_join', 'board_outfit'); "
+        "END IF; "
+        "END $$;"
     )
 
     op.create_table(
@@ -84,4 +90,4 @@ def downgrade() -> None:
     op.drop_index("ix_notifications_recipient_seen", table_name="notifications")
     op.drop_index("ix_notifications_recipient_id", table_name="notifications")
     op.drop_table("notifications")
-    op.execute("DROP TYPE notificationtype")
+    op.execute("DROP TYPE IF EXISTS notificationtype")

--- a/services/api/alembic/versions/20260508_c5d6e7f8_add_notifications.py
+++ b/services/api/alembic/versions/20260508_c5d6e7f8_add_notifications.py
@@ -8,6 +8,7 @@ Create Date: 2026-05-08
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects.postgresql import ENUM as PgENUM
 
 revision = "c5d6e7f8"
 down_revision = "b3c4d5e6"
@@ -16,16 +17,14 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Guard against the type already existing (e.g. from a failed partial run or
-    # a test DB that was only partially rolled back).
-    op.execute(
-        "DO $$ BEGIN "
-        "IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'notificationtype') THEN "
-        "CREATE TYPE notificationtype AS ENUM "
-        "('follow', 'like', 'comment', 'board_join', 'board_outfit'); "
-        "END IF; "
-        "END $$;"
+    # `create_type=False` is only honoured by postgresql.ENUM, not sa.Enum.
+    # Use PgENUM.create(checkfirst=True) so this is idempotent on any DB state.
+    notif_enum = PgENUM(
+        "follow", "like", "comment", "board_join", "board_outfit",
+        name="notificationtype",
+        create_type=False,
     )
+    notif_enum.create(op.get_bind(), checkfirst=True)
 
     op.create_table(
         "notifications",
@@ -49,8 +48,11 @@ def upgrade() -> None:
         ),
         sa.Column(
             "type",
-            sa.Enum("follow", "like", "comment", "board_join", "board_outfit",
-                    name="notificationtype", create_type=False),
+            PgENUM(
+                "follow", "like", "comment", "board_join", "board_outfit",
+                name="notificationtype",
+                create_type=False,
+            ),
             nullable=False,
         ),
         sa.Column(
@@ -90,4 +92,4 @@ def downgrade() -> None:
     op.drop_index("ix_notifications_recipient_seen", table_name="notifications")
     op.drop_index("ix_notifications_recipient_id", table_name="notifications")
     op.drop_table("notifications")
-    op.execute("DROP TYPE IF EXISTS notificationtype")
+    PgENUM(name="notificationtype", create_type=False).drop(op.get_bind(), checkfirst=True)

--- a/services/api/alembic/versions/20260508_c5d6e7f8_add_notifications.py
+++ b/services/api/alembic/versions/20260508_c5d6e7f8_add_notifications.py
@@ -1,0 +1,87 @@
+"""add notifications table
+
+Revision ID: c5d6e7f8
+Revises: b3c4d5e6
+Create Date: 2026-05-08
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "c5d6e7f8"
+down_revision = "b3c4d5e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "CREATE TYPE notificationtype AS ENUM "
+        "('follow', 'like', 'comment', 'board_join', 'board_outfit')"
+    )
+
+    op.create_table(
+        "notifications",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "recipient_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "actor_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "type",
+            sa.Enum("follow", "like", "comment", "board_join", "board_outfit",
+                    name="notificationtype", create_type=False),
+            nullable=False,
+        ),
+        sa.Column(
+            "outfit_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("outfits.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column(
+            "board_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("boards.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column(
+            "comment_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("comments.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column("body", sa.String(255), nullable=True),
+        sa.Column("seen", sa.Boolean, nullable=False, server_default="false"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index("ix_notifications_recipient_id", "notifications", ["recipient_id"])
+    op.create_index(
+        "ix_notifications_recipient_seen", "notifications", ["recipient_id", "seen"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_notifications_recipient_seen", table_name="notifications")
+    op.drop_index("ix_notifications_recipient_id", table_name="notifications")
+    op.drop_table("notifications")
+    op.execute("DROP TYPE notificationtype")

--- a/services/api/app/crud/notification.py
+++ b/services/api/app/crud/notification.py
@@ -1,0 +1,134 @@
+"""
+CRUD helpers for the notifications table.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from app.models.notification import Notification, NotificationType
+from app.models.user import User
+
+
+def create_notification(
+    db: Session,
+    *,
+    recipient_id: uuid.UUID,
+    actor_id: uuid.UUID,
+    type: NotificationType,
+    body: str | None = None,
+    outfit_id: uuid.UUID | None = None,
+    board_id: uuid.UUID | None = None,
+    comment_id: uuid.UUID | None = None,
+) -> Notification:
+    """
+    Insert a notification row.  No-ops if recipient == actor (no self-notifications).
+    Also de-dupes follow notifications (one per (actor, recipient) pair).
+    """
+    if recipient_id == actor_id:
+        # Return a dummy unsaved object so callers don't have to check for None
+        n = Notification(
+            recipient_id=recipient_id,
+            actor_id=actor_id,
+            type=type,
+        )
+        return n
+
+    # De-dupe follow: if this actor already notified this recipient of a follow, skip
+    if type == NotificationType.follow:
+        exists = (
+            db.query(Notification)
+            .filter(
+                Notification.recipient_id == recipient_id,
+                Notification.actor_id == actor_id,
+                Notification.type == NotificationType.follow,
+            )
+            .first()
+        )
+        if exists:
+            return exists
+
+    n = Notification(
+        recipient_id=recipient_id,
+        actor_id=actor_id,
+        type=type,
+        body=body,
+        outfit_id=outfit_id,
+        board_id=board_id,
+        comment_id=comment_id,
+    )
+    db.add(n)
+    db.commit()
+    db.refresh(n)
+    return n
+
+
+def get_notifications(
+    db: Session,
+    recipient_id: uuid.UUID,
+    cursor: str | None = None,
+    limit: int = 20,
+) -> tuple[list[Notification], str | None]:
+    """Newest-first, cursor-paginated by created_at."""
+    query = (
+        db.query(Notification)
+        .filter(Notification.recipient_id == recipient_id)
+        .order_by(Notification.created_at.desc())
+    )
+
+    if cursor:
+        try:
+            cursor_dt = datetime.fromisoformat(cursor.replace(" ", "+"))
+        except ValueError:
+            cursor_dt = None
+        if cursor_dt:
+            query = query.filter(Notification.created_at < cursor_dt)
+
+    rows = query.limit(limit + 1).all()
+
+    next_cursor = None
+    if len(rows) > limit:
+        rows = rows[:limit]
+        next_cursor = rows[-1].created_at.isoformat()
+
+    return rows, next_cursor
+
+
+def mark_seen(
+    db: Session,
+    recipient_id: uuid.UUID,
+    notification_ids: list[uuid.UUID] | None = None,
+) -> int:
+    """
+    Mark notifications as seen.
+
+    If notification_ids is provided (and non-empty), only those rows are updated.
+    Otherwise marks ALL unseen notifications for this recipient.
+
+    Returns the number of rows updated.
+    """
+    query = db.query(Notification).filter(
+        Notification.recipient_id == recipient_id,
+        Notification.seen == False,  # noqa: E712
+    )
+
+    if notification_ids:
+        query = query.filter(Notification.id.in_(notification_ids))
+
+    rows = query.all()
+    for row in rows:
+        row.seen = True
+    db.commit()
+    return len(rows)
+
+
+def unseen_count(db: Session, recipient_id: uuid.UUID) -> int:
+    return (
+        db.query(Notification)
+        .filter(
+            Notification.recipient_id == recipient_id,
+            Notification.seen == False,  # noqa: E712
+        )
+        .count()
+    )

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -5,7 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from app.config import settings
-from app.routers import auth, boards, health, outfits, users
+from app.routers import auth, boards, health, notifications, outfits, users
 from app.services.storage import LOCAL_UPLOADS_DIR
 
 
@@ -33,6 +33,7 @@ app.include_router(auth.router)
 app.include_router(outfits.router)
 app.include_router(users.router)
 app.include_router(boards.router)
+app.include_router(notifications.router)
 
 # Dev-mode local file storage — only mounted when S3 is not configured.
 # In production S3_BUCKET is set so this block is skipped.

--- a/services/api/app/models/__init__.py
+++ b/services/api/app/models/__init__.py
@@ -1,6 +1,7 @@
 # Import all models here so that Base.metadata is fully populated
 # for Alembic autogenerate and SQLAlchemy table creation.
 from app.models.board import Board, BoardMember, BoardOutfit
+from app.models.notification import Notification, NotificationType
 from app.models.clothing_item import ClothingItem
 from app.models.comment import Comment
 from app.models.follow import Follow
@@ -20,4 +21,6 @@ __all__ = [
     "Board",
     "BoardMember",
     "BoardOutfit",
+    "Notification",
+    "NotificationType",
 ]

--- a/services/api/app/models/notification.py
+++ b/services/api/app/models/notification.py
@@ -1,0 +1,71 @@
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Index, String, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class NotificationType(str, enum.Enum):
+    follow = "follow"
+    like = "like"
+    comment = "comment"
+    board_join = "board_join"
+    board_outfit = "board_outfit"
+
+
+class Notification(Base):
+    __tablename__ = "notifications"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=text("gen_random_uuid()"),
+    )
+    recipient_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    actor_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    type: Mapped[NotificationType] = mapped_column(
+        Enum(NotificationType, name="notificationtype"),
+        nullable=False,
+    )
+    # Optional FK columns — only one will be set depending on type
+    outfit_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("outfits.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    board_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("boards.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    comment_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("comments.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    # Short human-readable blurb, e.g. "@alice liked your outfit"
+    body: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    seen: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false", default=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("now()")
+    )
+
+    __table_args__ = (
+        Index("ix_notifications_recipient_id", "recipient_id"),
+        Index("ix_notifications_recipient_seen", "recipient_id", "seen"),
+    )

--- a/services/api/app/routers/boards.py
+++ b/services/api/app/routers/boards.py
@@ -13,9 +13,11 @@ from sqlalchemy.orm import Session
 
 from app.config import settings
 from app.crud import board as board_crud
+from app.crud import notification as notif_crud
 from app.crud import outfit as outfit_crud
 from app.crud import user as user_crud
 from app.dependencies import get_current_user, get_db
+from app.models.notification import NotificationType
 from app.models.user import User
 from app.schemas.board import (
     BoardMemberOut,
@@ -142,7 +144,19 @@ def join_board(
     board = board_crud.get_by_invite_code(db, invite_code)
     if not board:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invite link not found.")
+    was_member = board_crud.is_member(db, board.id, current_user.id)
     board_crud.join_board(db, board.id, current_user.id)
+    # Notify the board creator when a new member joins (not on idempotent re-join)
+    if not was_member and board.creator_id != current_user.id:
+        actor_name = current_user.display_name or current_user.username or "Someone"
+        notif_crud.create_notification(
+            db,
+            recipient_id=board.creator_id,
+            actor_id=current_user.id,
+            type=NotificationType.board_join,
+            body=f"{actor_name} joined your board \"{board.name}\".",
+            board_id=board.id,
+        )
     return _board_out(db, board)
 
 
@@ -215,12 +229,27 @@ def add_outfit(
     db: Session = Depends(get_db),
 ) -> OutfitOut:
     """Add an outfit to a board. Members only. The outfit must exist."""
-    _board_or_404(db, board_id)
+    board = _board_or_404(db, board_id)
     _require_member(db, board_id, current_user.id)
     outfit = outfit_crud.get_outfit_with_items(db, outfit_id)
     if not outfit:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Outfit not found.")
     board_crud.add_outfit(db, board_id, outfit_id, current_user.id)
+    # Notify all other board members that a new outfit was added
+    members = board_crud.get_members(db, board_id)
+    actor_name = current_user.display_name or current_user.username or "Someone"
+    for m in members:
+        if m.user_id == current_user.id:
+            continue
+        notif_crud.create_notification(
+            db,
+            recipient_id=m.user_id,
+            actor_id=current_user.id,
+            type=NotificationType.board_outfit,
+            body=f"{actor_name} posted to \"{board.name}\".",
+            board_id=board_id,
+            outfit_id=outfit_id,
+        )
     return OutfitOut.model_validate(outfit)
 
 

--- a/services/api/app/routers/notifications.py
+++ b/services/api/app/routers/notifications.py
@@ -1,0 +1,99 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.crud import notification as notif_crud
+from app.dependencies import get_current_user, get_db
+from app.models.notification import Notification
+from app.models.user import User
+from app.schemas.notification import (
+    MarkSeenRequest,
+    NotificationActor,
+    NotificationOut,
+    NotificationPage,
+    UnseenCountOut,
+)
+
+router = APIRouter(prefix="/notifications", tags=["notifications"])
+
+
+def _notification_out(n: Notification, db: Session) -> NotificationOut:
+    """Hydrate actor from DB and return a NotificationOut."""
+    actor: User | None = db.get(User, n.actor_id)
+    if actor is None:
+        # Actor was deleted — build a placeholder
+        actor_out = NotificationActor(
+            id=n.actor_id,
+            username=None,
+            display_name=None,
+            profile_image_url=None,
+        )
+    else:
+        actor_out = NotificationActor(
+            id=actor.id,
+            username=actor.username,
+            display_name=actor.display_name,
+            profile_image_url=actor.profile_image_url,
+        )
+
+    return NotificationOut(
+        id=n.id,
+        type=n.type,
+        seen=n.seen,
+        body=n.body,
+        created_at=n.created_at,
+        outfit_id=n.outfit_id,
+        board_id=n.board_id,
+        comment_id=n.comment_id,
+        actor=actor_out,
+    )
+
+
+@router.get("", response_model=NotificationPage)
+def list_notifications(
+    cursor: str | None = Query(default=None, description="ISO timestamp cursor for pagination"),
+    limit: int = Query(default=20, ge=1, le=50),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> NotificationPage:
+    """
+    Newest-first list of notifications for the current user.
+    Cursor is the ISO `created_at` of the last item returned.
+    """
+    rows, next_cursor = notif_crud.get_notifications(
+        db, recipient_id=current_user.id, cursor=cursor, limit=limit
+    )
+    return NotificationPage(
+        items=[_notification_out(n, db) for n in rows],
+        next_cursor=next_cursor,
+    )
+
+
+@router.get("/unseen-count", response_model=UnseenCountOut)
+def get_unseen_count(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> UnseenCountOut:
+    """Returns the number of unseen notifications for the badge."""
+    count = notif_crud.unseen_count(db, current_user.id)
+    return UnseenCountOut(unseen_count=count)
+
+
+@router.post("/seen", status_code=status.HTTP_204_NO_CONTENT)
+def mark_seen(
+    body: MarkSeenRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> None:
+    """
+    Mark notifications as seen.
+
+    Pass `notification_ids` to mark specific ones, or an empty list / omit it
+    to mark ALL unseen notifications as seen.
+    """
+    notif_crud.mark_seen(
+        db,
+        recipient_id=current_user.id,
+        notification_ids=body.notification_ids or None,
+    )

--- a/services/api/app/routers/outfits.py
+++ b/services/api/app/routers/outfits.py
@@ -7,10 +7,12 @@ from sqlalchemy.orm import Session
 import uuid
 
 from app.crud import follow as follow_crud
+from app.crud import notification as notif_crud
 from app.crud import outfit as outfit_crud
 from app.crud import social as social_crud
 from app.crud import user as user_crud
 from app.dependencies import get_current_user, get_db, get_optional_user
+from app.models.notification import NotificationType
 from app.models.user import User
 from app.schemas.outfit import FeedAuthor, FeedOutfitOut, FeedPage, OutfitMetadata, OutfitOut, VaultPage
 from app.schemas.outfit import CaptionSuggestionsOut, OutfitDetailOut, OutfitMetadata, OutfitOGOut, OutfitOut, OutfitOwner, VaultPage
@@ -349,7 +351,19 @@ def like_outfit(
 ) -> LikeStatus:
     """Like an outfit. Idempotent — safe to call multiple times."""
     outfit = _outfit_or_404(db, outfit_id)
+    already_liked = social_crud.is_liked_by(db, outfit.id, current_user.id)
     social_crud.like_outfit(db, current_user.id, outfit.id)
+    # Only send notification on first like (not on idempotent re-like)
+    if not already_liked and outfit.user_id != current_user.id:
+        actor_name = current_user.display_name or current_user.username or "Someone"
+        notif_crud.create_notification(
+            db,
+            recipient_id=outfit.user_id,
+            actor_id=current_user.id,
+            type=NotificationType.like,
+            body=f"{actor_name} liked your outfit.",
+            outfit_id=outfit.id,
+        )
     return LikeStatus(
         like_count=social_crud.get_like_count(db, outfit.id),
         liked=True,
@@ -399,6 +413,18 @@ def create_comment(
     """Post a comment on an outfit. Auth required."""
     outfit = _outfit_or_404(db, outfit_id)
     comment = social_crud.create_comment(db, outfit.id, current_user.id, body.body)
+    # Notify the outfit owner (skip if commenter is the owner)
+    if outfit.user_id != current_user.id:
+        actor_name = current_user.display_name or current_user.username or "Someone"
+        notif_crud.create_notification(
+            db,
+            recipient_id=outfit.user_id,
+            actor_id=current_user.id,
+            type=NotificationType.comment,
+            body=f"{actor_name} commented on your outfit.",
+            outfit_id=outfit.id,
+            comment_id=comment.id,
+        )
     return _comment_out(db, comment)
 
 

--- a/services/api/app/routers/users.py
+++ b/services/api/app/routers/users.py
@@ -4,9 +4,11 @@ from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, 
 from sqlalchemy.orm import Session
 
 from app.crud import follow as follow_crud
+from app.crud import notification as notif_crud
 from app.crud import user as user_crud
 from app.crud import wrapped as wrapped_crud
 from app.dependencies import get_current_user, get_db
+from app.models.notification import NotificationType
 from app.models.user import User
 from app.schemas.outfit import OutfitOut
 from app.schemas.user import FollowResponse, PublicProfile, SearchResult, UpdateProfileRequest
@@ -192,6 +194,15 @@ def follow_user(
     if target.id == current_user.id:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Cannot follow yourself.")
     follow_crud.follow(db, follower_id=current_user.id, following_id=target.id)
+    # Notify the person who was followed
+    actor_name = current_user.display_name or current_user.username or "Someone"
+    notif_crud.create_notification(
+        db,
+        recipient_id=target.id,
+        actor_id=current_user.id,
+        type=NotificationType.follow,
+        body=f"{actor_name} started following you.",
+    )
     return FollowResponse(following=True, follower_count=follow_crud.follower_count(db, target.id))
 
 

--- a/services/api/app/routers/users.py
+++ b/services/api/app/routers/users.py
@@ -180,29 +180,31 @@ def get_profile(username: str, db: Session = Depends(get_db)) -> PublicProfile:
     )
 
 
-@router.post("/{user_id}/follow", response_model=FollowResponse)
+@router.post("/{username}/follow", response_model=FollowResponse)
 def follow_user(
-    user_id: uuid.UUID,
+    username: str,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> FollowResponse:
-    if user_id == current_user.id:
+    target = user_crud.get_by_username(db, username)
+    if not target:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
+    if target.id == current_user.id:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Cannot follow yourself.")
-    if not user_crud.get_by_id(db, user_id):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
-    follow_crud.follow(db, follower_id=current_user.id, following_id=user_id)
-    return FollowResponse(following=True, follower_count=follow_crud.follower_count(db, user_id))
+    follow_crud.follow(db, follower_id=current_user.id, following_id=target.id)
+    return FollowResponse(following=True, follower_count=follow_crud.follower_count(db, target.id))
 
 
-@router.delete("/{user_id}/follow", response_model=FollowResponse)
+@router.delete("/{username}/follow", response_model=FollowResponse)
 def unfollow_user(
-    user_id: uuid.UUID,
+    username: str,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> FollowResponse:
-    if user_id == current_user.id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Cannot unfollow yourself.")
-    if not user_crud.get_by_id(db, user_id):
+    target = user_crud.get_by_username(db, username)
+    if not target:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
-    follow_crud.unfollow(db, follower_id=current_user.id, following_id=user_id)
-    return FollowResponse(following=False, follower_count=follow_crud.follower_count(db, user_id))
+    if target.id == current_user.id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Cannot unfollow yourself.")
+    follow_crud.unfollow(db, follower_id=current_user.id, following_id=target.id)
+    return FollowResponse(following=False, follower_count=follow_crud.follower_count(db, target.id))

--- a/services/api/app/schemas/notification.py
+++ b/services/api/app/schemas/notification.py
@@ -1,0 +1,46 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from app.models.notification import NotificationType
+
+
+class NotificationActor(BaseModel):
+    id: uuid.UUID
+    username: str | None
+    display_name: str | None
+    profile_image_url: str | None
+
+    model_config = {"from_attributes": True}
+
+
+class NotificationOut(BaseModel):
+    id: uuid.UUID
+    type: NotificationType
+    seen: bool
+    body: str | None
+    created_at: datetime
+
+    # Contextual FKs — frontend decides which to use based on type
+    outfit_id: uuid.UUID | None = None
+    board_id: uuid.UUID | None = None
+    comment_id: uuid.UUID | None = None
+
+    actor: NotificationActor
+
+    model_config = {"from_attributes": True}
+
+
+class NotificationPage(BaseModel):
+    items: list[NotificationOut]
+    next_cursor: str | None
+
+
+class UnseenCountOut(BaseModel):
+    unseen_count: int
+
+
+class MarkSeenRequest(BaseModel):
+    """If notification_ids is empty/omitted, marks ALL unseen as seen."""
+    notification_ids: list[uuid.UUID] = []

--- a/services/api/tests/test_feed.py
+++ b/services/api/tests/test_feed.py
@@ -4,7 +4,7 @@ import io
 from starlette.testclient import TestClient
 
 REGISTER_URL = "/auth/register"
-FOLLOW_URL = "/users/{user_id}/follow"
+FOLLOW_URL = "/users/{username}/follow"
 FEED_URL = "/outfits/feed"
 MY_VAULT_URL = "/outfits/me"
 USER_VAULT_URL = "/outfits/user/{username}"
@@ -48,7 +48,7 @@ class TestFeed:
         monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
         a = _register(client, USER_A)
         b = _register(client, USER_B)
-        client.post(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=_auth(a["access_token"]))
+        client.post(FOLLOW_URL.format(username=b["user"]["username"]), headers=_auth(a["access_token"]))
         _post_outfit(client, b["access_token"], "b's outfit")
         res = client.get(FEED_URL, headers=_auth(a["access_token"]))
         assert res.status_code == 200
@@ -71,7 +71,7 @@ class TestFeed:
         monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
         a = _register(client, USER_A)
         b = _register(client, USER_B)
-        client.post(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=_auth(a["access_token"]))
+        client.post(FOLLOW_URL.format(username=b["user"]["username"]), headers=_auth(a["access_token"]))
         for i in range(3):
             _post_outfit(client, b["access_token"], f"outfit {i}")
         res = client.get(FEED_URL + "?limit=2", headers=_auth(a["access_token"]))

--- a/services/api/tests/test_follows.py
+++ b/services/api/tests/test_follows.py
@@ -3,7 +3,7 @@
 from starlette.testclient import TestClient
 
 REGISTER_URL = "/auth/register"
-FOLLOW_URL = "/users/{user_id}/follow"
+FOLLOW_URL = "/users/{username}/follow"
 PROFILE_URL = "/users/{username}"
 
 USER_A = {"username": "usera", "email": "a@example.com", "password": "password123"}
@@ -44,7 +44,7 @@ class TestFollow:
     def test_follow_returns_200_with_counts(self, client):
         a = _register(client, USER_A)
         b = _register(client, USER_B)
-        res = client.post(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=_auth(a["access_token"]))
+        res = client.post(FOLLOW_URL.format(username=b["user"]["username"]), headers=_auth(a["access_token"]))
         assert res.status_code == 200
         assert res.json()["following"] is True
         assert res.json()["follower_count"] == 1
@@ -53,34 +53,34 @@ class TestFollow:
         a = _register(client, USER_A)
         b = _register(client, USER_B)
         headers = _auth(a["access_token"])
-        client.post(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=headers)
-        res = client.post(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=headers)
+        client.post(FOLLOW_URL.format(username=b["user"]["username"]), headers=headers)
+        res = client.post(FOLLOW_URL.format(username=b["user"]["username"]), headers=headers)
         assert res.status_code == 200
         assert res.json()["follower_count"] == 1
 
     def test_follow_updates_profile_counts(self, client):
         a = _register(client, USER_A)
         b = _register(client, USER_B)
-        client.post(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=_auth(a["access_token"]))
+        client.post(FOLLOW_URL.format(username=b["user"]["username"]), headers=_auth(a["access_token"]))
         assert client.get(PROFILE_URL.format(username="userb")).json()["follower_count"] == 1
         assert client.get(PROFILE_URL.format(username="usera")).json()["following_count"] == 1
 
     def test_self_follow_returns_400(self, client):
         a = _register(client, USER_A)
-        res = client.post(FOLLOW_URL.format(user_id=a["user"]["id"]), headers=_auth(a["access_token"]))
+        res = client.post(FOLLOW_URL.format(username=a["user"]["username"]), headers=_auth(a["access_token"]))
         assert res.status_code == 400
 
     def test_follow_unknown_user_returns_404(self, client):
         a = _register(client, USER_A)
         res = client.post(
-            FOLLOW_URL.format(user_id="00000000-0000-0000-0000-000000000000"),
+            FOLLOW_URL.format(username="nobody_exists"),
             headers=_auth(a["access_token"]),
         )
         assert res.status_code == 404
 
     def test_follow_requires_auth(self, client):
         b = _register(client, USER_B)
-        assert client.post(FOLLOW_URL.format(user_id=b["user"]["id"])).status_code == 401
+        assert client.post(FOLLOW_URL.format(username=b["user"]["username"])).status_code == 401
 
 
 class TestUnfollow:
@@ -88,8 +88,8 @@ class TestUnfollow:
         a = _register(client, USER_A)
         b = _register(client, USER_B)
         headers = _auth(a["access_token"])
-        client.post(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=headers)
-        res = client.delete(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=headers)
+        client.post(FOLLOW_URL.format(username=b["user"]["username"]), headers=headers)
+        res = client.delete(FOLLOW_URL.format(username=b["user"]["username"]), headers=headers)
         assert res.status_code == 200
         assert res.json()["following"] is False
         assert res.json()["follower_count"] == 0
@@ -97,14 +97,14 @@ class TestUnfollow:
     def test_unfollow_is_idempotent(self, client):
         a = _register(client, USER_A)
         b = _register(client, USER_B)
-        res = client.delete(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=_auth(a["access_token"]))
+        res = client.delete(FOLLOW_URL.format(username=b["user"]["username"]), headers=_auth(a["access_token"]))
         assert res.status_code == 200
 
     def test_self_unfollow_returns_400(self, client):
         a = _register(client, USER_A)
-        res = client.delete(FOLLOW_URL.format(user_id=a["user"]["id"]), headers=_auth(a["access_token"]))
+        res = client.delete(FOLLOW_URL.format(username=a["user"]["username"]), headers=_auth(a["access_token"]))
         assert res.status_code == 400
 
     def test_unfollow_requires_auth(self, client):
         b = _register(client, USER_B)
-        assert client.delete(FOLLOW_URL.format(user_id=b["user"]["id"])).status_code == 401
+        assert client.delete(FOLLOW_URL.format(username=b["user"]["username"])).status_code == 401

--- a/services/api/tests/test_notifications.py
+++ b/services/api/tests/test_notifications.py
@@ -1,0 +1,160 @@
+"""Tests for notification endpoints."""
+
+import io
+
+from starlette.testclient import TestClient
+
+REGISTER_URL = "/auth/register"
+FOLLOW_URL = "/users/{username}/follow"
+NOTIF_URL = "/notifications"
+UNSEEN_URL = "/notifications/unseen-count"
+SEEN_URL = "/notifications/seen"
+
+USER_A = {"username": "usera", "email": "a@example.com", "password": "password123"}
+USER_B = {"username": "userb", "email": "b@example.com", "password": "password123"}
+
+
+def _register(client: TestClient, payload: dict) -> dict:
+    res = client.post(REGISTER_URL, json=payload)
+    assert res.status_code == 201
+    return res.json()
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _post_outfit(client, token, caption="test outfit"):
+    fake_image = io.BytesIO(b"fake-image-data")
+    return client.post(
+        "/outfits",
+        headers=_auth(token),
+        files={"image": ("test.jpg", fake_image, "image/jpeg")},
+        data={"metadata": f'{{"caption": "{caption}"}}'},
+    )
+
+
+class TestNotifications:
+    def test_empty_list_initially(self, client):
+        a = _register(client, USER_A)
+        res = client.get(NOTIF_URL, headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        body = res.json()
+        assert body["items"] == []
+        assert body["next_cursor"] is None
+
+    def test_unseen_count_zero_initially(self, client):
+        a = _register(client, USER_A)
+        res = client.get(UNSEEN_URL, headers=_auth(a["access_token"]))
+        assert res.status_code == 200
+        assert res.json()["unseen_count"] == 0
+
+    def test_follow_creates_notification(self, client):
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        # A follows B — B should get a notification
+        client.post(FOLLOW_URL.format(username=b["user"]["username"]), headers=_auth(a["access_token"]))
+
+        res = client.get(NOTIF_URL, headers=_auth(b["access_token"]))
+        assert res.status_code == 200
+        items = res.json()["items"]
+        assert len(items) == 1
+        assert items[0]["type"] == "follow"
+        assert items[0]["seen"] is False
+        assert items[0]["actor"]["username"] == "usera"
+
+    def test_follow_increments_unseen_count(self, client):
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        client.post(FOLLOW_URL.format(username=b["user"]["username"]), headers=_auth(a["access_token"]))
+
+        res = client.get(UNSEEN_URL, headers=_auth(b["access_token"]))
+        assert res.json()["unseen_count"] == 1
+
+    def test_mark_all_seen(self, client):
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        client.post(FOLLOW_URL.format(username=b["user"]["username"]), headers=_auth(a["access_token"]))
+
+        # Mark all seen with empty list
+        res = client.post(SEEN_URL, headers=_auth(b["access_token"]), json={"notification_ids": []})
+        assert res.status_code == 204
+
+        # Count should now be 0
+        assert client.get(UNSEEN_URL, headers=_auth(b["access_token"])).json()["unseen_count"] == 0
+        # Items still exist but are marked seen
+        items = client.get(NOTIF_URL, headers=_auth(b["access_token"])).json()["items"]
+        assert items[0]["seen"] is True
+
+    def test_like_creates_notification(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        outfit = _post_outfit(client, b["access_token"], "b's fit")
+        assert outfit.status_code == 201
+
+        # A likes B's outfit — B gets notified
+        client.post(f"/outfits/{outfit.json()['id']}/likes", headers=_auth(a["access_token"]))
+
+        res = client.get(NOTIF_URL, headers=_auth(b["access_token"]))
+        items = res.json()["items"]
+        assert len(items) == 1
+        assert items[0]["type"] == "like"
+        assert items[0]["outfit_id"] == outfit.json()["id"]
+        assert items[0]["actor"]["username"] == "usera"
+
+    def test_comment_creates_notification(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        outfit = _post_outfit(client, b["access_token"], "b's fit")
+        assert outfit.status_code == 201
+
+        # A comments on B's outfit
+        client.post(
+            f"/outfits/{outfit.json()['id']}/comments",
+            headers=_auth(a["access_token"]),
+            json={"body": "looking good!"},
+        )
+
+        res = client.get(NOTIF_URL, headers=_auth(b["access_token"]))
+        items = res.json()["items"]
+        assert len(items) == 1
+        assert items[0]["type"] == "comment"
+        assert items[0]["outfit_id"] == outfit.json()["id"]
+
+    def test_no_self_notification_on_like(self, client, monkeypatch):
+        monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
+        a = _register(client, USER_A)
+        outfit = _post_outfit(client, a["access_token"], "my fit")
+        # Like own outfit — should not create a notification
+        client.post(f"/outfits/{outfit.json()['id']}/likes", headers=_auth(a["access_token"]))
+        res = client.get(NOTIF_URL, headers=_auth(a["access_token"]))
+        assert res.json()["items"] == []
+
+    def test_duplicate_follow_does_not_duplicate_notification(self, client):
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        headers = _auth(a["access_token"])
+        client.post(FOLLOW_URL.format(username=b["user"]["username"]), headers=headers)
+        client.post(FOLLOW_URL.format(username=b["user"]["username"]), headers=headers)
+
+        res = client.get(NOTIF_URL, headers=_auth(b["access_token"]))
+        assert len(res.json()["items"]) == 1
+
+    def test_mark_specific_notifications_seen(self, client):
+        a = _register(client, USER_A)
+        b = _register(client, USER_B)
+        client.post(FOLLOW_URL.format(username=b["user"]["username"]), headers=_auth(a["access_token"]))
+
+        items = client.get(NOTIF_URL, headers=_auth(b["access_token"])).json()["items"]
+        notif_id = items[0]["id"]
+
+        res = client.post(SEEN_URL, headers=_auth(b["access_token"]), json={"notification_ids": [notif_id]})
+        assert res.status_code == 204
+        assert client.get(UNSEEN_URL, headers=_auth(b["access_token"])).json()["unseen_count"] == 0
+
+    def test_requires_auth(self, client):
+        assert client.get(NOTIF_URL).status_code == 401
+        assert client.get(UNSEEN_URL).status_code == 401
+        assert client.post(SEEN_URL, json={}).status_code == 401

--- a/services/api/tests/test_profile.py
+++ b/services/api/tests/test_profile.py
@@ -7,7 +7,7 @@ UPDATE_PROFILE_URL = "/users/me"
 UPLOAD_AVATAR_URL = "/users/me/avatar"
 SEARCH_URL = "/users/search"
 SUGGESTED_URL = "/users/suggested"
-FOLLOW_URL = "/users/{user_id}/follow"
+FOLLOW_URL = "/users/{username}/follow"
 
 USER_A = {"username": "usera", "email": "a@example.com", "password": "password123"}
 USER_B = {"username": "userb", "email": "b@example.com", "password": "password123"}
@@ -156,7 +156,7 @@ class TestSuggestedUsers:
     def test_excludes_already_followed(self, client):
         a = _register(client, USER_A)
         b = _register(client, USER_B)
-        client.post(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=_auth(a["access_token"]))
+        client.post(FOLLOW_URL.format(username=b["user"]["username"]), headers=_auth(a["access_token"]))
         res = client.get(SUGGESTED_URL, headers=_auth(a["access_token"]))
         assert not any(u["username"] == "userb" for u in res.json())
 
@@ -173,7 +173,7 @@ class TestSuggestedUsers:
         a = _register(client, USER_A)
         b = _register(client, USER_B)
         c = _register(client, USER_C)
-        client.post(FOLLOW_URL.format(user_id=b["user"]["id"]), headers=_auth(a["access_token"]))
-        client.post(FOLLOW_URL.format(user_id=c["user"]["id"]), headers=_auth(b["access_token"]))
+        client.post(FOLLOW_URL.format(username=b["user"]["username"]), headers=_auth(a["access_token"]))
+        client.post(FOLLOW_URL.format(username=c["user"]["username"]), headers=_auth(b["access_token"]))
         res = client.get(SUGGESTED_URL, headers=_auth(a["access_token"]))
         assert any(u["username"] == "userc" for u in res.json())


### PR DESCRIPTION
## Summary

- Full frontend redesign to checkd v2 design system (ink/pink tokens, Instrument Serif display font, mobile-first upload flow)
- Local S3 fallback for dev — uploads save to `/tmp/checkd-uploads/` and are served via FastAPI StaticFiles when `S3_BUCKET` is not set
- Fixed follow/unfollow endpoints to accept `username` instead of UUID path param
- Implemented notification system (issue #81): `notifications` table, 3 endpoints (`GET /notifications`, `GET /notifications/unseen-count`, `POST /notifications/seen`), wired into follow/like/comment/board join/board outfit events

## Test plan

- [ ] API CI: 194 backend tests pass (includes 11 new notification tests)
- [ ] Web CI: all 5 Playwright smoke tests pass
- [ ] Migration: `notificationtype` enum creation is idempotent (guarded with `IF NOT EXISTS`)
- [ ] Unblocks Tomi on issue #82 (notification center UI) — endpoints are live

🤖 Generated with [Claude Code](https://claude.com/claude-code)