### PR TITLE
fix: proxy S3 images for share card canvas

### DIFF
--- a/apps/web/app/api/proxy-image/route.ts
+++ b/apps/web/app/api/proxy-image/route.ts
@@ -1,0 +1,53 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+/**
+ * GET /api/proxy-image?url=<encoded-url>
+ *
+ * Fetches an image server-side and returns it with CORS headers so the
+ * client-side Canvas can draw it without being tainted. Needed because
+ * S3 buckets don't ship CORS headers by default, and setting
+ * crossOrigin="anonymous" on an <img> causes the browser to reject the
+ * response, firing onerror instead of onload.
+ */
+export async function GET(request: NextRequest) {
+  const url = request.nextUrl.searchParams.get("url");
+
+  if (!url) {
+    return new NextResponse("Missing url param", { status: 400 });
+  }
+
+  // Basic allowlist — only proxy from known S3 / CDN origins
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return new NextResponse("Invalid url", { status: 400 });
+  }
+
+  const allowed =
+    parsed.hostname.endsWith(".amazonaws.com") ||
+    parsed.hostname.endsWith(".cloudfront.net") ||
+    parsed.hostname === "cdn.example.com"; // local dev mock
+
+  if (!allowed) {
+    return new NextResponse("Origin not allowed", { status: 403 });
+  }
+
+  const upstream = await fetch(url, { cache: "force-cache" });
+
+  if (!upstream.ok) {
+    return new NextResponse("Upstream fetch failed", { status: 502 });
+  }
+
+  const contentType = upstream.headers.get("Content-Type") ?? "image/jpeg";
+  const buffer = await upstream.arrayBuffer();
+
+  return new NextResponse(buffer, {
+    status: 200,
+    headers: {
+      "Content-Type": contentType,
+      "Access-Control-Allow-Origin": "*",
+      "Cache-Control": "public, max-age=86400, immutable",
+    },
+  });
+}

--- a/apps/web/components/outfits/story-card-sheet.tsx
+++ b/apps/web/components/outfits/story-card-sheet.tsx
@@ -55,7 +55,10 @@ export function StoryCardSheet({ outfitId, imageUrl, wornOn, createdAt, onClose 
     canvas.height = H;
 
     const img = new Image();
-    img.crossOrigin = "anonymous";
+    // Load through the Next.js proxy so the image is same-origin.
+    // Direct S3 URLs fail with crossOrigin="anonymous" unless the bucket
+    // has CORS headers — the proxy adds them server-side.
+    const proxiedSrc = `/api/proxy-image?url=${encodeURIComponent(imageUrl)}`;
 
     img.onload = () => {
       // Background
@@ -151,7 +154,7 @@ export function StoryCardSheet({ outfitId, imageUrl, wornOn, createdAt, onClose 
       setRendered(true);
     };
 
-    img.src = imageUrl;
+    img.src = proxiedSrc;
   }, [imageUrl, dateLabel]);
 
   function handleDownload() {


### PR DESCRIPTION
## Problem
The share card showed a plain pink fallback instead of the outfit photo. Root cause: `crossOrigin="anonymous"` on the canvas `<img>` causes S3 to reject the request entirely (no CORS headers on the bucket) → `onerror` fires → fallback renders.

## Fix
Added `/api/proxy-image?url=<encoded>` Next.js route handler that fetches the image server-side (no browser CORS restriction) and returns it with `Access-Control-Allow-Origin: *`. The canvas now loads from the same origin, so `toBlob()` works and the share card renders the actual outfit photo.