### PR TITLE
fix: $PORT in Dockerfile + 300s healthcheck timeout

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,5 +1,5 @@
 [deploy]
 startCommand = "uvicorn app.main:app --host 0.0.0.0 --port $PORT"
 healthcheckPath = "/health"
-healthcheckTimeout = 60
+healthcheckTimeout = 300
 restartPolicyType = "on_failure"

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -11,4 +11,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}


### PR DESCRIPTION
## Summary
- Dockerfile CMD was hardcoded to `--port 8000` but Railway assigns `PORT` dynamically (usually 8080), causing health check connection refused
- Changed to shell-form CMD: `uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}` so the env var is expanded at runtime
- Bumped `healthcheckTimeout` to 300s to give Docker build + cold start enough headroom

## Root cause
Railway sets `$PORT` and health-checks that port. The app was binding to `8000`, not `$PORT` → every attempt was connection refused.