### PR TITLE
fix(pre-launch): 10 QA bugs fixed before 100-user launch

### DIFF
--- a/apps/web/app/boards/[id]/page.tsx
+++ b/apps/web/app/boards/[id]/page.tsx
@@ -111,6 +111,7 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [leaveLoading, setLeaveLoading] = useState(false);
+  const [deleteLoading, setDeleteLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
@@ -276,20 +277,30 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
             ) : null}
 
             {/* Leave / delete */}
-            <div className="mt-4 flex gap-2 border-t border-line/60 pt-4">
+            <div className="mt-4 flex flex-col gap-2 border-t border-line/60 pt-4">
+              {errorMessage && !deleteLoading ? (
+                <p className="text-[0.72rem] text-error">{errorMessage}</p>
+              ) : null}
               {isCreator ? (
-                <Link
-                  href="/boards"
-                  className="text-[0.72rem] text-mute transition hover:text-error"
-                  onClick={async (e) => {
-                    e.preventDefault();
+                <button
+                  type="button"
+                  disabled={deleteLoading}
+                  className="w-fit text-[0.72rem] text-mute transition hover:text-error disabled:opacity-50"
+                  onClick={async () => {
                     if (!confirm("Delete this board and all its content?")) return;
-                    await apiClient.boards.delete(id);
-                    router.replace("/boards");
+                    setDeleteLoading(true);
+                    setErrorMessage(null);
+                    const result = await apiClient.boards.delete(id);
+                    if (result.ok) {
+                      router.replace("/boards");
+                    } else {
+                      setErrorMessage(result.message ?? "Failed to delete. Please try again.");
+                      setDeleteLoading(false);
+                    }
                   }}
                 >
-                  Delete board
-                </Link>
+                  {deleteLoading ? "Deleting…" : "Delete board"}
+                </button>
               ) : (
                 <button
                   type="button"

--- a/apps/web/app/boards/join/[code]/page.tsx
+++ b/apps/web/app/boards/join/[code]/page.tsx
@@ -68,6 +68,13 @@ export default function JoinBoardPage({ params }: { params: Promise<{ code: stri
     if (result.ok) {
       router.replace(`/boards/${result.data.id}`);
     } else {
+      // If the user is already a member, just take them to the board —
+      // no need to show an error. We have the board ID from the preview.
+      const msg = result.message?.toLowerCase() ?? "";
+      if ((result.status === 409 || msg.includes("already")) && board) {
+        router.replace(`/boards/${board.id}`);
+        return;
+      }
       setJoining(false);
       setJoinError(result.message);
     }

--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -154,6 +154,7 @@ export default function ExplorePage() {
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [gridStatus, setGridStatus] = useState<"idle" | "loading" | "ready" | "error">("idle");
   const [loadingMore, setLoadingMore] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
 
   const [suggested, setSuggested] = useState<UserSearchResult[]>([]);
   const [suggestedLoading, setSuggestedLoading] = useState(true);
@@ -180,7 +181,7 @@ export default function ExplorePage() {
     });
 
     return () => { active = false; };
-  }, [isAuthenticated, isLoading]);
+  }, [isAuthenticated, isLoading, reloadKey]);
 
   // Load suggested users
   useEffect(() => {
@@ -340,7 +341,7 @@ export default function ExplorePage() {
               <p className="text-sm text-mute">Couldn&rsquo;t load outfits. Try refreshing.</p>
               <button
                 type="button"
-                onClick={() => router.refresh()}
+                onClick={() => setReloadKey((k) => k + 1)}
                 className="mt-4 rounded-full border border-line bg-white px-4 py-2.5 text-sm font-semibold text-ink-soft transition hover:border-pink-deep/25"
               >
                 Refresh

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-[100dvh] flex-col items-center justify-center px-5">
+      <div className="w-full max-w-[360px] text-center">
+        <p className="font-display italic text-4xl text-pink-deep mb-8">checkd</p>
+        <div className="soft-panel px-6 py-10">
+          <p className="font-display text-6xl text-ink/10 mb-4">404</p>
+          <h1 className="font-display text-2xl tracking-[-0.03em] text-ink mb-2">
+            page not found
+          </h1>
+          <p className="text-sm leading-6 text-ink-soft mb-6">
+            This page doesn&apos;t exist or was moved.
+          </p>
+          <Link href="/feed" className="btn-primary w-full">
+            go to feed
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { apiClient, type UserSearchResult } from "@/lib/api-client";
 import { useAuth } from "@/lib/auth-context";
 
@@ -221,6 +221,7 @@ const STEPS = 3;
 
 export default function OnboardingPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { isAuthenticated, isLoading } = useAuth();
   const [step, setStep] = useState(0);
   const [follows, setFollows] = useState<FollowMap>({});
@@ -240,7 +241,10 @@ export default function OnboardingPage() {
     if (typeof window !== "undefined") {
       localStorage.setItem(STORAGE_KEY, "true");
     }
-    router.replace("/feed");
+    // If the user arrived here from a board invite (or any other ?next= flow),
+    // send them there instead of the generic feed.
+    const next = searchParams.get("next");
+    router.replace(next ?? "/feed");
   }
 
   function skip() {

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Suspense } from "react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -215,11 +216,11 @@ function StepUpload({ onDone }: { onDone: () => void }) {
   );
 }
 
-// ── Page ──────────────────────────────────────────────────────────────────────
+// ── Page (inner — uses useSearchParams, must be inside Suspense) ──────────────
 
 const STEPS = 3;
 
-export default function OnboardingPage() {
+function OnboardingInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { isAuthenticated, isLoading } = useAuth();
@@ -307,5 +308,21 @@ export default function OnboardingPage() {
         )}
       </div>
     </main>
+  );
+}
+
+// ── Page (exported — wraps inner in Suspense for Next.js static prerender) ────
+
+export default function OnboardingPage() {
+  return (
+    <Suspense
+      fallback={
+        <main className="flex min-h-screen items-center justify-center bg-paper px-4">
+          <p className="font-display text-5xl text-pink-deep">checkd</p>
+        </main>
+      }
+    >
+      <OnboardingInner />
+    </Suspense>
   );
 }

--- a/apps/web/app/vault/page.tsx
+++ b/apps/web/app/vault/page.tsx
@@ -17,24 +17,6 @@ const INITIAL_PAGE_SIZE = 12;
 type VaultStatus = "idle" | "loading" | "ready" | "error";
 type LikeMap = Record<string, { liked: boolean; count: number }>;
 
-function matchesSearch(outfit: OutfitResponse, query: string): boolean {
-  if (!query.trim()) return true;
-  const q = query.trim().toLowerCase();
-  const items = outfit.clothing_items ?? [];
-  return (
-    outfit.caption?.toLowerCase().includes(q) === true ||
-    outfit.event_name?.toLowerCase().includes(q) === true ||
-    outfit.vibe_check_tone?.toLowerCase().includes(q) === true ||
-    outfit.vibe_check_text?.toLowerCase().includes(q) === true ||
-    items.some(
-      (i) =>
-        i.brand?.toLowerCase().includes(q) ||
-        i.category?.toLowerCase().includes(q) ||
-        i.color?.toLowerCase().includes(q)
-    )
-  );
-}
-
 function toCardData(outfit: OutfitResponse): OutfitCardData {
   return {
     id: outfit.id,
@@ -77,6 +59,12 @@ export default function VaultPage() {
 
   // Like state
   const [likes, setLikes] = useState<LikeMap>({});
+
+  // Search state — uses the backend searchVault endpoint so all outfits are searched,
+  // not just the currently loaded page. Debounced 300ms.
+  const [searchResults, setSearchResults] = useState<OutfitResponse[] | null>(null);
+  const [searchLoading, setSearchLoading] = useState(false);
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -144,6 +132,30 @@ export default function VaultPage() {
   }, [nextCursor, loadingMore, vaultStatus]);
 
   const sentinelRef = useSentinel(() => { void loadMore(); });
+
+  // Debounced API search — fires 300ms after the user stops typing.
+  // When query is empty, clears results so the paginated list shows instead.
+  useEffect(() => {
+    if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    if (!searchQuery.trim()) {
+      setSearchResults(null);
+      setSearchLoading(false);
+      return;
+    }
+    setSearchLoading(true);
+    searchTimerRef.current = setTimeout(async () => {
+      const result = await apiClient.outfits.searchVault(searchQuery.trim(), 50);
+      setSearchLoading(false);
+      if (result.ok) {
+        setSearchResults(result.data);
+      } else {
+        setSearchResults([]);
+      }
+    }, 300);
+    return () => {
+      if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    };
+  }, [searchQuery]);
 
   async function handleLike(outfitId: string) {
     const current = likes[outfitId];
@@ -255,29 +267,44 @@ export default function VaultPage() {
             </div>
           ) : null}
 
-          {(() => {
-            const filtered = outfits.filter((o) => matchesSearch(o, searchQuery));
-            if (vaultStatus === "ready" && outfits.length > 0 && filtered.length === 0) {
-              return (
-                <div className="px-5 py-10 text-center">
-                  <p className="font-display text-2xl text-ink">no matches.</p>
-                  <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-ink-soft">
-                    try searching by brand, event, color, or vibe.
-                  </p>
-                  <button
-                    type="button"
-                    onClick={() => setSearchQuery("")}
-                    className="mt-5 text-sm text-pink-deep hover:underline"
-                  >
-                    clear search
-                  </button>
-                </div>
-              );
-            }
-            return null;
-          })()}
+          {/* Search results — API-powered, shows all matching outfits across the full vault */}
+          {searchQuery.trim() ? (
+            searchLoading ? (
+              <div className="grid grid-cols-3 gap-px bg-line">
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <div key={i} className="aspect-[3/4] w-full animate-pulse bg-pink-soft skeleton-stripe" />
+                ))}
+              </div>
+            ) : searchResults !== null && searchResults.length === 0 ? (
+              <div className="px-5 py-10 text-center">
+                <p className="font-display text-2xl text-ink">no matches.</p>
+                <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-ink-soft">
+                  try searching by brand, event, color, or vibe.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setSearchQuery("")}
+                  className="mt-5 text-sm text-pink-deep hover:underline"
+                >
+                  clear search
+                </button>
+              </div>
+            ) : searchResults !== null ? (
+              <div className="grid grid-cols-3 gap-px bg-line">
+                {searchResults.map((outfit) => (
+                  <OutfitCard
+                    key={outfit.id}
+                    outfit={toCardData(outfit)}
+                    compact
+                    liked={likes[outfit.id]?.liked}
+                    onLike={(e) => { e.preventDefault(); void handleLike(outfit.id); }}
+                  />
+                ))}
+              </div>
+            ) : null
+          ) : null}
 
-          {vaultStatus === "ready" && outfits.length === 0 ? (
+          {vaultStatus === "ready" && outfits.length === 0 && !searchQuery.trim() ? (
             <div className="px-5 py-16 text-center">
               <p className="font-display text-2xl text-ink">your archive is ready.</p>
               <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-ink-soft">
@@ -291,10 +318,10 @@ export default function VaultPage() {
             </div>
           ) : null}
 
-          {vaultStatus === "ready" && outfits.length > 0 ? (
+          {vaultStatus === "ready" && outfits.length > 0 && !searchQuery.trim() ? (
             <>
               <div className="grid grid-cols-3 gap-px bg-line">
-                {outfits.filter((o) => matchesSearch(o, searchQuery)).map((outfit) => (
+                {outfits.map((outfit) => (
                   <OutfitCard
                     key={outfit.id}
                     outfit={toCardData(outfit)}

--- a/apps/web/components/auth/auth-form.tsx
+++ b/apps/web/components/auth/auth-form.tsx
@@ -87,7 +87,11 @@ export function AuthForm({ mode, next }: AuthFormProps) {
     if (result.ok) {
       setErrors({});
       setSubmitState({ status: "idle" });
-      router.replace(mode === "signup" ? "/onboarding" : (next ?? "/feed"));
+      router.replace(
+        mode === "signup"
+          ? (next ? `/onboarding?next=${encodeURIComponent(next)}` : "/onboarding")
+          : (next ?? "/feed")
+      );
       return;
     }
 

--- a/apps/web/components/chrome/desktop-nav.tsx
+++ b/apps/web/components/chrome/desktop-nav.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useAuth } from "@/lib/auth-context";
 
-const AUTH_PATHS = ["/login", "/signup", "/onboarding", "/forgot-password"];
+const AUTH_PATHS = ["/login", "/signup", "/onboarding", "/forgot-password", "/upload"];
 
 const NAV_LINKS = [
   { href: "/feed", label: "feed" },

--- a/apps/web/components/outfits/outfit-detail-view.tsx
+++ b/apps/web/components/outfits/outfit-detail-view.tsx
@@ -49,6 +49,7 @@ function CommentsSection({ outfitId }: { outfitId: string }) {
   const [newBody, setNewBody] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -83,10 +84,13 @@ function CommentsSection({ outfitId }: { outfitId: string }) {
     e.preventDefault();
     if (!newBody.trim() || submitting || !isAuthenticated) return;
     setSubmitting(true);
+    setSubmitError(null);
     const result = await apiClient.outfits.createComment(outfitId, newBody.trim());
     if (result.ok) {
       setComments((prev) => [result.data, ...prev]);
       setNewBody("");
+    } else {
+      setSubmitError(result.message ?? "Failed to post comment. Please try again.");
     }
     setSubmitting(false);
   }
@@ -111,11 +115,16 @@ function CommentsSection({ outfitId }: { outfitId: string }) {
       {/* Compose box */}
       {isAuthenticated ? (
         <form onSubmit={(e) => void handleSubmit(e)} className="mb-5">
+          {submitError ? (
+            <p className="mb-2 rounded-xl border border-error/20 bg-error/5 px-3 py-2 text-xs text-error">
+              {submitError}
+            </p>
+          ) : null}
           <div className="flex items-end gap-2">
             <textarea
               ref={inputRef}
               value={newBody}
-              onChange={(e) => setNewBody(e.target.value)}
+              onChange={(e) => { setNewBody(e.target.value); if (submitError) setSubmitError(null); }}
               onKeyDown={(e) => {
                 if (e.key === "Enter" && !e.shiftKey) {
                   e.preventDefault();
@@ -200,8 +209,11 @@ function CommentRow({ comment, isOwn, editing, onStartEdit, onCancelEdit, onSave
   async function handleSave() {
     if (!editBody.trim() || saving) return;
     setSaving(true);
-    await onSaveEdit(editBody.trim());
-    setSaving(false);
+    try {
+      await onSaveEdit(editBody.trim());
+    } finally {
+      setSaving(false);
+    }
   }
 
   return (
@@ -345,7 +357,15 @@ export function OutfitDetailView({ id }: { id: string }) {
           <header className="mb-5 flex items-center justify-between">
             <button
               type="button"
-              onClick={() => router.back()}
+              onClick={() => {
+                // If there's browser history, go back. Otherwise fall back to /feed
+                // so users who opened a shared link don't end up on an external page.
+                if (typeof window !== "undefined" && window.history.length > 1) {
+                  router.back();
+                } else {
+                  router.push("/feed");
+                }
+              }}
               className="flex items-center gap-2 rounded-full border border-line bg-white px-4 py-2 text-sm font-medium text-ink-soft transition hover:border-pink-deep/30 hover:text-ink"
             >
               <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -465,7 +465,8 @@ async function sendRequest<T>(
     }
 
     if (typeof window !== "undefined") {
-      window.location.assign("/login");
+      const next = encodeURIComponent(window.location.pathname + window.location.search);
+      window.location.assign(`/login?next=${next}`);
     }
 
     return {


### PR DESCRIPTION
## Summary

All 10 issues surfaced in the pre-launch QA audit are fixed in this PR.

**Critical / High (must-fix before launch)**
- **Board delete** — now has a loading state, checks `result.ok`, and only navigates on success. Previously it navigated unconditionally even when the API returned an error.
- **Vault search** — replaced the local `matchesSearch` filter (which only searched the loaded page) with a debounced call to the `searchVault` API endpoint, so the full vault is searched regardless of pagination state.
- **Back button** — falls back to `/feed` when `window.history.length <= 1`, fixing the case where users opened a shared outfit link directly and tapping back sent them to an external site.
- **Signup `?next=`** — the `next` param is now encoded into the `/onboarding` URL and honoured in `finish()`, so new users who sign up from a board invite land in the board instead of the feed.
- **Session expiry redirect** — the `/login` redirect now includes `?next=<current path>` so users land back where they were after re-authenticating.

**High / Medium (honorable mentions)**
- **Comment errors** — submit failure is shown with an inline error banner; the edit save button uses `try/finally` so it never gets permanently stuck in "saving…"
- **Board join already-a-member** — 409 / "already" responses now silently redirect to the board instead of showing a raw API error string
- **Explore refresh button** — replaced broken `router.refresh()` (which doesn't re-run client `useEffect` hooks) with a `reloadKey` state that re-triggers the load effect
- **Global 404 page** — added `app/not-found.tsx` with checkd branding; previously any bad URL showed the bare Next.js default
- **Desktop nav on upload** — added `/upload` to `AUTH_PATHS` so the desktop nav is hidden on the upload page, preventing a double-header

## Test plan

- [ ] Board delete → button shows "Deleting…", API error shows inline, does not navigate away on failure
- [ ] Vault search → typing a brand/color finds outfits past the first 12 (full-DB search)
- [ ] Open a shared outfit URL directly → back button goes to `/feed`, not an external site
- [ ] Sign up from a board invite link (`/signup?next=/boards/join/<code>`) → after onboarding, lands on the join page
- [ ] Let a session expire mid-task → redirected to `/login?next=<current path>`, lands back after login
- [ ] Post a comment while offline → error banner appears under the compose box
- [ ] Edit a comment → cancel always works even if save fails
- [ ] Open a board invite link a second time (already a member) → silently redirected to the board
- [ ] Explore page error state → Refresh button reloads the grid
- [ ] Navigate to `/this-does-not-exist` → shows branded 404 page
- [ ] Open `/upload` on desktop → only one nav bar visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)