### PR TITLE
feat: vibe check on story card, one-sentence vibe, back buttons

### DIFF
--- a/apps/web/app/search/page.tsx
+++ b/apps/web/app/search/page.tsx
@@ -210,11 +210,27 @@ export default function SearchPage() {
       <div className="mx-auto max-w-lg">
 
         {/* ── Header ─────────────────────────────────────────────────────── */}
-        <header className="mb-5">
-          <p className="font-display text-[2.2rem] leading-none text-pink-deep">
-            checkd
-          </p>
-          <p className="mt-1 text-sm text-mute">Find people</p>
+        <header className="mb-5 flex items-center justify-between">
+          <div>
+            <p className="font-display text-[2.2rem] leading-none text-pink-deep">checkd</p>
+            <p className="mt-1 text-sm text-mute">Find people</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              if (typeof window !== "undefined" && window.history.length > 1) {
+                router.back();
+              } else {
+                router.push("/feed");
+              }
+            }}
+            className="flex items-center gap-1.5 rounded-full border border-line bg-white px-4 py-2 text-sm font-medium text-ink-soft transition hover:border-pink-deep/30 hover:text-ink"
+          >
+            <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="m15 18-6-6 6-6" />
+            </svg>
+            back
+          </button>
         </header>
 
         {/* ── Search bar ─────────────────────────────────────────────────── */}

--- a/apps/web/components/outfits/outfit-detail-view.tsx
+++ b/apps/web/components/outfits/outfit-detail-view.tsx
@@ -23,6 +23,12 @@ const TONE_BADGE: Record<string, { bg: string; text: string; border: string }> =
   vintage:    { bg: "bg-orange-100/85",  text: "text-orange-900",  border: "border-orange-300/75" },
 };
 
+/** Trim AI-generated vibe text to the first sentence for a tighter display. */
+function firstSentence(text: string): string {
+  const m = text.match(/^.+?[.!?](?:\s|$)/);
+  return m ? m[0].trim() : text;
+}
+
 function formatDate(d?: string | null) {
   if (!d) return null;
   return new Intl.DateTimeFormat("en-US", { month: "long", day: "numeric", year: "numeric" }).format(new Date(d));
@@ -444,7 +450,7 @@ export function OutfitDetailView({ id }: { id: string }) {
                     {outfit?.vibe_check_text ? (
                       <div className="rounded-[1rem] border border-line bg-pink-soft px-4 py-3">
                         <p className="mb-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-pink-deep">Vibe check</p>
-                        <p className="text-sm leading-6 text-ink-soft">{outfit.vibe_check_text}</p>
+                        <p className="text-sm leading-6 text-ink-soft">{firstSentence(outfit.vibe_check_text)}</p>
                       </div>
                     ) : null}
                   </>
@@ -536,6 +542,8 @@ export function OutfitDetailView({ id }: { id: string }) {
           imageUrl={outfit?.image_url ?? ""}
           wornOn={outfit?.worn_on}
           createdAt={outfit?.created_at}
+          vibeCheckText={outfit?.vibe_check_text}
+          vibeCheckTone={outfit?.vibe_check_tone}
           onClose={() => setShowShare(false)}
         />
       ) : null}

--- a/apps/web/components/outfits/story-card-sheet.tsx
+++ b/apps/web/components/outfits/story-card-sheet.tsx
@@ -7,8 +7,48 @@ type StoryCardSheetProps = {
   imageUrl: string;
   wornOn?: string | null;
   createdAt?: string | null;
+  vibeCheckText?: string | null;
+  vibeCheckTone?: string | null;
   onClose: () => void;
 };
+
+// Tone accent colours — match the Python story_card.py palette
+const TONE_ACCENT: Record<string, string> = {
+  athletic:   "#22d3ee",
+  boho:       "#c084fc",
+  business:   "#93c5fd",
+  casual:     "#60a5fa",
+  formal:     "#fbbf24",
+  maximalist: "#f472b6",
+  minimalist: "#cbd5e1",
+  preppy:     "#4ade80",
+  streetwear: "#fb7185",
+  vintage:    "#fb923c",
+};
+
+/** Wrap text to fit maxWidth on a canvas context. Returns array of lines. */
+function wrapLines(ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string[] {
+  const words = text.split(" ");
+  const lines: string[] = [];
+  let line = "";
+  for (const word of words) {
+    const test = line ? `${line} ${word}` : word;
+    if (ctx.measureText(test).width > maxWidth && line) {
+      lines.push(line);
+      line = word;
+    } else {
+      line = test;
+    }
+  }
+  if (line) lines.push(line);
+  return lines;
+}
+
+/** Extract the first sentence from a vibe check string. */
+function firstSentence(text: string): string {
+  const m = text.match(/^.+?[.!?](?:\s|$)/);
+  return m ? m[0].trim() : text;
+}
 
 function formatShareDate(dateStr?: string | null): string {
   if (!dateStr) return "";
@@ -33,7 +73,7 @@ function roundRect(
   ctx.closePath();
 }
 
-export function StoryCardSheet({ outfitId, imageUrl, wornOn, createdAt, onClose }: StoryCardSheetProps) {
+export function StoryCardSheet({ outfitId, imageUrl, wornOn, createdAt, vibeCheckText, vibeCheckTone, onClose }: StoryCardSheetProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [rendered, setRendered] = useState(false);
   const [downloading, setDownloading] = useState(false);
@@ -85,8 +125,78 @@ export function StoryCardSheet({ outfitId, imageUrl, wornOn, createdAt, onClose 
       ctx.fillStyle = grad;
       ctx.fillRect(0, 0, W, H);
 
-      // ── Branding pill — bottom-left ──────────────────────────────────
+      // ── Vibe check — above branding pill ─────────────────────────────
       const PAD = 52;
+      const VIBE_MAX_W = W - PAD * 2;
+
+      if (vibeCheckText || vibeCheckTone) {
+        const vibe = vibeCheckText ? firstSentence(vibeCheckText) : null;
+        const accentColor = TONE_ACCENT[(vibeCheckTone ?? "").toLowerCase()] ?? "rgba(255,255,255,0.7)";
+
+        // Measure how many lines the vibe text needs so we can position from the bottom up
+        let vibeLineCount = 0;
+        if (vibe) {
+          ctx.font = `italic 400 34px Georgia, serif`;
+          vibeLineCount = wrapLines(ctx, vibe, VIBE_MAX_W).length;
+        }
+
+        const TONE_H   = vibeCheckTone ? 44 : 0;
+        const VIBE_H   = vibeLineCount * 42;
+        const BLOCK_H  = TONE_H + (TONE_H && VIBE_H ? 14 : 0) + VIBE_H;
+        const PILL_H   = 72;
+        const PILL_GAP = 24;
+
+        // Start block this many pixels above the pill
+        let vy = H - PAD - PILL_H - PILL_GAP - BLOCK_H;
+
+        // Tone badge
+        if (vibeCheckTone) {
+          ctx.save();
+          ctx.font = `600 22px -apple-system, sans-serif`;
+          const badgeText = vibeCheckTone.toUpperCase();
+          const bw = ctx.measureText(badgeText).width;
+          const bpad = 14;
+          const bh = 32;
+          // Badge background
+          ctx.globalAlpha = 0.18;
+          ctx.fillStyle = accentColor;
+          const rx = PAD, ry = vy;
+          ctx.beginPath();
+          ctx.roundRect(rx, ry, bw + bpad * 2, bh, bh / 2);
+          ctx.fill();
+          ctx.globalAlpha = 1;
+          // Badge border
+          ctx.strokeStyle = accentColor;
+          ctx.lineWidth = 1.5;
+          ctx.beginPath();
+          ctx.roundRect(rx, ry, bw + bpad * 2, bh, bh / 2);
+          ctx.stroke();
+          // Badge text
+          ctx.fillStyle = accentColor;
+          ctx.textAlign = "left";
+          ctx.textBaseline = "middle";
+          ctx.fillText(badgeText, rx + bpad, ry + bh / 2);
+          ctx.restore();
+          vy += bh + 14;
+        }
+
+        // Vibe text
+        if (vibe) {
+          ctx.save();
+          ctx.font = `italic 400 34px Georgia, serif`;
+          ctx.fillStyle = "rgba(255,255,255,0.92)";
+          ctx.textAlign = "left";
+          ctx.textBaseline = "top";
+          const lines = wrapLines(ctx, vibe, VIBE_MAX_W);
+          for (const line of lines) {
+            ctx.fillText(line, PAD, vy);
+            vy += 42;
+          }
+          ctx.restore();
+        }
+      }
+
+      // ── Branding pill — bottom-left ──────────────────────────────────
       const PILL_H = 72;
       const PILL_PAD_X = 30;
       const LOGO_SIZE = 40;
@@ -155,7 +265,7 @@ export function StoryCardSheet({ outfitId, imageUrl, wornOn, createdAt, onClose 
     };
 
     img.src = proxiedSrc;
-  }, [imageUrl, dateLabel]);
+  }, [imageUrl, dateLabel, vibeCheckText, vibeCheckTone]);
 
   function handleDownload() {
     const canvas = canvasRef.current;

--- a/services/api/app/services/vibe_check.py
+++ b/services/api/app/services/vibe_check.py
@@ -46,7 +46,7 @@ Respond with ONLY a JSON object in this exact format (no markdown, no extra text
 {{"vibe_check_text": "...", "vibe_check_tone": "..."}}
 
 Rules:
-- vibe_check_text: 1-2 punchy, encouraging sentences about the overall vibe. Be specific and fun.
+- vibe_check_text: exactly 1 punchy, encouraging sentence (under 15 words) about the overall vibe. Be specific and fun.
 - vibe_check_tone: pick EXACTLY ONE word from this list: {tones}
 """
 


### PR DESCRIPTION
## Summary

- **Story card vibe check** — The share canvas now renders the vibe tone badge (colour-coded pill) + vibe text in italic white Georgia above the frosted branding pill. Matches the same visual language as the in-app badge. Text wraps cleanly and never overlaps the pill.
- **One-sentence vibe** — Backend prompt updated to \"exactly 1 sentence, under 15 words\". A \`firstSentence()\` helper also trims any existing longer texts in the detail panel and on the canvas, so it's clean immediately without waiting for re-uploads.
- **Back button — search page** — Search had no way to navigate back. Added a \"← back\" pill button to the header using \`router.back()\` with a \`/feed\` fallback for direct links (same pattern as outfit detail).

## Test plan

- [ ] Open a fit → tap share → story card preview shows tone badge + vibe sentence above the "checkd · date" pill
- [ ] Fits with multi-sentence vibe text show only the first sentence in both the detail panel and the story card
- [ ] New upload → vibe check comes back as one short sentence
- [ ] Navigate to /search (from vault, feed header, or explore) → "← back" button appears in top-right, tapping it returns to the previous page

🤖 Generated with [Claude Code](https://claude.com/claude-code)