### PR TITLE
fix: logo font, board overlap, rename boards, clickable members, story card 9:16

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "web",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000,
+      "autoPort": true
+    }
+  ]
+}

--- a/apps/web/app/boards/[id]/page.tsx
+++ b/apps/web/app/boards/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { use, useEffect, useState } from "react";
+import { use, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiClient, type Board, type BoardMember, type OutfitResponse } from "@/lib/api-client";
 import { MobileNav } from "@/components/chrome/mobile-nav";
@@ -67,6 +67,33 @@ function InviteCopy({ code }: { code: string }) {
 
 // ── Member strip ──────────────────────────────────────────────────────────────
 
+function MemberAvatar({ member }: { member: BoardMember }) {
+  const inner = member.profile_image_url ? (
+    <img
+      src={member.profile_image_url}
+      alt={member.username ?? "Member"}
+      className="h-8 w-8 rounded-full border-2 border-white object-cover shadow-sm"
+    />
+  ) : (
+    <div className="flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-pink-soft text-[0.65rem] font-semibold text-ink-soft shadow-sm">
+      {(member.display_name ?? member.username ?? "?").charAt(0).toUpperCase()}
+    </div>
+  );
+
+  if (member.username) {
+    return (
+      <Link
+        href={`/profile/${member.username}`}
+        title={member.display_name ?? member.username ?? "Member"}
+        className="transition hover:opacity-80"
+      >
+        {inner}
+      </Link>
+    );
+  }
+  return <div title={member.display_name ?? "Member"}>{inner}</div>;
+}
+
 function MemberStrip({ members }: { members: BoardMember[] }) {
   const shown = members.slice(0, 7);
   const extra = members.length - shown.length;
@@ -74,19 +101,7 @@ function MemberStrip({ members }: { members: BoardMember[] }) {
   return (
     <div className="flex items-center gap-1.5">
       {shown.map((m) => (
-        <div key={m.user_id} title={m.display_name ?? m.username ?? "Member"}>
-          {m.profile_image_url ? (
-            <img
-              src={m.profile_image_url}
-              alt={m.username ?? "Member"}
-              className="h-8 w-8 rounded-full border-2 border-white object-cover shadow-sm"
-            />
-          ) : (
-            <div className="flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-pink-soft text-[0.65rem] font-semibold text-ink-soft shadow-sm">
-              {(m.display_name ?? m.username ?? "?").charAt(0).toUpperCase()}
-            </div>
-          )}
-        </div>
+        <MemberAvatar key={m.user_id} member={m} />
       ))}
       {extra > 0 ? (
         <div className="flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-pink-soft text-[0.6rem] font-semibold text-pink-deep">
@@ -112,6 +127,10 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [leaveLoading, setLeaveLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState(false);
+  const [editNameValue, setEditNameValue] = useState("");
+  const [editNameSaving, setEditNameSaving] = useState(false);
+  const editNameInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!authLoading && !isAuthenticated) router.replace("/login");
@@ -173,6 +192,27 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
       setErrorMessage(result.message);
       setLeaveLoading(false);
     }
+  }
+
+  function startEditName() {
+    setEditNameValue(board?.name ?? "");
+    setEditingName(true);
+    // Focus the input on next tick after render
+    setTimeout(() => editNameInputRef.current?.focus(), 0);
+  }
+
+  async function saveEditName() {
+    const trimmed = editNameValue.trim();
+    if (!trimmed || editNameSaving) return;
+    setEditNameSaving(true);
+    const result = await apiClient.boards.update(id, { name: trimmed });
+    if (result.ok) {
+      setBoard(result.data);
+    } else {
+      setErrorMessage(result.message);
+    }
+    setEditingName(false);
+    setEditNameSaving(false);
   }
 
   if (authLoading || !isAuthenticated) return null;
@@ -246,8 +286,54 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
         ) : (
           <section className="soft-panel mb-6 px-6 py-6">
             <div className="flex items-start justify-between gap-3">
-              <div className="min-w-0">
-                <h1 className="font-display text-3xl leading-tight tracking-[-0.03em] text-ink">{board?.name}</h1>
+              <div className="min-w-0 flex-1">
+                {editingName ? (
+                  <div className="flex items-center gap-2">
+                    <input
+                      ref={editNameInputRef}
+                      value={editNameValue}
+                      onChange={(e) => setEditNameValue(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") void saveEditName();
+                        if (e.key === "Escape") setEditingName(false);
+                      }}
+                      maxLength={120}
+                      className="min-w-0 flex-1 rounded-xl border border-pink-deep/40 bg-white px-3 py-2 font-display text-2xl tracking-[-0.03em] text-ink outline-none focus:border-pink-deep"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => void saveEditName()}
+                      disabled={editNameSaving || !editNameValue.trim()}
+                      className="shrink-0 rounded-full bg-ink px-4 py-2 text-sm font-medium text-paper transition hover:opacity-90 disabled:opacity-40"
+                    >
+                      {editNameSaving ? "saving…" : "save"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setEditingName(false)}
+                      className="shrink-0 rounded-full border border-line px-3 py-2 text-sm text-ink-soft transition hover:text-ink"
+                    >
+                      cancel
+                    </button>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    <h1 className="font-display text-3xl leading-tight tracking-[-0.03em] text-ink">{board?.name}</h1>
+                    {isCreator ? (
+                      <button
+                        type="button"
+                        onClick={startEditName}
+                        aria-label="Rename board"
+                        className="mt-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-line text-mute/60 transition hover:border-pink-deep/30 hover:text-ink"
+                      >
+                        <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                          <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                          <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+                        </svg>
+                      </button>
+                    ) : null}
+                  </div>
+                )}
                 {eventLabel ? (
                   <p className="mt-1 text-sm text-mute">{eventLabel}</p>
                 ) : null}

--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -130,28 +130,11 @@ function TabSwitcher({ active, onChange }: { active: Tab; onChange: (t: Tab) => 
 
 function BoardActivityCard({
   outfit,
-  boardName,
 }: {
   outfit: BoardOutfitResponse;
   boardName: string;
 }) {
-  return (
-    <div className="relative">
-      <OutfitCard outfit={toBoardCardData(outfit)} showAuthor />
-      {/* Board name badge */}
-      <div className="pointer-events-none absolute left-3 bottom-[4.5rem] right-3">
-        <span className="inline-flex max-w-full items-center gap-1.5 truncate rounded-full border border-line bg-white/88 px-3 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.14em] text-ink-soft backdrop-blur">
-          <svg viewBox="0 0 24 24" className="h-3 w-3 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <rect x="4" y="4" width="6.5" height="6.5" rx="1.4" />
-            <rect x="13.5" y="4" width="6.5" height="6.5" rx="1.4" />
-            <rect x="4" y="13.5" width="6.5" height="6.5" rx="1.4" />
-            <rect x="13.5" y="13.5" width="6.5" height="6.5" rx="1.4" />
-          </svg>
-          <span className="truncate">{boardName}</span>
-        </span>
-      </div>
-    </div>
-  );
+  return <OutfitCard outfit={toBoardCardData(outfit)} showAuthor />;
 }
 
 // ── Vault feed tab ────────────────────────────────────────────────────────────
@@ -455,7 +438,7 @@ export default function FeedPage() {
       <main className="px-4 py-6 sm:px-6 lg:px-10">
         <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-6xl items-center justify-center">
           <section className="soft-panel w-full max-w-xl px-6 py-10 text-center sm:px-8">
-            <p className="font-logo text-5xl text-pink-deep" style={{ fontWeight: 100, letterSpacing: "-0.02em" }}>checkd.</p>
+            <p className="font-display text-5xl text-pink-deep" style={{ letterSpacing: "-0.02em" }}>checkd</p>
             <h1 className="mt-4 text-4xl text-ink">Opening your feed</h1>
           </section>
         </div>

--- a/apps/web/components/outfits/outfit-detail-view.tsx
+++ b/apps/web/components/outfits/outfit-detail-view.tsx
@@ -447,7 +447,7 @@ export function OutfitDetailView({ id }: { id: string }) {
                       <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-mute">{outfit.event_name}</p>
                     ) : null}
                     {dateLabel ? <p className="text-[0.7rem] uppercase tracking-[0.18em] text-mute">{dateLabel}</p> : null}
-                    {outfit?.vibe_check_text ? (
+                    {outfit?.vibe_check_text?.trim() ? (
                       <div className="rounded-[1rem] border border-line bg-pink-soft px-4 py-3">
                         <p className="mb-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-pink-deep">Vibe check</p>
                         <p className="text-sm leading-6 text-ink-soft">{firstSentence(outfit.vibe_check_text)}</p>

--- a/apps/web/components/outfits/story-card-sheet.tsx
+++ b/apps/web/components/outfits/story-card-sheet.tsx
@@ -88,9 +88,9 @@ export function StoryCardSheet({ outfitId, imageUrl, wornOn, createdAt, vibeChec
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
-    // 1080 × 1350 — 4:5 portrait (Instagram-friendly)
+    // 1080 × 1920 — 9:16 portrait (Instagram Story size)
     const W = 1080;
-    const H = 1350;
+    const H = 1920;
     canvas.width = W;
     canvas.height = H;
 
@@ -332,7 +332,7 @@ export function StoryCardSheet({ outfitId, imageUrl, wornOn, createdAt, vibeChec
 
         {/* Card preview — shows the canvas at display scale */}
         <div className="mx-6 mb-5 overflow-hidden rounded-[1.2rem] border border-line bg-pink-soft">
-          <div className="relative aspect-[4/5] w-full">
+          <div className="relative aspect-[9/16] w-full">
             <canvas
               ref={canvasRef}
               className="h-full w-full"

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -852,6 +852,15 @@ export const boardApiClient = {
     });
   },
 
+  async update(boardId: string, input: { name: string }): Promise<ApiResult<Board>> {
+    return sendRequest<Board>(`/boards/${boardId}`, {
+      method: "PATCH",
+      body: input,
+      requiresAuth: true,
+      successMessage: "Board updated."
+    });
+  },
+
   async delete(boardId: string): Promise<ApiResult<null>> {
     return sendRequest<null>(`/boards/${boardId}`, {
       method: "DELETE",

--- a/apps/web/test-results/.last-run.json
+++ b/apps/web/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/architecture.html
+++ b/architecture.html
@@ -1,0 +1,528 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>OOTD Architecture</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #0f1117; color: #e2e8f0; padding: 32px; }
+  h1 { text-align: center; font-size: 22px; font-weight: 700; color: #f8fafc; margin-bottom: 6px; letter-spacing: .5px; }
+  .subtitle { text-align: center; font-size: 13px; color: #64748b; margin-bottom: 36px; }
+
+  .arch { display: grid; grid-template-columns: 260px 1fr 260px; gap: 0; align-items: start; }
+
+  /* ─── LAYER CARD ─── */
+  .layer { border-radius: 12px; padding: 18px 16px; }
+  .layer-title {
+    font-size: 11px; font-weight: 700; letter-spacing: 1.2px; text-transform: uppercase;
+    margin-bottom: 14px; padding-bottom: 8px; border-bottom: 1px solid rgba(255,255,255,.08);
+  }
+
+  /* FRONTEND */
+  .fe { background: #1a1f35; border: 1px solid #2d3a6e; }
+  .fe .layer-title { color: #818cf8; }
+
+  /* BACKEND */
+  .be-col { display: flex; flex-direction: column; gap: 12px; padding: 0 16px; }
+
+  /* DB */
+  .db { background: #1a2a1a; border: 1px solid #2d5a2d; }
+  .db .layer-title { color: #4ade80; }
+
+  /* ─── BOX (router / crud / model) ─── */
+  .box {
+    border-radius: 8px; padding: 12px 14px;
+    font-size: 12.5px; line-height: 1.55;
+  }
+  .box-title { font-weight: 700; font-size: 12px; margin-bottom: 6px; }
+  .box ul { list-style: none; padding: 0; }
+  .box ul li { padding: 1px 0; color: #94a3b8; }
+  .box ul li span.method { display: inline-block; width: 42px; font-weight: 600; font-size: 11px; }
+  .box ul li span.get  { color: #34d399; }
+  .box ul li span.post { color: #60a5fa; }
+  .box ul li span.del  { color: #f87171; }
+  .box ul li span.lock { color: #fbbf24; font-size: 10px; margin-left: 3px; }
+  .box ul li span.path { color: #e2e8f0; }
+
+  /* router boxes */
+  .rtr { background: #1e2a3a; border: 1px solid #2d4a6e; }
+  .rtr .box-title { color: #60a5fa; }
+
+  /* crud boxes */
+  .crd { background: #261e3a; border: 1px solid #4a2d6e; }
+  .crd .box-title { color: #c084fc; }
+
+  /* service boxes */
+  .svc { background: #2a1e2a; border: 1px solid #6e2d5a; }
+  .svc .box-title { color: #f0abfc; }
+
+  /* dep boxes */
+  .dep { background: #1e2a26; border: 1px solid #2d6e4a; }
+  .dep .box-title { color: #6ee7b7; }
+
+  /* layer header cards */
+  .layer-hdr { border-radius: 10px; padding: 14px 16px; text-align: center; }
+  .fe-hdr { background: #1a1f35; border: 1px solid #2d3a6e; }
+  .be-hdr { background: #1e1a2a; border: 1px solid #4a2d6e; }
+  .db-hdr { background: #1a2a1a; border: 1px solid #2d5a2d; }
+  .layer-hdr .lbl { font-size: 11px; font-weight: 700; letter-spacing: 1.2px; text-transform: uppercase; }
+  .fe-hdr .lbl { color: #818cf8; }
+  .be-hdr .lbl { color: #c084fc; }
+  .db-hdr .lbl { color: #4ade80; }
+  .layer-hdr .tech { font-size: 11px; color: #64748b; margin-top: 3px; }
+
+  /* ─── DB TABLES ─── */
+  .table-card {
+    border-radius: 8px; padding: 12px 14px; margin-bottom: 10px;
+    background: #1f2e1f; border: 1px solid #2d5a2d;
+    font-size: 12px;
+  }
+  .table-card:last-child { margin-bottom: 0; }
+  .table-name { font-weight: 700; color: #4ade80; font-size: 12px; margin-bottom: 6px; font-family: monospace; }
+  .field { color: #94a3b8; padding: 1px 0; }
+  .field .fname { color: #e2e8f0; font-family: monospace; font-size: 11px; }
+  .field .ftype { color: #64748b; font-size: 10.5px; margin-left: 4px; }
+  .field .ftag { font-size: 10px; margin-left: 4px; border-radius: 3px; padding: 1px 4px; }
+  .pk  { background: #422006; color: #fb923c; }
+  .fk  { background: #1e3a5f; color: #60a5fa; }
+  .idx { background: #2d1f50; color: #a78bfa; }
+  .rel { font-size: 11px; color: #64748b; margin-top: 6px; padding-top: 6px; border-top: 1px solid rgba(255,255,255,.06); }
+  .rel span { color: #86efac; }
+
+  /* ─── ARROWS / CONNECTORS ─── */
+  .arrows { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px; padding-top: 60px; }
+  .arrow { font-size: 20px; color: #4a5568; }
+  .arrow-lbl { font-size: 10px; color: #4a5568; text-align: center; max-width: 60px; }
+
+  /* ─── FE SECTION ─── */
+  .fe-section { margin-bottom: 10px; }
+  .fe-section-title { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .8px; color: #4a5568; margin-bottom: 6px; }
+  .fe-box { background: #1f2540; border: 1px solid #2d3a6e; border-radius: 7px; padding: 10px 12px; margin-bottom: 8px; font-size: 12px; }
+  .fe-box .fb-title { font-weight: 700; color: #a5b4fc; margin-bottom: 5px; font-size: 11.5px; }
+  .fe-box ul { list-style: none; }
+  .fe-box ul li { color: #64748b; padding: 1px 0; font-size: 11.5px; }
+  .fe-box ul li strong { color: #94a3b8; }
+
+  /* ─── CENTER COLUMN ─── */
+  .be-section-title {
+    font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .8px;
+    color: #4a5568; margin-bottom: 6px; margin-top: 4px;
+  }
+
+  /* ─── FLOW LEGEND ─── */
+  .flow-row {
+    display: grid; grid-template-columns: repeat(5, 1fr); gap: 8px;
+    margin-top: 32px;
+  }
+  .flow-step {
+    border-radius: 8px; padding: 12px; text-align: center;
+    font-size: 11.5px;
+  }
+  .flow-step .fs-num { font-size: 18px; font-weight: 800; margin-bottom: 4px; }
+  .flow-step .fs-name { font-weight: 700; margin-bottom: 4px; font-size: 12px; }
+  .flow-step .fs-desc { font-size: 11px; color: #94a3b8; }
+  .fs1 { background: #1a1f35; border: 1px solid #2d3a6e; }
+  .fs1 .fs-num { color: #818cf8; }
+  .fs1 .fs-name { color: #a5b4fc; }
+  .fs2 { background: #1e2a3a; border: 1px solid #2d4a6e; }
+  .fs2 .fs-num { color: #60a5fa; }
+  .fs2 .fs-name { color: #93c5fd; }
+  .fs3 { background: #261e3a; border: 1px solid #4a2d6e; }
+  .fs3 .fs-num { color: #c084fc; }
+  .fs3 .fs-name { color: #d8b4fe; }
+  .fs4 { background: #2a1e1e; border: 1px solid #6e2d2d; }
+  .fs4 .fs-num { color: #f87171; }
+  .fs4 .fs-name { color: #fca5a5; }
+  .fs5 { background: #1a2a1a; border: 1px solid #2d5a2d; }
+  .fs5 .fs-num { color: #4ade80; }
+  .fs5 .fs-name { color: #86efac; }
+  .flow-arrow { display: flex; align-items: center; justify-content: center; font-size: 22px; color: #374151; padding-top: 12px; }
+
+  /* ─── CONNECTOR LINE SECTION ─── */
+  .connector { display: flex; align-items: center; justify-content: center; }
+  .conn-line { height: 2px; flex: 1; background: linear-gradient(to right, transparent, #374151, transparent); }
+  .conn-mid { font-size: 11px; color: #4b5563; padding: 0 10px; white-space: nowrap; }
+
+  hr.divider { border: none; border-top: 1px solid #1e293b; margin: 28px 0; }
+  .section-label { font-size: 13px; font-weight: 700; color: #475569; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 16px; }
+</style>
+</head>
+<body>
+
+<h1>OOTD — Full Architecture</h1>
+<p class="subtitle">Frontend · API · Database · Service connections</p>
+
+<!-- ═══════════════════════════ MAIN 3-COLUMN GRID ═══════════════════════════ -->
+<div class="arch">
+
+  <!-- ═══ LEFT: FRONTEND ═══ -->
+  <div class="fe layer">
+    <div class="layer-title">Frontend &nbsp;·&nbsp; Next.js + React</div>
+
+    <div class="fe-section">
+      <div class="fe-section-title">API Client &nbsp;·&nbsp; lib/api-client.ts</div>
+      <div class="fe-box">
+        <div class="fb-title">sendRequest&lt;T&gt;()</div>
+        <ul>
+          <li>Auto Bearer token injection</li>
+          <li>Auto-refresh on 401</li>
+          <li>Multipart FormData support</li>
+          <li>Error normalization</li>
+        </ul>
+      </div>
+      <div class="fe-box">
+        <div class="fb-title">Auth API</div>
+        <ul>
+          <li><strong>register()</strong></li>
+          <li><strong>login()</strong></li>
+          <li><strong>logout()</strong></li>
+          <li><strong>refresh()</strong></li>
+          <li><strong>me()</strong></li>
+        </ul>
+      </div>
+      <div class="fe-box">
+        <div class="fb-title">Outfit API</div>
+        <ul>
+          <li><strong>create()</strong> &nbsp;→ multipart</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="fe-section">
+      <div class="fe-section-title">Auth &nbsp;·&nbsp; lib/auth-context.tsx</div>
+      <div class="fe-box">
+        <div class="fb-title">AuthProvider</div>
+        <ul>
+          <li>Bootstrap: refresh → me</li>
+          <li>State: AuthUser | null</li>
+          <li><strong>login()</strong>, <strong>signup()</strong>, <strong>logout()</strong></li>
+          <li>Cookie: HttpOnly session</li>
+        </ul>
+      </div>
+      <div class="fe-box">
+        <div class="fb-title">useAuth() hook</div>
+        <ul>
+          <li>Consumed by all pages</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="fe-section">
+      <div class="fe-section-title">Pages &nbsp;·&nbsp; app/</div>
+      <div class="fe-box">
+        <ul>
+          <li>Next.js App Router</li>
+          <li>middleware.ts (route guards)</li>
+          <li>Tailwind CSS</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- ═══ CENTER: BACKEND ═══ -->
+  <div class="be-col">
+
+    <!-- Header -->
+    <div class="be-hdr layer-hdr">
+      <div class="lbl">Backend &nbsp;·&nbsp; FastAPI + SQLAlchemy</div>
+      <div class="tech">Python 3.12 · PostgreSQL 16 · JWT Auth · S3 Storage</div>
+    </div>
+
+    <!-- ROUTERS -->
+    <div class="be-section-title">Routers &nbsp;→&nbsp; HTTP interface</div>
+
+    <div class="box rtr">
+      <div class="box-title">auth.py</div>
+      <ul>
+        <li><span class="method post">POST</span><span class="path">/auth/register</span></li>
+        <li><span class="method post">POST</span><span class="path">/auth/login</span></li>
+        <li><span class="method post">POST</span><span class="path">/auth/refresh</span></li>
+        <li><span class="method post">POST</span><span class="path">/auth/logout</span></li>
+        <li><span class="method get">GET</span><span class="path">/auth/me</span><span class="lock">🔒</span></li>
+      </ul>
+    </div>
+
+    <div class="box rtr">
+      <div class="box-title">users.py</div>
+      <ul>
+        <li><span class="method get">GET</span><span class="path">/users/{username}</span></li>
+        <li><span class="method post">POST</span><span class="path">/users/{id}/follow</span><span class="lock">🔒</span></li>
+        <li><span class="method del">DEL</span><span class="path">/users/{id}/follow</span><span class="lock">🔒</span></li>
+      </ul>
+    </div>
+
+    <div class="box rtr">
+      <div class="box-title">outfits.py</div>
+      <ul>
+        <li><span class="method post">POST</span><span class="path">/outfits</span><span class="lock">🔒</span></li>
+        <li><span class="method get">GET</span><span class="path">/outfits/feed</span><span class="lock">🔒</span></li>
+        <li><span class="method get">GET</span><span class="path">/outfits/me</span><span class="lock">🔒</span></li>
+        <li><span class="method get">GET</span><span class="path">/outfits/user/{username}</span></li>
+      </ul>
+    </div>
+
+    <div class="box rtr">
+      <div class="box-title">health.py</div>
+      <ul>
+        <li><span class="method get">GET</span><span class="path">/health</span></li>
+      </ul>
+    </div>
+
+    <!-- DEPENDENCIES -->
+    <div class="be-section-title">Dependencies &nbsp;→&nbsp; Injected per request</div>
+    <div class="box dep">
+      <div class="box-title">dependencies.py</div>
+      <ul>
+        <li><strong style="color:#6ee7b7">get_db()</strong> — yields SQLAlchemy Session</li>
+        <li><strong style="color:#6ee7b7">get_current_user()</strong> — validates Bearer JWT → User or 401</li>
+      </ul>
+    </div>
+
+    <!-- CRUD -->
+    <div class="be-section-title">CRUD &nbsp;→&nbsp; Database operations</div>
+
+    <div class="box crd">
+      <div class="box-title">user_crud.py</div>
+      <ul>
+        <li>get_by_email / get_by_username / get_by_id</li>
+        <li>create_user(username, email, password_hash)</li>
+      </ul>
+    </div>
+
+    <div class="box crd">
+      <div class="box-title">outfit_crud.py</div>
+      <ul>
+        <li>create_outfit() — atomic outfit + items insert</li>
+        <li>get_outfit_with_items(outfit_id)</li>
+        <li>get_user_outfits(user_id, cursor, limit)</li>
+        <li>get_feed(following_ids, cursor, limit)</li>
+      </ul>
+    </div>
+
+    <div class="box crd">
+      <div class="box-title">follow_crud.py</div>
+      <ul>
+        <li>follow / unfollow (idempotent)</li>
+        <li>is_following(follower_id, following_id)</li>
+        <li>follower_count / following_count</li>
+        <li>following_ids(user_id) → list[UUID]</li>
+      </ul>
+    </div>
+
+    <div class="box crd">
+      <div class="box-title">session_crud.py</div>
+      <ul>
+        <li>create_session(user_id, token_hash, expires_at)</li>
+        <li>get_by_token_hash(hash)</li>
+        <li>revoke_session(session) — sets revoked_at</li>
+      </ul>
+    </div>
+
+    <!-- SERVICES -->
+    <div class="be-section-title">Services &nbsp;→&nbsp; External integrations</div>
+
+    <div class="box svc">
+      <div class="box-title">auth.py &nbsp;·&nbsp; AuthService</div>
+      <ul>
+        <li>hash_password / verify_password — bcrypt 4.x</li>
+        <li>create_access_token — JWT HS256, 15-min TTL</li>
+        <li>create_refresh_token — JWT HS256, 7-day TTL</li>
+        <li>Token hashing — SHA-256 for safe DB storage</li>
+        <li>HttpOnly cookie — SameSite=Lax, path=/auth</li>
+      </ul>
+    </div>
+
+    <div class="box svc">
+      <div class="box-title">storage.py &nbsp;·&nbsp; S3</div>
+      <ul>
+        <li>upload_image(file_bytes, content_type, user_id)</li>
+        <li>Allowed: JPEG, PNG, WebP, HEIC · Max 10 MB</li>
+        <li>Returns public HTTPS URL</li>
+        <li>InvalidImageError → 422 · StorageError → 500</li>
+      </ul>
+    </div>
+
+  </div>
+
+  <!-- ═══ RIGHT: DATABASE ═══ -->
+  <div class="db layer">
+    <div class="layer-title">Database &nbsp;·&nbsp; PostgreSQL 16</div>
+
+    <div class="table-card">
+      <div class="table-name">users</div>
+      <div class="field"><span class="fname">id</span><span class="ftype">UUID</span><span class="ftag pk">PK</span></div>
+      <div class="field"><span class="fname">email</span><span class="ftype">String</span><span class="ftag idx">UNIQUE</span></div>
+      <div class="field"><span class="fname">username</span><span class="ftype">String?</span><span class="ftag idx">UNIQUE</span></div>
+      <div class="field"><span class="fname">password_hash</span><span class="ftype">String</span></div>
+      <div class="field"><span class="fname">display_name</span><span class="ftype">String?</span></div>
+      <div class="field"><span class="fname">profile_image_url</span><span class="ftype">String?</span></div>
+      <div class="field"><span class="fname">bio</span><span class="ftype">String?</span></div>
+      <div class="field"><span class="fname">created_at / updated_at</span><span class="ftype">DateTime</span></div>
+      <div class="rel">→ <span>outfits</span>, <span>refresh_sessions</span>, <span>follows</span>, <span>likes</span>, <span>comments</span></div>
+    </div>
+
+    <div class="table-card">
+      <div class="table-name">outfits</div>
+      <div class="field"><span class="fname">id</span><span class="ftype">UUID</span><span class="ftag pk">PK</span></div>
+      <div class="field"><span class="fname">user_id</span><span class="ftype">UUID</span><span class="ftag fk">FK → users</span></div>
+      <div class="field"><span class="fname">image_url</span><span class="ftype">String</span></div>
+      <div class="field"><span class="fname">caption</span><span class="ftype">String?</span></div>
+      <div class="field"><span class="fname">event_name</span><span class="ftype">String?</span></div>
+      <div class="field"><span class="fname">worn_on</span><span class="ftype">Date?</span></div>
+      <div class="field"><span class="fname">vibe_check_text</span><span class="ftype">String?</span></div>
+      <div class="field"><span class="fname">vibe_check_tone</span><span class="ftype">String?</span></div>
+      <div class="field"><span class="fname">created_at / updated_at</span><span class="ftype">DateTime</span></div>
+      <div class="rel">→ <span>clothing_items</span>, <span>likes</span>, <span>comments</span></div>
+    </div>
+
+    <div class="table-card">
+      <div class="table-name">clothing_items</div>
+      <div class="field"><span class="fname">id</span><span class="ftype">UUID</span><span class="ftag pk">PK</span></div>
+      <div class="field"><span class="fname">outfit_id</span><span class="ftype">UUID</span><span class="ftag fk">FK → outfits</span></div>
+      <div class="field"><span class="fname">category</span><span class="ftype">String</span></div>
+      <div class="field"><span class="fname">brand</span><span class="ftype">String?</span></div>
+      <div class="field"><span class="fname">color</span><span class="ftype">String?</span></div>
+      <div class="field"><span class="fname">display_order</span><span class="ftype">Int (0)</span></div>
+      <div class="field"><span class="fname">link_url</span><span class="ftype">String?</span></div>
+      <div class="field"><span class="fname">created_at</span><span class="ftype">DateTime</span></div>
+    </div>
+
+    <div class="table-card">
+      <div class="table-name">follows</div>
+      <div class="field"><span class="fname">follower_id</span><span class="ftype">UUID</span><span class="ftag fk">FK → users</span><span class="ftag pk">CPK</span></div>
+      <div class="field"><span class="fname">following_id</span><span class="ftype">UUID</span><span class="ftag fk">FK → users</span><span class="ftag pk">CPK</span></div>
+      <div class="field"><span class="fname">created_at</span><span class="ftype">DateTime</span></div>
+      <div class="rel">CHECK: <span>follower_id ≠ following_id</span></div>
+    </div>
+
+    <div class="table-card">
+      <div class="table-name">refresh_sessions</div>
+      <div class="field"><span class="fname">id</span><span class="ftype">UUID</span><span class="ftag pk">PK</span></div>
+      <div class="field"><span class="fname">user_id</span><span class="ftype">UUID</span><span class="ftag fk">FK → users</span></div>
+      <div class="field"><span class="fname">token_hash</span><span class="ftype">String</span><span class="ftag idx">UNIQUE</span></div>
+      <div class="field"><span class="fname">user_agent / ip_address</span><span class="ftype">String?</span></div>
+      <div class="field"><span class="fname">expires_at</span><span class="ftype">DateTime</span></div>
+      <div class="field"><span class="fname">revoked_at</span><span class="ftype">DateTime?</span></div>
+      <div class="field"><span class="fname">created_at</span><span class="ftype">DateTime</span></div>
+    </div>
+
+    <div class="table-card">
+      <div class="table-name">likes</div>
+      <div class="field"><span class="fname">user_id</span><span class="ftype">UUID</span><span class="ftag fk">FK → users</span><span class="ftag pk">CPK</span></div>
+      <div class="field"><span class="fname">outfit_id</span><span class="ftype">UUID</span><span class="ftag fk">FK → outfits</span><span class="ftag pk">CPK</span></div>
+      <div class="field"><span class="fname">created_at</span><span class="ftype">DateTime</span></div>
+    </div>
+
+    <div class="table-card">
+      <div class="table-name">comments</div>
+      <div class="field"><span class="fname">id</span><span class="ftype">UUID</span><span class="ftag pk">PK</span></div>
+      <div class="field"><span class="fname">outfit_id</span><span class="ftype">UUID</span><span class="ftag fk">FK → outfits</span></div>
+      <div class="field"><span class="fname">user_id</span><span class="ftype">UUID</span><span class="ftag fk">FK → users</span></div>
+      <div class="field"><span class="fname">body</span><span class="ftype">String</span></div>
+      <div class="field"><span class="fname">created_at / updated_at</span><span class="ftype">DateTime</span></div>
+    </div>
+
+  </div>
+</div>
+
+<hr class="divider" />
+
+<!-- ═══════════════════════════ REQUEST FLOW ═══════════════════════════ -->
+<div class="section-label">Request Flow — Example: POST /outfits</div>
+
+<div style="display:grid; grid-template-columns: repeat(9, 1fr); gap:4px; align-items:center;">
+  <div class="flow-step fs1">
+    <div class="fs-num">1</div>
+    <div class="fs-name">Frontend</div>
+    <div class="fs-desc">sendRequest() builds multipart FormData (image + JSON metadata)</div>
+  </div>
+  <div class="flow-arrow">→</div>
+  <div class="flow-step fs2">
+    <div class="fs-num">2</div>
+    <div class="fs-name">Router</div>
+    <div class="fs-desc">get_current_user() validates Bearer JWT → User</div>
+  </div>
+  <div class="flow-arrow">→</div>
+  <div class="flow-step svc" style="padding:12px; text-align:center; border-radius:8px;">
+    <div class="fs-num" style="font-size:18px;font-weight:800;color:#f0abfc">3</div>
+    <div class="fs-name" style="font-weight:700;font-size:12px;color:#f0abfc;margin-bottom:4px;">Storage</div>
+    <div class="fs-desc" style="font-size:11px;color:#94a3b8;">upload_image() → S3 → returns HTTPS URL</div>
+  </div>
+  <div class="flow-arrow">→</div>
+  <div class="flow-step fs3">
+    <div class="fs-num">4</div>
+    <div class="fs-name">CRUD</div>
+    <div class="fs-desc">create_outfit() inserts outfit + items atomically</div>
+  </div>
+  <div class="flow-arrow">→</div>
+  <div class="flow-step fs5">
+    <div class="fs-num">5</div>
+    <div class="fs-name">Database</div>
+    <div class="fs-desc">outfits + clothing_items rows committed to Postgres</div>
+  </div>
+</div>
+
+<hr class="divider" />
+
+<!-- ═══════════════════════════ AUTH FLOW ═══════════════════════════ -->
+<div class="section-label">Auth Flow — Token Lifecycle</div>
+
+<div style="display:grid; grid-template-columns: repeat(9, 1fr); gap:4px; align-items:center;">
+  <div class="flow-step fs1">
+    <div class="fs-num">1</div>
+    <div class="fs-name">Register / Login</div>
+    <div class="fs-desc">POST credentials → hashed with bcrypt</div>
+  </div>
+  <div class="flow-arrow">→</div>
+  <div class="flow-step fs2">
+    <div class="fs-num">2</div>
+    <div class="fs-name">Issue Tokens</div>
+    <div class="fs-desc">access_token (JWT, 15 min) + refresh_token (JWT, 7 days)</div>
+  </div>
+  <div class="flow-arrow">→</div>
+  <div class="flow-step fs3">
+    <div class="fs-num">3</div>
+    <div class="fs-name">Store Session</div>
+    <div class="fs-desc">SHA-256 hash of refresh token saved to DB. Raw token → HttpOnly cookie</div>
+  </div>
+  <div class="flow-arrow">→</div>
+  <div class="flow-step svc" style="padding:12px; text-align:center; border-radius:8px;">
+    <div class="fs-num" style="font-size:18px;font-weight:800;color:#f0abfc">4</div>
+    <div class="fs-name" style="font-weight:700;font-size:12px;color:#f0abfc;margin-bottom:4px;">Auto-Refresh</div>
+    <div class="fs-desc" style="font-size:11px;color:#94a3b8;">On 401: POST /auth/refresh → new token pair, old session revoked</div>
+  </div>
+  <div class="flow-arrow">→</div>
+  <div class="flow-step fs2">
+    <div class="fs-num">5</div>
+    <div class="fs-name">Protected Routes</div>
+    <div class="fs-desc">get_current_user() decodes JWT, returns User or 401</div>
+  </div>
+</div>
+
+<hr class="divider" />
+
+<!-- ═══════════════════════════ MIGRATIONS ═══════════════════════════ -->
+<div class="section-label">Alembic Migrations</div>
+<div style="display:flex;gap:16px;">
+  <div class="box crd" style="flex:1">
+    <div class="box-title">20260411_3f8a1c2d &nbsp;·&nbsp; initial_schema</div>
+    <ul>
+      <li style="color:#94a3b8">Creates all 7 tables: users, outfits, clothing_items, follows, refresh_sessions, likes, comments</li>
+      <li style="color:#94a3b8">All FK constraints + CASCADE deletes</li>
+      <li style="color:#94a3b8">Indexes on email, username, token_hash</li>
+    </ul>
+  </div>
+  <div class="box crd" style="flex:1">
+    <div class="box-title">20260417_a1b2c3d4 &nbsp;·&nbsp; add_link_url_to_clothing_items</div>
+    <ul>
+      <li style="color:#94a3b8">Adds nullable <code style="color:#c084fc">link_url VARCHAR</code> to clothing_items</li>
+      <li style="color:#94a3b8">Depends on: 3f8a1c2d</li>
+      <li style="color:#94a3b8">Reversible (downgrade drops column)</li>
+    </ul>
+  </div>
+</div>
+
+<p style="text-align:center;margin-top:28px;font-size:11px;color:#374151;">OOTD · reaganbourne/OOTD · generated 2026-04-20</p>
+
+</body>
+</html>

--- a/docs/performance-plan.md
+++ b/docs/performance-plan.md
@@ -1,0 +1,366 @@
+# App performance plan
+
+This write-up focuses on making the app feel faster for real users. The current stack is a Next.js web app on Vercel, a FastAPI service on Railway, Postgres on Railway, and images in S3. Deployment matters, but the biggest gains will likely come from shortening the first-screen request chain, optimizing images, and removing backend query work that grows with feed size.
+
+## Current performance hypothesis
+
+The app is doing too much after the browser loads:
+
+1. Browser downloads and hydrates client-side Next.js pages.
+2. Auth bootstraps in the browser, sometimes with `/auth/refresh` and then `/auth/me`.
+3. The page fetches data from the public Railway API URL.
+4. The API queries Postgres and often does additional per-row lookups.
+5. The browser downloads outfit/profile images directly from S3.
+
+Any one of those can be okay. Together, they make the app feel slower than it needs to, especially on mobile networks.
+
+## What to measure first
+
+Do this before changing infrastructure so we can prove which fixes actually help.
+
+### Frontend metrics
+
+Add lightweight route timing in the web app:
+
+- Time to first page shell.
+- Time from route mount to first API request.
+- Time from route mount to first outfit cards visible.
+- API duration per endpoint from the browser's perspective.
+- Image load time for outfit cards.
+
+Recommended tools:
+
+- Vercel Speed Insights for field-level web vitals.
+- Browser Performance tab for local reproduction.
+- Simple `performance.mark()` instrumentation around feed/explore/profile loads.
+
+### API metrics
+
+Add request duration logging middleware in FastAPI:
+
+- Method, path, status, duration.
+- Slow request warning threshold, for example `>500ms`.
+- DB query count per request if possible.
+
+Start with the endpoints users feel most:
+
+- `GET /outfits/feed`
+- `GET /outfits/explore`
+- `GET /outfits/me`
+- `GET /users/me`
+- `POST /outfits`
+- `GET /boards`
+- `GET /boards/{id}/outfits`
+
+### Deployment checks
+
+Confirm these in production:
+
+- Vercel project region.
+- Railway API region.
+- Railway Postgres region.
+- S3 bucket region.
+- Whether API and Postgres are in the same Railway project/environment.
+
+The deployment guide currently points S3 at `us-east-2`. Railway supports deploy regions including US East/Virginia and US West/California. Vercel Functions can also be configured to run close to data sources. Aligning compute and data region is one of the easiest infrastructure wins.
+
+## Highest-impact fixes
+
+### 1. Optimize images and generate thumbnails
+
+This is likely the biggest user-visible win because the app is image-heavy.
+
+Current issue:
+
+- The app uses raw `<img>` tags in many core screens.
+- Uploaded outfit images may be served as large originals.
+- Browsers may download more pixels than the card actually needs.
+
+Recommended fix:
+
+- Generate multiple image sizes at upload time:
+  - `thumb`: around 400px wide for feed cards.
+  - `medium`: around 900px wide for detail pages.
+  - `original`: preserved for downloads or future processing.
+- Store dimensions and thumbnail URLs on the outfit record.
+- Use thumbnails in feed/explore/boards/profile grids.
+- Use medium image on detail pages.
+- Keep originals out of the critical browsing path.
+
+Next.js option:
+
+- Use `next/image` for remote images where layout dimensions are stable.
+- Configure `images.remotePatterns` in `apps/web/next.config.ts` for the exact S3/CloudFront host.
+- Use `sizes` accurately so mobile does not download desktop-sized images.
+
+Infrastructure option:
+
+- Put CloudFront in front of S3 for image delivery.
+- Consider S3 Transfer Acceleration only for uploads from far-away users. It helps long-distance uploads into S3, but it is not a replacement for thumbnails/CDN delivery.
+
+Why this matters:
+
+- Next.js image optimization can serve correctly sized images and modern formats, but it needs remote image configuration and explicit dimensions for remote images.
+- Thumbnails reduce bytes before they ever reach the browser or Next image optimizer.
+
+### 2. Remove feed/explore N+1 queries
+
+Current issue:
+
+- `GET /outfits/feed` and `GET /outfits/explore` fetch outfits, then loop through results and call `user_crud.get_by_id()` for each unique author.
+- `OutfitOut.model_validate(outfit)` can also touch `clothing_items`, which may trigger lazy relationship loads.
+- Comments do per-comment author lookups.
+
+Recommended fix:
+
+- Fetch authors in one bulk query by user IDs.
+- Use SQLAlchemy eager loading for relationships needed in response models.
+- For outfit lists, avoid returning full clothing item detail unless the UI needs it on the card.
+- Add tests that assert response shape stays stable.
+
+Implementation direction:
+
+- Add a `user_crud.get_by_ids(db, ids)` helper.
+- In feed/explore, build `author_by_id` once.
+- Use `selectinload(Outfit.clothing_items)` where clothing items are required.
+- Consider a separate `FeedOutfitSummary` schema that excludes `clothing_items` for card lists.
+
+Why this matters:
+
+- SQLAlchemy lazy loading emits extra SELECT statements when a relationship is accessed after the parent query. `selectinload()` batches related rows into a small number of queries.
+
+### 3. Shorten auth bootstrap
+
+Current issue:
+
+- `AuthProvider` runs on the client.
+- On cold page load it may call `/auth/refresh`, then `/auth/me`, then the page makes its own data request.
+- Because the API is cross-origin, every extra request is noticeable.
+
+Recommended fix:
+
+- Collapse auth bootstrap to one request when possible.
+- Make `/auth/refresh` return the user object along with the access token, so refresh does not need to be followed by `/auth/me`.
+- Hydrate initial auth state from a server-readable session signal where practical.
+- Avoid blocking public pages on auth unless they actually need it.
+
+Possible endpoint change:
+
+- Current: `POST /auth/refresh` -> access token, then `GET /auth/me` -> user.
+- Better: `POST /auth/refresh` -> access token + user.
+
+Why this matters:
+
+- Fewer serial requests means the UI can show real content sooner.
+
+### 4. Move first-screen data fetching closer to the server
+
+Current issue:
+
+- Core pages are client components that fetch in `useEffect`.
+- That means the browser must load JavaScript and hydrate before data fetching starts.
+
+Recommended fix:
+
+- Convert read-heavy screens to Server Component shells where possible.
+- Fetch initial page data on the server, then pass it to client components for interactivity.
+- Keep infinite scroll, likes, comments, and uploads client-side.
+
+Best candidates:
+
+- Explore page.
+- Public outfit detail page.
+- Public profile page.
+- Feed initial page, if auth can be handled cleanly on the server.
+
+Why this matters:
+
+- Next.js App Router supports data fetching in Server Components and streaming. Server fetching can start before client hydration, and loading states can be streamed with `loading.tsx` and `Suspense`.
+
+### 5. Align deployment regions
+
+Current issue:
+
+- The browser calls Railway directly from Vercel-served pages.
+- If Vercel, Railway API, Railway Postgres, and S3 are spread across regions, every request pays physical latency.
+
+Recommended fix:
+
+- Keep Railway API and Railway Postgres in the same region.
+- Pick a region close to the primary user base and S3 bucket.
+- Since the S3 bucket appears to be `us-east-2`, prefer East Coast placement unless analytics show otherwise.
+- Consider Railway US East for API/Postgres and Vercel `iad1` for server compute.
+
+If moving the frontend backend boundary:
+
+- Option A: Keep Vercel frontend + Railway API, but region-align them and optimize requests.
+- Option B: Put the frontend and API behind the same domain using a proxy/rewrite so browser requests avoid extra CORS friction and cookies become simpler.
+- Option C: Move API-like read endpoints into Next.js route handlers only if the team wants a larger architecture shift.
+
+Important nuance:
+
+- Vercel static assets are CDN-served globally by default, so deployment geography mostly affects dynamic server code and backend/API calls, not static JS/CSS delivery.
+
+### 6. Make uploads return fast
+
+Current issue:
+
+- `POST /outfits` reads the image, uploads to storage, runs vibe check, writes DB, then returns.
+- Vibe check is best-effort but still synchronous when it succeeds.
+
+Recommended fix:
+
+- Create outfit immediately after upload and metadata validation.
+- Return the created outfit with `vibe_check_status: "pending"`.
+- Run vibe check in a background job.
+- Patch the outfit when AI completes.
+- Let the UI update when the result is ready.
+
+Implementation levels:
+
+- Simple: FastAPI `BackgroundTasks` for low volume.
+- Better: a real queue/worker if this becomes core product behavior.
+- Best user experience: optimistic upload UI that shows the outfit immediately.
+
+Why this matters:
+
+- AI calls are variable and should not sit in the user-facing upload critical path.
+
+### 7. Add caching where data is public or slow-changing
+
+Good candidates:
+
+- Public outfit detail.
+- Public profile header.
+- Open Graph metadata.
+- Story card PNGs.
+- Explore pages if freshness can be slightly relaxed.
+
+Recommended fix:
+
+- Add HTTP cache headers on public endpoints.
+- Cache generated story cards instead of regenerating on every request.
+- Use CDN caching for images and public share assets.
+- For server-side Next fetches, use `next: { revalidate: ... }` where data can be stale for a short window.
+
+Avoid caching:
+
+- Authenticated feed unless keyed carefully.
+- Private boards unless cache policy is explicit and safe.
+- Like/comment state unless using short-lived or split cache patterns.
+
+### 8. Improve perceived performance
+
+These do not always reduce raw latency, but they make the app feel faster.
+
+- Keep skeleton cards stable and sized like final content.
+- Show cached/previous feed immediately while refreshing.
+- Prefetch detail routes when card links enter the viewport.
+- Load only the first 6-8 feed images eagerly; lazy-load the rest.
+- Avoid blocking the whole app on global auth loading when the route can render a public shell.
+- Use optimistic updates for likes, comments, board adds, and uploads.
+
+## Deployment-specific recommendations
+
+### Keep Vercel + Railway for now
+
+Do not migrate hosts as the first move. The current deployment can be fast enough if regions, images, auth, and query patterns are fixed.
+
+### Region alignment checklist
+
+- Railway API: choose US East if most users are US-based and S3 remains `us-east-2`.
+- Railway Postgres: keep in the same Railway region as API.
+- Vercel Functions: use a region close to Railway/Postgres if server-side rendering or route handlers call the API.
+- S3: keep in `us-east-2` for now unless there is a strong reason to move; add CloudFront for delivery.
+
+### Same-domain API path
+
+Consider proxying API calls through the web domain:
+
+- Browser calls `/api/backend/outfits/feed`.
+- Vercel rewrites or a route handler forwards to Railway.
+- Cookies and CORS become easier.
+
+Tradeoff:
+
+- This can add a Vercel hop if done naively.
+- It is most useful when paired with server-side rendering, auth simplification, or same-domain cookie benefits.
+
+## Suggested implementation order
+
+### Phase 1: Measure and quick wins
+
+- Add FastAPI request duration logging.
+- Add frontend timing marks for feed/explore/profile.
+- Confirm production regions.
+- Add CloudFront or at least set long-lived cache headers for S3 images.
+- Reduce auth bootstrap from two requests to one after refresh.
+
+### Phase 2: Image performance
+
+- Generate thumbnail and medium image variants on upload.
+- Store image dimensions and variant URLs.
+- Use feed thumbnails everywhere card-size images are rendered.
+- Configure `next/image` remote patterns and use it on stable card/profile images.
+
+### Phase 3: API query performance
+
+- Bulk load authors in feed/explore/comments.
+- Add eager loading for clothing items only where needed.
+- Create summary schemas for list endpoints.
+- Add indexes based on real query plans.
+
+### Phase 4: Render path improvements
+
+- Convert explore and public outfit detail to Server Component shells.
+- Add `loading.tsx` for major routes.
+- Stream slow sections below the first viewport.
+- Prefetch high-probability navigations.
+
+### Phase 5: Background work
+
+- Move vibe checks out of `POST /outfits`.
+- Cache generated story cards.
+- Add a worker/queue if background tasks need reliability.
+
+## Concrete code hotspots
+
+- `apps/web/lib/auth-context.tsx`: auth bootstrap currently controls app loading.
+- `apps/web/lib/api-client.ts`: all browser API calls hit `NEXT_PUBLIC_API_URL`.
+- `apps/web/app/feed/page.tsx`: client-rendered feed fetches after hydration.
+- `apps/web/app/explore/page.tsx`: good candidate for server-side initial data.
+- `apps/web/components/outfits/outfit-card.tsx`: important image rendering path.
+- `services/api/app/routers/outfits.py`: feed/explore author lookup and synchronous upload flow.
+- `services/api/app/crud/outfit.py`: feed/explore query shape and relationship loading.
+- `services/api/app/db.py`: add pool sizing/logging options if API traffic grows.
+
+## Success targets
+
+Set concrete goals so speed work does not become vibes-only:
+
+- Feed first content visible: under 1.5s on good mobile connection.
+- Feed API p95: under 300ms without image transfer.
+- Explore API p95: under 250ms.
+- Auth bootstrap p95: under 250ms when cached, under 500ms cold.
+- Upload response: under 2s after file upload reaches backend, with AI finishing async.
+- Card image bytes: under 150KB for feed thumbnails in common cases.
+
+## Research notes
+
+- Next.js recommends Server Components for server-side data fetching and supports streaming with `Suspense` and `loading.js`.
+- Next.js `<Image>` can serve remote images in appropriate sizes and formats, but remote hosts need `images.remotePatterns` and remote images need explicit dimensions or `fill`.
+- Vercel serves static assets through its CDN by default; dynamic function latency depends on where the function runs relative to data sources.
+- Railway supports multiple deploy regions and private networking between services in the same project/environment.
+- SQLAlchemy lazy relationships can emit additional SELECT statements when accessed; `selectinload()` and `joinedload()` are the usual tools to batch related data.
+- S3 Transfer Acceleration can improve long-distance uploads by routing through CloudFront edge locations, but CloudFront/CDN plus thumbnails is the stronger read-path optimization for this app.
+
+Sources:
+
+- Next.js data fetching docs: https://nextjs.org/docs/app/getting-started/fetching-data
+- Next.js image optimization docs: https://nextjs.org/docs/15/app/getting-started/images
+- Vercel function regions docs: https://vercel.com/docs/functions/configuring-functions/region
+- Vercel regions docs: https://vercel.com/docs/regions
+- Railway regions docs: https://docs.railway.com/deployments/regions
+- Railway private networking docs: https://docs.railway.com/private-networking
+- SQLAlchemy relationship loading docs: https://docs.sqlalchemy.org/20/orm/queryguide/relationships.html
+- AWS S3 Transfer Acceleration docs: https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration-getting-started.html

--- a/scripts/sync-issues.sh
+++ b/scripts/sync-issues.sh
@@ -1,0 +1,414 @@
+#!/bin/bash
+# Run from ~/OOTDtest: bash scripts/sync-issues.sh
+set -e
+
+echo "=== Closing completed issues ==="
+gh issue close 22 --comment "Closed — merged in PR #63 (feat-be-feed-and-social). Endpoint live in prod."
+gh issue close 53 --comment "Closed — merged in PR #66 (feat-be-story-card). Endpoint live in prod."
+
+echo ""
+echo "=== Phase 2 — Backend gaps ==="
+
+gh issue create \
+  --title "Edit profile endpoint" \
+  --label "phase 2" \
+  --assignee "reaganbourne" \
+  --body "## Summary
+\`PATCH /users/me\` — let users update their own profile.
+
+## Fields
+- \`display_name: str | None\`
+- \`bio: str | None\`
+- \`username: str | None\` (must be unique, validate format)
+
+## Notes
+- Auth required
+- Return updated \`PublicProfile\` shape
+- 409 if username already taken"
+
+gh issue create \
+  --title "Avatar upload endpoint" \
+  --label "phase 2" \
+  --assignee "reaganbourne" \
+  --body "## Summary
+\`POST /users/me/avatar\` — upload a profile photo to S3 and store the URL on the user row.
+
+## Notes
+- Same validation as outfit images: JPEG/PNG/WebP, max 10 MB
+- Reuse the existing \`upload_image\` service — just a different S3 key prefix (\`avatars/{user_id}/\`)
+- Store URL in \`users.profile_image_url\`
+- Return updated profile"
+
+echo ""
+echo "=== Phase 2 — Missing UI tickets ==="
+
+gh issue create \
+  --title "Vault page UI — outfit grid" \
+  --label "phase 2" \
+  --assignee "otthomas" \
+  --body "## Summary
+Replace the current \`/vault\` placeholder with a real outfit grid.
+
+## Requirements
+- Responsive masonry or uniform grid of outfit cards
+- Uses \`GET /outfits/me\` with cursor pagination (infinite scroll or load-more)
+- Empty state: prompt user to upload their first outfit
+- Outfit card: photo thumbnail, caption, worn date, vibe tone badge
+
+## Depends on
+Outfit card component (create that first — reused everywhere)"
+
+gh issue create \
+  --title "Outfit card component" \
+  --label "phase 2" \
+  --assignee "otthomas" \
+  --body "## Summary
+Reusable outfit card component used in the feed, vault, profile, boards, and explore pages.
+
+## Must show
+- Outfit photo (cover fit)
+- \`@username\` + avatar (for feed context)
+- Caption (truncated)
+- Vibe tone badge (coloured pill matching the 10 tones)
+- Worn date
+- Tap → opens outfit detail view
+
+## Notes
+- Build this before the feed, vault, and profile pages — they all depend on it
+- Should handle missing caption / missing vibe check gracefully"
+
+gh issue create \
+  --title "Outfit detail view" \
+  --label "phase 2" \
+  --assignee "otthomas" \
+  --body "## Summary
+Full-screen outfit detail — shown when tapping any outfit card.
+
+## Must show
+- Full-size outfit photo
+- Vibe check text (full sentence) + tone badge
+- Clothing items list (category, brand, color, link if present)
+- Caption, event name, worn date
+- \`@username\` + follow button (if viewing someone else's)
+- Share button → opens story card / copy link options
+
+## Notes
+- Can be a modal sheet on mobile or a dedicated route
+- Story card share: calls \`GET /outfits/{id}/story-card\`, triggers native share sheet"
+
+gh issue create \
+  --title "App navigation shell — bottom tab bar" \
+  --label "phase 2" \
+  --assignee "otthomas" \
+  --body "## Summary
+The persistent navigation frame that wraps all authenticated pages.
+
+## Tabs
+1. **Feed** — home feed from followed users
+2. **Upload** — existing upload flow
+3. **Vault** — personal outfit grid
+4. **Profile** — own profile page
+
+## Notes
+- Active tab indicator
+- Upload tab should be visually distinct (center button, larger)
+- Works alongside the existing route-protection middleware"
+
+gh issue create \
+  --title "Onboarding flow UI" \
+  --label "phase 2" \
+  --assignee "otthomas" \
+  --body "## Summary
+Post-signup onboarding so new users aren't dropped into an empty app.
+
+## Steps
+1. **Welcome screen** — brief product pitch, 'Let's build your vault'
+2. **Follow suggestions** — calls \`GET /users/suggested\` (backend ticket), show 5-8 users with follow buttons
+3. **First outfit prompt** — 'Upload your first fit to get your vibe check' → links to upload flow
+
+## Notes
+- Only shown once (store completion flag in localStorage or cookie)
+- Skip button on each step
+- Depends on the suggested users endpoint"
+
+echo ""
+echo "=== Phase 3 — Sharing & virality ==="
+
+gh issue create \
+  --title "Open Graph tags + shareable outfit URL endpoint" \
+  --label "phase 3" \
+  --assignee "reaganbourne" \
+  --body "## Summary
+Makes outfit links look great when shared in iMessage, Twitter, Slack, etc.
+
+## Endpoint
+\`GET /outfits/{id}/og\` — returns JSON with OG metadata:
+\`\`\`json
+{
+  \"title\": \"@usera's outfit — streetwear\",
+  \"description\": \"Effortlessly cool with a streetwear edge.\",
+  \"image_url\": \"/outfits/{id}/story-card\",
+  \"url\": \"https://ootd.app/outfits/{id}\"
+}
+\`\`\`
+
+## Notes
+- No auth required
+- Tomi uses this to populate \`<meta property='og:...'>\` tags on the public outfit page
+- image_url points to the story card endpoint (already built)"
+
+gh issue create \
+  --title "Public outfit page — no auth required" \
+  --label "phase 3" \
+  --assignee "otthomas" \
+  --body "## Summary
+\`/outfits/{id}\` — a shareable web page for any outfit, accessible without an account.
+
+## Must show
+- Outfit photo
+- \`@username\`, caption, vibe check, clothing items
+- Open Graph meta tags (using the OG endpoint — backend ticket)
+- 'Download OOTD' CTA — links to App Store / landing page
+- Follow button (if logged in) or 'Sign up to follow' (if logged out)
+
+## Notes
+- This is the viral entry point — every shared story card should link here
+- 404 if outfit not found"
+
+gh issue create \
+  --title "User search endpoint" \
+  --label "phase 3" \
+  --assignee "reaganbourne" \
+  --body "## Summary
+\`GET /users/search?q=reagan\` — search users by username or display_name.
+
+## Returns
+Array of \`PublicProfile\` objects (with follower count + following status).
+
+## Notes
+- Case-insensitive prefix match on username and display_name
+- Limit to 20 results
+- Auth optional — works logged out too (no following status if logged out)"
+
+gh issue create \
+  --title "Suggested users to follow endpoint" \
+  --label "phase 3" \
+  --assignee "reaganbourne" \
+  --body "## Summary
+\`GET /users/suggested\` — returns users worth following.
+
+## Logic (in priority order)
+1. Users followed by people you already follow (friends of friends)
+2. Users with the most followers overall (fallback for new users with no follows)
+
+## Returns
+Array of \`PublicProfile\` (up to 10), excluding people already followed and yourself.
+
+## Notes
+- Auth required
+- Used in onboarding flow and 'Who to follow' sidebar"
+
+gh issue create \
+  --title "Explore page UI" \
+  --label "phase 3" \
+  --assignee "otthomas" \
+  --body "## Summary
+A public grid of recent outfits from everyone on the platform — visible without following anyone.
+
+## Requirements
+- Grid of outfit cards (most recent first)
+- Uses \`GET /outfits/feed\` when logged in, or a public endpoint TBD for logged-out users
+- Search bar at top → links to user search UI
+- 'Who to follow' rail (uses \`GET /users/suggested\`)
+
+## Notes
+- This solves the empty-feed problem for new users
+- Consider a future 'trending' sort based on likes"
+
+gh issue create \
+  --title "User search UI" \
+  --label "phase 3" \
+  --assignee "otthomas" \
+  --body "## Summary
+Search screen — find other users by name or username.
+
+## Requirements
+- Search input with debounce (300ms)
+- Results: avatar, display_name, @username, follower count, follow/unfollow button
+- Empty state: 'No users found for ...'
+- Loading skeleton while fetching
+
+## Depends on
+User search endpoint (backend ticket)"
+
+gh issue create \
+  --title "AI caption generator endpoint" \
+  --label "phase 3" \
+  --assignee "reaganbourne" \
+  --body "## Summary
+\`POST /outfits/{id}/suggest-caption\` — Claude looks at the outfit image and clothing items and suggests 3 caption options.
+
+## Response
+\`\`\`json
+{
+  \"suggestions\": [
+    \"sunday best and absolutely built different 🤍\",
+    \"the fit is giving — coastal grandmother meets city girl\",
+    \"dressed for the life i'm manifesting\"
+  ]
+}
+\`\`\`
+
+## Notes
+- Auth required (own outfit only)
+- Sends image (base64) + clothing items + existing caption (if any) to Claude
+- Tomi shows suggestions as tappable chips in upload step 3 (Context)"
+
+echo ""
+echo "=== Phase 4 — Notifications ==="
+
+gh issue create \
+  --title "Notification model + endpoints" \
+  --label "phase 4" \
+  --assignee "reaganbourne" \
+  --body "## Summary
+In-app notification system — new followers, likes, comments, board activity.
+
+## Schema
+\`\`\`
+notifications
+  id          UUID PK
+  user_id     UUID FK → users (recipient)
+  actor_id    UUID FK → users (who triggered it)
+  type        ENUM: follow | like | comment | board_join | board_outfit
+  outfit_id   UUID FK → outfits (nullable)
+  board_id    UUID FK → boards (nullable)
+  body        String (pre-rendered text, e.g. '@usera liked your outfit')
+  seen        Boolean default false
+  created_at  DateTime
+\`\`\`
+
+## Endpoints
+- \`GET /notifications\` — paginated, newest first, auth required
+- \`POST /notifications/seen\` — mark all as seen (or specific IDs)
+- \`GET /notifications/unseen-count\` — for the bell badge"
+
+gh issue create \
+  --title "Notification center UI" \
+  --label "phase 4" \
+  --assignee "otthomas" \
+  --body "## Summary
+Bell icon in the nav bar with unseen count badge + notification list screen.
+
+## Requirements
+- Bell icon in top nav with red dot when unseen count > 0
+- Notification list: avatar, text, timestamp, thumbnail if outfit-related
+- Tap notification → navigate to relevant outfit/profile/board
+- Mark all as seen on open
+- Empty state: 'No notifications yet'
+
+## Depends on
+Notification model + endpoints (backend ticket)"
+
+gh issue create \
+  --title "Email notifications" \
+  --label "phase 4" \
+  --assignee "reaganbourne" \
+  --body "## Summary
+Transactional and digest emails using Resend (or SendGrid).
+
+## Emails to send
+1. **Welcome email** — on registration, product intro + link to upload first outfit
+2. **New follower** — 'X started following you'
+3. **Weekly digest** — 'Here's what you missed this week' (if inactive 7+ days)
+4. **Streak reminder** — 'You're on a 4-day streak 🔥 — don't break it'
+
+## Notes
+- Add \`email_notifications: bool\` opt-out to user model
+- Streak reminder is highest-retention email — prioritise it"
+
+gh issue create \
+  --title "Edit profile UI" \
+  --label "phase 4" \
+  --assignee "otthomas" \
+  --body "## Summary
+Settings screen for editing own profile.
+
+## Fields
+- Avatar (tap to upload — uses avatar upload endpoint)
+- Display name
+- Username (with availability check)
+- Bio (textarea, 160 char limit)
+
+## Notes
+- Depends on edit profile endpoint + avatar upload endpoint (backend phase 2 tickets)
+- Accessible from own profile page via 'Edit' button"
+
+gh issue create \
+  --title "Style profile AI endpoint" \
+  --label "phase 4" \
+  --assignee "reaganbourne" \
+  --body "## Summary
+\`GET /users/me/style-profile\` — Claude analyzes the user's last 30 outfits and returns a paragraph describing their dominant aesthetic.
+
+## Response
+\`\`\`json
+{
+  \"summary\": \"Your style is grounded in effortless minimalism with a soft edge — lots of neutral tones, clean silhouettes, and the occasional streetwear statement piece.\",
+  \"top_tones\": [\"minimalist\", \"casual\", \"streetwear\"],
+  \"updated_at\": \"2026-04-01T00:00:00Z\"
+}
+\`\`\`
+
+## Notes
+- Cache the result and regenerate at most once per week (store in a new \`style_profiles\` table or as a JSON column on users)
+- Only available if user has 5+ outfits"
+
+gh issue create \
+  --title "Style profile + caption suggestions UI" \
+  --label "phase 4" \
+  --assignee "otthomas" \
+  --body "## Summary
+Two UI features powered by the AI endpoints.
+
+## 1. Style profile card on own profile page
+- Shown below the vault grid on own profile
+- 'Your vibe: ...' paragraph
+- Top 3 tone pills
+- 'Updated X days ago'
+
+## 2. Caption suggestions in upload flow
+- On Step 3 (Context/metadata), after the caption field
+- 'Need inspiration?' → fetches suggestions from \`POST /outfits/{id}/suggest-caption\`
+- Shows 3 tappable chips — tap to populate the caption field
+
+## Depends on
+Style profile endpoint + caption generator endpoint (phase 4 backend tickets)"
+
+echo ""
+echo "=== Phase 5 — Mobile ==="
+
+gh issue create \
+  --title "React Native / Expo mobile app scaffold" \
+  --label "phase 5" \
+  --body "## Summary
+OOTD is fundamentally a mobile-first experience — camera access, daily habit, share sheet integration. Plan the mobile app scaffold early.
+
+## Scope
+- Expo + TypeScript scaffold
+- Shared API client from \`packages/contracts\`
+- Auth flow (login/register)
+- Bottom tab navigator: Feed / Upload / Vault / Profile
+- Camera integration for outfit upload
+- Native share sheet for story cards (\`GET /outfits/{id}/story-card\`)
+- Push notifications via Expo Notifications
+
+## Notes
+- Reuse API contracts from packages/contracts
+- iOS first, Android later
+- No timeline yet — flag for Phase 5 planning"
+
+echo ""
+echo "=== All done! ==="
+echo "Closed: #22, #53"
+echo "Created: all new phase 2-5 tickets"

--- a/services/api/app/crud/board.py
+++ b/services/api/app/crud/board.py
@@ -74,6 +74,14 @@ def get_by_invite_code(db: Session, invite_code: str) -> Board | None:
     return db.query(Board).filter(Board.invite_code == invite_code).first()
 
 
+def update_board(db: Session, board: Board, name: str) -> Board:
+    """Rename a board. Only the creator should call this."""
+    board.name = name.strip()
+    db.commit()
+    db.refresh(board)
+    return board
+
+
 def delete_board(db: Session, board: Board) -> None:
     db.delete(board)
     db.commit()

--- a/services/api/app/routers/boards.py
+++ b/services/api/app/routers/boards.py
@@ -24,6 +24,7 @@ from app.schemas.board import (
     BoardOut,
     CreateBoardRequest,
     PinRequest,
+    UpdateBoardRequest,
 )
 from app.schemas.outfit import BoardOutfitOut, BoardOutfitPage, FeedAuthor, OutfitOut
 
@@ -114,6 +115,20 @@ def delete_board(
     board = _board_or_404(db, board_id)
     _require_creator(db, board_id, current_user.id)
     board_crud.delete_board(db, board)
+
+
+@router.patch("/{board_id}", response_model=BoardOut)
+def update_board(
+    board_id: uuid.UUID,
+    payload: UpdateBoardRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> BoardOut:
+    """Rename a board. Creator only."""
+    board = _board_or_404(db, board_id)
+    _require_creator(db, board_id, current_user.id)
+    board = board_crud.update_board(db, board, payload.name)
+    return _board_out(db, board)
 
 
 # ── Joining ───────────────────────────────────────────────────────────────────

--- a/services/api/app/schemas/board.py
+++ b/services/api/app/schemas/board.py
@@ -13,6 +13,10 @@ class CreateBoardRequest(BaseModel):
     event_date: date | None = None
 
 
+class UpdateBoardRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+
+
 class BoardOut(BaseModel):
     id: uuid.UUID
     name: str


### PR DESCRIPTION
## Summary

- **Logo bug**: `font-logo` class doesn't exist in Tailwind config — replaced with `font-display` in feed loading state, also removed stray period from "checkd."
- **Board card overlap**: the absolute-positioned board name badge in the feed's boards tab sat at `bottom-[4.5rem]` and overlapped the card footer on mobile — removed the overlay (board name already appears in the section header above each group)
- **Clickable board members**: member avatars in the board detail strip are now `<Link>` tags to `/profile/{username}`
- **Edit board name**: creators see a pencil icon next to the board name → taps into an inline input with save/cancel; backed by new `PATCH /boards/{id}` endpoint + `UpdateBoardRequest` schema + CRUD function
- **Vibe check display**: added `.trim()` guard so an accidental empty string from the API doesn't silently hide the vibe check block
- **Story card size**: canvas resized from 1080×1350 (4:5) to 1080×1920 (9:16) — proper Instagram Story dimensions; preview aspect ratio updated to match

## Test plan

- [ ] Feed loading state shows correct Instrument Serif "checkd" wordmark
- [ ] Boards feed tab cards render without overlap on mobile (375px viewport)
- [ ] Tapping a member avatar on a board detail page navigates to their profile
- [ ] Board creator sees pencil icon; clicking opens inline input; save renames the board; Escape cancels
- [ ] Non-creator does not see the pencil icon
- [ ] Vibe check block shows when vibe_check_text is non-empty
- [ ] Story card preview shows 9:16 portrait; downloaded PNG is 1080×1920