### PR TITLE
fix: date picker, outfit delete, Strava-style share card

### DIFF
--- a/apps/web/components/outfits/outfit-detail-view.tsx
+++ b/apps/web/components/outfits/outfit-detail-view.tsx
@@ -40,6 +40,7 @@ export function OutfitDetailView({ id }: { id: string }) {
   const [likeLoading, setLikeLoading] = useState(false);
   const [showShare, setShowShare] = useState(false);
   const [showComments, setShowComments] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
     let active = true;
@@ -90,6 +91,17 @@ export function OutfitDetailView({ id }: { id: string }) {
       }
     }
     setLikeLoading(false);
+  }
+
+  async function handleDelete() {
+    if (!confirm("Delete this outfit? This can't be undone.")) return;
+    setDeleting(true);
+    const result = await apiClient.outfits.delete(id);
+    if (result.ok) {
+      router.push("/vault");
+    } else {
+      setDeleting(false);
+    }
   }
 
   // ── Not found ──
@@ -318,17 +330,20 @@ export function OutfitDetailView({ id }: { id: string }) {
                 </button>
 
                 {isOwn ? (
-                  <Link
-                    href="/vault"
-                    className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-line bg-white text-mute transition hover:border-pink-deep/30 hover:text-ink"
-                    aria-label="View in vault"
+                  <button
+                    type="button"
+                    onClick={() => void handleDelete()}
+                    disabled={deleting}
+                    className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-line bg-white text-mute transition hover:border-error/40 hover:text-error disabled:opacity-40"
+                    aria-label="Delete outfit"
                   >
                     <svg viewBox="0 0 24 24" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                      <path d="M7 7.5A2.5 2.5 0 0 1 9.5 5h5A2.5 2.5 0 0 1 17 7.5V9H7V7.5Z" />
-                      <path d="M6 9h12v9.5A2.5 2.5 0 0 1 15.5 21h-7A2.5 2.5 0 0 1 6 18.5V9Z" />
-                      <path d="M10 13h4" />
+                      <polyline points="3 6 5 6 21 6" />
+                      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                      <path d="M10 11v6M14 11v6" />
+                      <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
                     </svg>
-                  </Link>
+                  </button>
                 ) : null}
               </div>
             </div>
@@ -337,7 +352,13 @@ export function OutfitDetailView({ id }: { id: string }) {
       </main>
 
       {showShare ? (
-        <StoryCardSheet outfitId={id} onClose={() => setShowShare(false)} />
+        <StoryCardSheet
+          outfitId={id}
+          imageUrl={outfit?.image_url ?? ""}
+          wornOn={outfit?.worn_on}
+          createdAt={outfit?.created_at}
+          onClose={() => setShowShare(false)}
+        />
       ) : null}
 
       {showComments ? (

--- a/apps/web/components/outfits/story-card-sheet.tsx
+++ b/apps/web/components/outfits/story-card-sheet.tsx
@@ -1,24 +1,192 @@
 "use client";
 
-import { useState } from "react";
-import { apiClient } from "@/lib/api-client";
+import { useEffect, useRef, useState } from "react";
 
 type StoryCardSheetProps = {
   outfitId: string;
+  imageUrl: string;
+  wornOn?: string | null;
+  createdAt?: string | null;
   onClose: () => void;
 };
 
-export function StoryCardSheet({ outfitId, onClose }: StoryCardSheetProps) {
+function formatShareDate(dateStr?: string | null): string {
+  if (!dateStr) return "";
+  const d = new Date(dateStr);
+  return d.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" });
+}
+
+function roundRect(
+  ctx: CanvasRenderingContext2D,
+  x: number, y: number, w: number, h: number, r: number
+) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+}
+
+export function StoryCardSheet({ outfitId, imageUrl, wornOn, createdAt, onClose }: StoryCardSheetProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [rendered, setRendered] = useState(false);
+  const [downloading, setDownloading] = useState(false);
   const [copied, setCopied] = useState(false);
 
-  const cardUrl = apiClient.outfits.storyCardUrl(outfitId);
+  const dateLabel = formatShareDate(wornOn ?? createdAt);
   const shareLink = `${typeof window !== "undefined" ? window.location.origin : ""}/outfits/${outfitId}`;
 
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    // 1080 × 1350 — 4:5 portrait (Instagram-friendly)
+    const W = 1080;
+    const H = 1350;
+    canvas.width = W;
+    canvas.height = H;
+
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+
+    img.onload = () => {
+      // Background
+      ctx.fillStyle = "#faf7f5";
+      ctx.fillRect(0, 0, W, H);
+
+      // Cover-fit the outfit photo
+      const imgAspect = img.naturalWidth / img.naturalHeight;
+      const canvasAspect = W / H;
+      let sx = 0, sy = 0, sw = img.naturalWidth, sh = img.naturalHeight;
+      if (imgAspect > canvasAspect) {
+        sw = img.naturalHeight * canvasAspect;
+        sx = (img.naturalWidth - sw) / 2;
+      } else {
+        sh = img.naturalWidth / canvasAspect;
+        sy = (img.naturalHeight - sh) / 2;
+      }
+      ctx.drawImage(img, sx, sy, sw, sh, 0, 0, W, H);
+
+      // Bottom gradient for text legibility
+      const grad = ctx.createLinearGradient(0, H * 0.6, 0, H);
+      grad.addColorStop(0, "rgba(0,0,0,0)");
+      grad.addColorStop(1, "rgba(0,0,0,0.5)");
+      ctx.fillStyle = grad;
+      ctx.fillRect(0, 0, W, H);
+
+      // ── Branding pill — bottom-left ──────────────────────────────────
+      const PAD = 52;
+      const PILL_H = 72;
+      const PILL_PAD_X = 30;
+      const LOGO_SIZE = 40;
+      const DATE_SIZE = 27;
+      const SEP = 20;
+
+      ctx.font = `italic 400 ${LOGO_SIZE}px Georgia, serif`;
+      const logoW = ctx.measureText("checkd").width;
+      ctx.font = `400 ${DATE_SIZE}px Georgia, serif`;
+      const dateW = dateLabel ? ctx.measureText(dateLabel).width : 0;
+
+      const innerW = logoW + (dateLabel ? SEP + dateW : 0);
+      const pillW = innerW + PILL_PAD_X * 2;
+      const pillX = PAD;
+      const pillY = H - PAD - PILL_H;
+      const textY = pillY + PILL_H / 2;
+
+      // Frosted pill
+      ctx.save();
+      ctx.globalAlpha = 0.2;
+      ctx.fillStyle = "#ffffff";
+      roundRect(ctx, pillX, pillY, pillW, PILL_H, PILL_H / 2);
+      ctx.fill();
+      ctx.restore();
+
+      ctx.save();
+      ctx.globalAlpha = 0.4;
+      ctx.strokeStyle = "rgba(255,255,255,0.6)";
+      ctx.lineWidth = 1.5;
+      roundRect(ctx, pillX, pillY, pillW, PILL_H, PILL_H / 2);
+      ctx.stroke();
+      ctx.restore();
+
+      // "checkd" — italic, pink
+      ctx.save();
+      ctx.font = `italic 400 ${LOGO_SIZE}px Georgia, serif`;
+      ctx.fillStyle = "#F9A8D4";
+      ctx.textAlign = "left";
+      ctx.textBaseline = "middle";
+      ctx.fillText("checkd", pillX + PILL_PAD_X, textY);
+      ctx.restore();
+
+      // Date — white, smaller
+      if (dateLabel) {
+        ctx.save();
+        ctx.font = `400 ${DATE_SIZE}px Georgia, serif`;
+        ctx.fillStyle = "rgba(255,255,255,0.85)";
+        ctx.textAlign = "left";
+        ctx.textBaseline = "middle";
+        ctx.fillText(dateLabel, pillX + PILL_PAD_X + logoW + SEP, textY + 1);
+        ctx.restore();
+      }
+
+      setRendered(true);
+    };
+
+    img.onerror = () => {
+      ctx.fillStyle = "#F9A8D4";
+      ctx.fillRect(0, 0, W, H);
+      ctx.font = `italic 400 96px Georgia, serif`;
+      ctx.fillStyle = "#faf7f5";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText("checkd", W / 2, H / 2);
+      setRendered(true);
+    };
+
+    img.src = imageUrl;
+  }, [imageUrl, dateLabel]);
+
   function handleDownload() {
-    const a = document.createElement("a");
-    a.href = cardUrl;
-    a.download = `ootd-${outfitId.slice(0, 8)}.png`;
-    a.click();
+    const canvas = canvasRef.current;
+    if (!canvas || !rendered) return;
+    setDownloading(true);
+    canvas.toBlob((blob) => {
+      if (!blob) { setDownloading(false); return; }
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `checkd-${outfitId.slice(0, 8)}.png`;
+      a.click();
+      URL.revokeObjectURL(url);
+      setDownloading(false);
+    }, "image/png");
+  }
+
+  function handleNativeShare() {
+    const canvas = canvasRef.current;
+    if (!canvas || !rendered) return;
+    canvas.toBlob(async (blob) => {
+      if (!blob || !navigator.share) return;
+      try {
+        const file = new File([blob], "checkd-fit.png", { type: "image/png" });
+        const canShare = navigator.canShare?.({ files: [file] });
+        if (canShare) {
+          await navigator.share({ files: [file], title: "my checkd fit" });
+        } else {
+          await navigator.share({ title: "my checkd fit", url: shareLink });
+        }
+      } catch {
+        // user cancelled
+      }
+    }, "image/png");
   }
 
   async function handleCopyLink() {
@@ -27,93 +195,82 @@ export function StoryCardSheet({ outfitId, onClose }: StoryCardSheetProps) {
     setTimeout(() => setCopied(false), 2000);
   }
 
-  async function handleNativeShare() {
-    if (!navigator.share) return;
-    await navigator.share({ title: "my checkd fit", url: shareLink });
-  }
-
   const canNativeShare = typeof navigator !== "undefined" && "share" in navigator;
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-end justify-center bg-[rgba(36,21,28,0.42)] px-4 pb-4 sm:items-center sm:pb-0 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-end justify-center bg-[rgba(26,20,22,0.55)] px-4 pb-4 sm:items-center sm:pb-0 backdrop-blur-sm"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
       <div className="soft-panel w-full max-w-sm overflow-hidden">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 pt-6 pb-4">
-          <h2 className="font-display text-2xl tracking-[-0.03em] text-ink">Share look</h2>
+        <div className="flex items-center justify-between px-6 pt-5 pb-4">
+          <h2 className="font-display text-2xl tracking-[-0.03em] text-ink">share look</h2>
           <button
             type="button"
             onClick={onClose}
-            className="flex h-8 w-8 items-center justify-center rounded-full border border-rose/12 text-mute transition hover:border-rose/22 hover:text-plum"
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-line text-mute transition hover:text-ink"
           >
-            <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
               <path d="M18 6 6 18M6 6l12 12" />
             </svg>
           </button>
         </div>
 
-        {/* Story card preview */}
-        <div className="relative mx-6 mb-5 overflow-hidden rounded-[1.4rem] border border-rose/10 bg-[#0d0f14] shadow-[0_12px_40px_rgba(0,0,0,0.18)]">
-          {/* Aspect ratio wrapper — story cards are 1080×1920 (9:16) */}
-          <div className="relative aspect-[9/16] w-full">
-            <img
-              src={cardUrl}
-              alt="Story card preview"
-              className="h-full w-full object-cover"
-              loading="lazy"
+        {/* Card preview — shows the canvas at display scale */}
+        <div className="mx-6 mb-5 overflow-hidden rounded-[1.2rem] border border-line bg-pink-soft">
+          <div className="relative aspect-[4/5] w-full">
+            <canvas
+              ref={canvasRef}
+              className="h-full w-full"
+              style={{ display: rendered ? "block" : "none", objectFit: "cover" }}
             />
-            {/* Loading shimmer shown while img loads */}
-            <div className="absolute inset-0 -z-10 animate-pulse bg-[linear-gradient(135deg,_#1a1020_0%,_#2a1830_50%,_#1a1020_100%)]" />
+            {!rendered && <div className="absolute inset-0 animate-pulse bg-pink-soft" />}
           </div>
         </div>
 
         {/* Actions */}
-        <div className="space-y-3 px-6 pb-6">
-          {/* Download */}
+        <div className="space-y-2.5 px-6 pb-6">
           <button
             type="button"
             onClick={handleDownload}
-            className="btn-primary flex w-full items-center gap-3"
+            disabled={!rendered || downloading}
+            className="btn-primary w-full gap-2.5 disabled:opacity-50"
           >
-            <svg viewBox="0 0 24 24" className="h-4.5 w-4.5 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
               <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
               <polyline points="7 10 12 15 17 10" />
               <line x1="12" y1="15" x2="12" y2="3" />
             </svg>
-            Save story card
+            {downloading ? "saving…" : "save to camera roll"}
           </button>
 
-          <div className="flex gap-3">
-            {/* Copy link */}
+          <div className="flex gap-2.5">
             <button
               type="button"
               onClick={() => void handleCopyLink()}
-              className="flex flex-1 items-center justify-center gap-2 rounded-[1.2rem] border border-rose/15 bg-white py-3.5 text-sm font-semibold text-plum transition hover:border-rose/25"
+              className="flex flex-1 items-center justify-center gap-2 rounded-full border border-line bg-white py-3 text-sm font-medium text-ink-soft transition hover:border-pink-deep/40"
             >
-              <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <svg viewBox="0 0 24 24" className="h-3.5 w-3.5 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
                 <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
                 <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
               </svg>
-              {copied ? "Copied!" : "Copy link"}
+              {copied ? "copied!" : "copy link"}
             </button>
 
-            {/* Native share (mobile) */}
             {canNativeShare ? (
               <button
                 type="button"
-                onClick={() => void handleNativeShare()}
-                className="flex flex-1 items-center justify-center gap-2 rounded-[1.2rem] border border-rose/15 bg-white py-3.5 text-sm font-semibold text-plum transition hover:border-rose/25"
+                onClick={handleNativeShare}
+                disabled={!rendered}
+                className="flex flex-1 items-center justify-center gap-2 rounded-full border border-line bg-white py-3 text-sm font-medium text-ink-soft transition hover:border-pink-deep/40 disabled:opacity-50"
               >
-                <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <circle cx="18" cy="5" r="3" />
-                  <circle cx="6" cy="12" r="3" />
-                  <circle cx="18" cy="19" r="3" />
-                  <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
-                  <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+                <svg viewBox="0 0 24 24" className="h-3.5 w-3.5 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                  <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
+                  <polyline points="16 6 12 2 8 6" />
+                  <line x1="12" y1="2" x2="12" y2="15" />
                 </svg>
-                Share
+                share
               </button>
             ) : null}
           </div>

--- a/apps/web/components/upload/upload-flow.tsx
+++ b/apps/web/components/upload/upload-flow.tsx
@@ -581,10 +581,14 @@ const CURRENT_YEAR = new Date().getFullYear();
 const YEARS = Array.from({ length: CURRENT_YEAR - 2019 }, (_, i) => CURRENT_YEAR - i);
 
 function DateSelect({ value, onChange }: { value: string; onChange: (v: string) => void }) {
-  const parts = value ? value.split("-") : ["", "", ""];
-  const [y, m, d] = parts;
+  // Use local state so partial picks aren't wiped on re-render.
+  // Parent only receives a value when all three parts are filled.
+  const initial = value ? value.split("-") : ["", "", ""];
+  const [y, setY] = useState(initial[0] ?? "");
+  const [m, setM] = useState(initial[1] ?? "");
+  const [d, setD] = useState(initial[2] ?? "");
 
-  function update(nextY: string, nextM: string, nextD: string) {
+  function commit(nextY: string, nextM: string, nextD: string) {
     if (nextY && nextM && nextD) {
       onChange(`${nextY}-${nextM.padStart(2, "0")}-${nextD.padStart(2, "0")}`);
     } else if (!nextY && !nextM && !nextD) {
@@ -598,7 +602,7 @@ function DateSelect({ value, onChange }: { value: string; onChange: (v: string) 
     <div className="flex gap-2">
       <select
         value={m}
-        onChange={(e) => update(y, e.target.value, d)}
+        onChange={(e) => { setM(e.target.value); commit(y, e.target.value, d); }}
         className={selectClass}
         style={{ flex: "2" }}
       >
@@ -609,7 +613,7 @@ function DateSelect({ value, onChange }: { value: string; onChange: (v: string) 
       </select>
       <select
         value={d}
-        onChange={(e) => update(y, m, e.target.value)}
+        onChange={(e) => { setD(e.target.value); commit(y, m, e.target.value); }}
         className={selectClass}
       >
         <option value="">day</option>
@@ -619,7 +623,7 @@ function DateSelect({ value, onChange }: { value: string; onChange: (v: string) 
       </select>
       <select
         value={y}
-        onChange={(e) => update(e.target.value, m, d)}
+        onChange={(e) => { setY(e.target.value); commit(e.target.value, m, d); }}
         className={selectClass}
         style={{ flex: "1.5" }}
       >

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -595,6 +595,14 @@ export const outfitApiClient = {
     return `${DEFAULT_API_BASE_URL}/outfits/${outfitId}/story-card`;
   },
 
+  async delete(outfitId: string): Promise<ApiResult<null>> {
+    return sendRequest<null>(`/outfits/${outfitId}`, {
+      method: "DELETE",
+      requiresAuth: true,
+      successMessage: "Outfit deleted."
+    });
+  },
+
   async suggestCaptions(image: File): Promise<ApiResult<CaptionSuggestions>> {
     const formData = new FormData();
     formData.append("image", image);

--- a/services/api/app/crud/outfit.py
+++ b/services/api/app/crud/outfit.py
@@ -198,3 +198,10 @@ def get_explore(
         next_cursor = outfits[-1].created_at.isoformat()
 
     return outfits, next_cursor
+
+
+
+def delete_outfit(db: Session, outfit: "Outfit") -> None:
+    """Permanently delete an outfit and all related rows (cascade handles children)."""
+    db.delete(outfit)
+    db.commit()

--- a/services/api/app/routers/outfits.py
+++ b/services/api/app/routers/outfits.py
@@ -341,6 +341,19 @@ def get_outfit(
     )
 
 
+@router.delete("/{outfit_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_outfit(
+    outfit_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Delete an outfit. Only the owner can delete their own outfit."""
+    outfit = _outfit_or_404(db, outfit_id)
+    if outfit.user_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Cannot delete this outfit.")
+    outfit_crud.delete_outfit(db, outfit)
+
+
 # ── Likes ─────────────────────────────────────────────────────────────────────
 
 def _outfit_or_404(db: Session, outfit_id_str: str):


### PR DESCRIPTION
## Changes

### Date picker fixed
Replaced controlled selects (value from parent prop) with local `useState` per field. Previously, picking month before day caused the selection to vanish on re-render because `onChange` was only called when all three fields were filled — interim state was lost.

### Outfit delete
- `DELETE /outfits/{outfit_id}` backend endpoint (owner-only, 403 otherwise)
- `delete_outfit` CRUD helper
- `apiClient.outfits.delete()` frontend method
- Trash icon button on the detail view action row (owners only) — confirms before deleting, redirects to vault on success

### Share card redesigned (Strava-style)
- Pure client-side Canvas — no backend image generation
- Outfit photo full-bleed, cover-fit to 1080×1350 (4:5 Instagram portrait)
- Soft bottom gradient for legibility
- Frosted pill in bottom-left: **pink italic "checkd"** + date in white, nothing else
- Actions: save to camera roll (PNG download), copy link, native share (mobile)