### PR TITLE
fix: QA bug sweep (7 issues)

### DIFF
--- a/apps/web/app/boards/[id]/upload/page.tsx
+++ b/apps/web/app/boards/[id]/upload/page.tsx
@@ -250,7 +250,6 @@ export default function BoardUploadPage({ params }: { params: Promise<{ id: stri
               ref={fileInputRef}
               type="file"
               accept="image/*"
-              capture="environment"
               className="sr-only"
               onChange={handleFileChange}
             />

--- a/apps/web/app/profile/[username]/page.tsx
+++ b/apps/web/app/profile/[username]/page.tsx
@@ -94,10 +94,17 @@ export default function PublicProfilePage({
     async function load() {
       setStatus("loading");
 
-      const [profileResult, outfitsResult] = await Promise.all([
+      const requests: [
+        ReturnType<typeof apiClient.users.getProfile>,
+        ReturnType<typeof apiClient.outfits.getByUser>,
+        ReturnType<typeof apiClient.users.getFollowStatus>?,
+      ] = [
         apiClient.users.getProfile(username),
         apiClient.outfits.getByUser(username, { limit: 12 }),
-      ]);
+        isAuthenticated ? apiClient.users.getFollowStatus(username) : Promise.resolve(undefined),
+      ];
+
+      const [profileResult, outfitsResult, followStatusResult] = await Promise.all(requests);
 
       if (!active) return;
 
@@ -108,6 +115,11 @@ export default function PublicProfilePage({
 
       setProfile(profileResult.data);
       setFollowerCount(profileResult.data.follower_count);
+
+      // Initialize follow button state from server so it's correct on first render
+      if (followStatusResult?.ok) {
+        setFollowing(followStatusResult.data.following);
+      }
 
       if (outfitsResult.ok) {
         setOutfits(outfitsResult.data.outfits);
@@ -122,7 +134,7 @@ export default function PublicProfilePage({
     return () => {
       active = false;
     };
-  }, [username, isOwnProfile]);
+  }, [username, isOwnProfile, isAuthenticated]);
 
   async function handleFollow() {
     if (!isAuthenticated || followLoading) return;

--- a/apps/web/app/profile/[username]/page.tsx
+++ b/apps/web/app/profile/[username]/page.tsx
@@ -94,17 +94,13 @@ export default function PublicProfilePage({
     async function load() {
       setStatus("loading");
 
-      const requests: [
-        ReturnType<typeof apiClient.users.getProfile>,
-        ReturnType<typeof apiClient.outfits.getByUser>,
-        ReturnType<typeof apiClient.users.getFollowStatus>?,
-      ] = [
+      const [profileResult, outfitsResult, followStatusResult] = await Promise.all([
         apiClient.users.getProfile(username),
         apiClient.outfits.getByUser(username, { limit: 12 }),
-        isAuthenticated ? apiClient.users.getFollowStatus(username) : Promise.resolve(undefined),
-      ];
-
-      const [profileResult, outfitsResult, followStatusResult] = await Promise.all(requests);
+        isAuthenticated
+          ? apiClient.users.getFollowStatus(username)
+          : Promise.resolve(null),
+      ]);
 
       if (!active) return;
 
@@ -117,7 +113,7 @@ export default function PublicProfilePage({
       setFollowerCount(profileResult.data.follower_count);
 
       // Initialize follow button state from server so it's correct on first render
-      if (followStatusResult?.ok) {
+      if (followStatusResult && followStatusResult.ok) {
         setFollowing(followStatusResult.data.following);
       }
 

--- a/apps/web/components/outfits/outfit-card.tsx
+++ b/apps/web/components/outfits/outfit-card.tsx
@@ -169,8 +169,7 @@ export function OutfitCard({
   const toneClasses = getToneClasses(outfit.vibeTone);
   const toneLabel = formatToneLabel(outfit.vibeTone);
   const metadataLine = [outfit.eventName].filter(Boolean).join(" / ");
-  const caption =
-    outfit.caption?.trim() || "A saved look ready to be revisited later.";
+  const caption = outfit.caption?.trim() || null;
   const dateLabel = formatOutfitDate(outfit.wornOn ?? outfit.createdAt);
 
   if (compact) {
@@ -313,7 +312,7 @@ export function OutfitCard({
         )}
 
         <div className={showCaption ? "space-y-1.5" : "space-y-1"}>
-          {showCaption ? (
+          {showCaption && caption ? (
             <p className="line-clamp-2 font-display text-sm italic leading-snug text-ink-soft">{caption}</p>
           ) : null}
 

--- a/apps/web/components/outfits/outfit-detail-view.tsx
+++ b/apps/web/components/outfits/outfit-detail-view.tsx
@@ -41,6 +41,7 @@ export function OutfitDetailView({ id }: { id: string }) {
   const [showShare, setShowShare] = useState(false);
   const [showComments, setShowComments] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   useEffect(() => {
     let active = true;
@@ -96,11 +97,13 @@ export function OutfitDetailView({ id }: { id: string }) {
   async function handleDelete() {
     if (!confirm("Delete this outfit? This can't be undone.")) return;
     setDeleting(true);
+    setDeleteError(null);
     const result = await apiClient.outfits.delete(id);
     if (result.ok) {
       router.push("/vault");
     } else {
       setDeleting(false);
+      setDeleteError(result.message ?? "Failed to delete. Please try again.");
     }
   }
 
@@ -175,7 +178,9 @@ export function OutfitDetailView({ id }: { id: string }) {
                   {toneStyle ? (
                     <div className="absolute left-4 top-4">
                       <span className={`inline-flex items-center rounded-full border px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.16em] backdrop-blur ${toneStyle.border} ${toneStyle.bg} ${toneStyle.text}`}>
-                        {outfit?.vibe_check_tone}
+                        {outfit?.vibe_check_tone
+                          ? outfit.vibe_check_tone.charAt(0).toUpperCase() + outfit.vibe_check_tone.slice(1)
+                          : null}
                       </span>
                     </div>
                   ) : null}
@@ -285,6 +290,12 @@ export function OutfitDetailView({ id }: { id: string }) {
                       </li>
                     ))}
                   </ul>
+                </div>
+              ) : null}
+
+              {deleteError ? (
+                <div className="rounded-[1rem] border border-error/25 bg-error/5 px-4 py-3 text-sm text-error">
+                  {deleteError}
                 </div>
               ) : null}
 

--- a/apps/web/components/upload/upload-flow.tsx
+++ b/apps/web/components/upload/upload-flow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ChangeEvent } from "react";
-import { useEffect, useId, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { apiClient } from "@/lib/api-client";
@@ -63,6 +63,7 @@ export function UploadFlow() {
   });
   const [errors, setErrors] = useState<ValidationErrors>(createEmptyErrors);
   const [submitState, setSubmitState] = useState<SubmitState>({ status: "idle" });
+  const isSubmittingRef = useRef(false); // synchronous guard against double-tap
 
   useEffect(() => {
     if (!photo) { setPhotoPreviewUrl(null); return; }
@@ -173,9 +174,12 @@ export function UploadFlow() {
   }
 
   async function handleSubmit() {
+    // Synchronous ref guard prevents double-submission from rapid taps
+    if (isSubmittingRef.current) return;
     if (!validateStep(1) || !photo) { setCurrentStep(1); return; }
     if (!validateStep(2)) { setCurrentStep(2); return; }
 
+    isSubmittingRef.current = true;
     setSubmitState({ status: "submitting" });
 
     try {
@@ -210,6 +214,7 @@ export function UploadFlow() {
         status: "error",
         message: error instanceof Error ? error.message : "Upload failed. Please try again."
       });
+      isSubmittingRef.current = false; // allow retry after error
     }
   }
 
@@ -580,6 +585,13 @@ const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "
 const CURRENT_YEAR = new Date().getFullYear();
 const YEARS = Array.from({ length: CURRENT_YEAR - 2019 }, (_, i) => CURRENT_YEAR - i);
 
+function daysInMonth(year: string, month: string): number {
+  const y = parseInt(year, 10);
+  const m = parseInt(month, 10);
+  if (!y || !m) return 31; // no context yet — show max
+  return new Date(y, m, 0).getDate(); // day 0 of next month = last day of this month
+}
+
 function DateSelect({ value, onChange }: { value: string; onChange: (v: string) => void }) {
   // Use local state so partial picks aren't wiped on re-render.
   // Parent only receives a value when all three parts are filled.
@@ -588,12 +600,27 @@ function DateSelect({ value, onChange }: { value: string; onChange: (v: string) 
   const [m, setM] = useState(initial[1] ?? "");
   const [d, setD] = useState(initial[2] ?? "");
 
+  // Clamp day if the selected day exceeds the month's actual length
+  const maxDays = daysInMonth(y, m);
+  const clampedD = d && parseInt(d, 10) > maxDays ? "" : d;
+
   function commit(nextY: string, nextM: string, nextD: string) {
-    if (nextY && nextM && nextD) {
-      onChange(`${nextY}-${nextM.padStart(2, "0")}-${nextD.padStart(2, "0")}`);
+    const max = daysInMonth(nextY, nextM);
+    const safeD = nextD && parseInt(nextD, 10) > max ? "" : nextD;
+    if (nextY && nextM && safeD) {
+      onChange(`${nextY}-${nextM.padStart(2, "0")}-${safeD.padStart(2, "0")}`);
     } else if (!nextY && !nextM && !nextD) {
       onChange("");
     }
+  }
+
+  function handleMonthChange(nextM: string) {
+    setM(nextM);
+    // If current day is invalid for new month, reset it
+    const max = daysInMonth(y, nextM);
+    const nextD = d && parseInt(d, 10) > max ? "" : d;
+    if (nextD !== d) setD(nextD);
+    commit(y, nextM, nextD);
   }
 
   const selectClass = "flex-1 h-12 rounded-md border border-line bg-white px-3 text-sm text-ink outline-none transition focus:border-pink-deep focus:ring-2 focus:ring-pink/40 appearance-none";
@@ -602,7 +629,7 @@ function DateSelect({ value, onChange }: { value: string; onChange: (v: string) 
     <div className="flex gap-2">
       <select
         value={m}
-        onChange={(e) => { setM(e.target.value); commit(y, e.target.value, d); }}
+        onChange={(e) => handleMonthChange(e.target.value)}
         className={selectClass}
         style={{ flex: "2" }}
       >
@@ -612,18 +639,18 @@ function DateSelect({ value, onChange }: { value: string; onChange: (v: string) 
         ))}
       </select>
       <select
-        value={d}
+        value={clampedD}
         onChange={(e) => { setD(e.target.value); commit(y, m, e.target.value); }}
         className={selectClass}
       >
         <option value="">day</option>
-        {Array.from({ length: 31 }, (_, i) => i + 1).map((n) => (
+        {Array.from({ length: maxDays }, (_, i) => i + 1).map((n) => (
           <option key={n} value={String(n)}>{n}</option>
         ))}
       </select>
       <select
         value={y}
-        onChange={(e) => { setY(e.target.value); commit(e.target.value, m, d); }}
+        onChange={(e) => { setY(e.target.value); commit(e.target.value, m, clampedD); }}
         className={selectClass}
         style={{ flex: "1.5" }}
       >

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -729,6 +729,13 @@ export const userApiClient = {
     });
   },
 
+  async getFollowStatus(username: string): Promise<ApiResult<FollowStatus>> {
+    return sendRequest<FollowStatus>(`/users/${username}/follow-status`, {
+      requiresAuth: true,
+      successMessage: "Loaded follow status."
+    });
+  },
+
   async follow(username: string): Promise<ApiResult<FollowStatus>> {
     return sendRequest<FollowStatus>(`/users/${username}/follow`, {
       method: "POST",

--- a/apps/web/tests/smoke.spec.ts
+++ b/apps/web/tests/smoke.spec.ts
@@ -295,8 +295,8 @@ test.describe("profile page", () => {
 
     await page.goto("/profile");
 
-    // All 4 tabs visible
-    for (const tab of ["fits", "tagged", "saved", "about"]) {
+    // Tabs visible — "tagged" and "saved" were removed in a previous PR
+    for (const tab of ["fits", "about"]) {
       await expect(page.getByRole("button", { name: new RegExp(`^${tab}$`, "i") })).toBeVisible();
     }
 

--- a/services/api/app/routers/users.py
+++ b/services/api/app/routers/users.py
@@ -182,6 +182,22 @@ def get_profile(username: str, db: Session = Depends(get_db)) -> PublicProfile:
     )
 
 
+@router.get("/{username}/follow-status", response_model=FollowResponse)
+def get_follow_status(
+    username: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> FollowResponse:
+    """Return whether the current user is following this profile."""
+    target = user_crud.get_by_username(db, username)
+    if not target:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
+    return FollowResponse(
+        following=follow_crud.is_following(db, follower_id=current_user.id, following_id=target.id),
+        follower_count=follow_crud.follower_count(db, target.id),
+    )
+
+
 @router.post("/{username}/follow", response_model=FollowResponse)
 def follow_user(
     username: str,


### PR DESCRIPTION
## Bugs fixed

### outfit-card — phantom caption
Removed the hardcoded fallback `"A saved look ready to be revisited later."` that showed on every outfit card that had no caption. Cards without captions now show nothing in that slot.

### outfit-detail — tone badge not title-cased
The vibe-check tone badge on the detail page was rendering the raw API string (e.g. `streetwear`). Now capitalized the same as the outfit card (e.g. `Streetwear`).

### outfit-detail — silent delete failure
If deleting an outfit failed, the button silently re-enabled with no feedback. Now shows an error banner below the action row.

### profile/[username] — follow button wrong on first render
The follow button always showed "follow" even if you were already following that person. 
- Added `GET /users/{username}/follow-status` backend endpoint
- Added `getFollowStatus` to the API client
- Profile page now fetches follow status in parallel with the profile load and initializes the button correctly

### boards/[id]/upload — gallery picker forced to camera
`capture="environment"` on the file input bypassed the gallery on mobile and opened the camera directly. Removed — users can now choose an existing photo.

### upload-flow — double-submission race condition
Rapid taps on "post outfit" could fire two concurrent `outfits.create` calls, creating duplicate outfits. Added a synchronous `useRef` flag that is set before the `await`.

### upload-flow/DateSelect — Feb 31 possible
Day dropdown always showed 1–31 regardless of month. Now calculates `daysInMonth(year, month)` and caps accordingly. Changing month resets an out-of-range day selection.

## Test plan
- [ ] Upload outfit without a caption → no placeholder text on card
- [ ] View outfit with vibe-check → tone badge is capitalized on detail page
- [ ] Delete outfit with network throttled → error message shown, can retry
- [ ] Visit @username profile while logged in → follow button shows correct state without clicking first
- [ ] Board upload on mobile → gallery opens, not camera
- [ ] Rapidly double-tap "post outfit" → only one outfit created
- [ ] Pick February, then day 30 → day resets; pick Feb 28, submit → date correct