### PR TITLE
fix: start.sh entrypoint so $PORT expands in Railway

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,5 +1,4 @@
 [deploy]
-startCommand = "uvicorn app.main:app --host 0.0.0.0 --port $PORT"
 healthcheckPath = "/health"
 healthcheckTimeout = 300
 restartPolicyType = "on_failure"

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -11,4 +11,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}
+RUN chmod +x start.sh
+CMD ["./start.sh"]

--- a/services/api/start.sh
+++ b/services/api/start.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec uvicorn app.main:app --host 0.0.0.0 --port "${PORT:-8000}"


### PR DESCRIPTION
## Problem
Railway runs `startCommand` without a shell, so `$PORT` was passed as a literal string to uvicorn → `Invalid value for '--port': '$PORT' is not a valid integer`.

## Fix
- Added `start.sh` entrypoint script that runs in `/bin/sh`, so `${PORT:-8000}` always expands to a real integer
- Updated Dockerfile CMD to `["./start.sh"]` (exec form, delegates expansion to the script's shell)
- Removed `startCommand` from `railway.toml` so the Dockerfile CMD is used without any override