### PR TITLE
fix: hardcode port 8000 + EXPOSE for Railway health check

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -11,5 +11,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-RUN chmod +x start.sh
-CMD ["./start.sh"]
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Problem
App starts on port 8000 but Railway's health check was hitting a different port — connection refused.

## Fix
- `EXPOSE 8000` tells Railway exactly which port to probe
- Hardcode `--port 8000` in the Dockerfile CMD (no \$PORT shell expansion needed)
- Remove start.sh indirection

## After merging
Also go to Railway → your service → **Variables** and add `PORT=8000` so the generated domain routes to the right port.