### PR TITLE
fix: direct SQL DELETE for outfit to avoid FK nullify crash

### DIFF
--- a/services/api/app/crud/outfit.py
+++ b/services/api/app/crud/outfit.py
@@ -202,6 +202,9 @@ def get_explore(
 
 
 def delete_outfit(db: Session, outfit: "Outfit") -> None:
-    """Permanently delete an outfit and all related rows (cascade handles children)."""
-    db.delete(outfit)
+    """Permanently delete an outfit. Uses a direct SQL DELETE so SQLAlchemy
+    doesn't try to nullify the non-nullable clothing_item.outfit_id FK before
+    the row is gone — Postgres CASCADE handles child rows automatically."""
+    from sqlalchemy import delete as sql_delete
+    db.execute(sql_delete(Outfit).where(Outfit.id == outfit.id))
     db.commit()


### PR DESCRIPTION
## Root cause
`_outfit_or_404` loads the outfit via `get_outfit_with_items`, which eagerly loads `clothing_items` into the SQLAlchemy session. When `db.delete(outfit)` is then called, SQLAlchemy's ORM tries to issue `UPDATE clothing_items SET outfit_id = NULL` before the DELETE — but `outfit_id` is non-nullable, causing a constraint violation and a 500 response. The outfit appears to not delete from the user's perspective.

## Fix
Replace `db.delete(outfit)` with a direct `sqlalchemy.delete()` statement. This bypasses ORM session tracking entirely and issues a raw `DELETE FROM outfits WHERE id = ?`, letting Postgres `CASCADE` delete all child rows (clothing_items, likes, comments, notifications) atomically.