### PR TITLE
fix: outfit-only vibe prompt + unify home page on mobile

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -17,123 +17,69 @@ export default async function HomePage() {
 
   return (
     <main
-      className="relative min-h-screen overflow-hidden"
+      className="relative flex min-h-screen items-center justify-center overflow-hidden px-4 py-10 sm:px-8 sm:py-12"
       style={{
         background:
           "radial-gradient(120% 80% at 80% 0%, rgba(255,255,255,0.45), transparent 60%), radial-gradient(80% 60% at 0% 100%, rgba(232,168,192,0.55), transparent 60%), #F8C8DC"
       }}
     >
-      {/* Mobile — full pink, left-aligned, space-between */}
-      <div
-        className="relative flex min-h-screen flex-col md:hidden"
-        style={{ padding: "60px 28px 40px" }}
-      >
-        {/* Top: est. tag + wordmark + tagline */}
-        <div>
-          <div
-            style={{
-              fontFamily: "ui-monospace, 'SF Mono', Menlo, monospace",
-              fontSize: 10,
-              letterSpacing: "0.15em",
-              color: "#faf7f5",
-              opacity: 0.7,
-              textTransform: "lowercase"
-            }}
-          >
-            est. 2026
-          </div>
-          <div
-            className="font-display"
-            style={{ fontSize: 88, lineHeight: 0.95, letterSpacing: "-0.02em", color: "#faf7f5", marginTop: 40 }}
-          >
-            checkd
-          </div>
-          <div
-            className="font-display"
-            style={{ fontSize: 22, lineHeight: 1.25, marginTop: 14, color: "#faf7f5", opacity: 0.92, maxWidth: 260 }}
-          >
-            your daily fit, kept&nbsp;close. shared with the&nbsp;girls.
-          </div>
-        </div>
+      <section className="w-full max-w-4xl overflow-hidden rounded-2xl border border-pink-deep/40 bg-paper/90 shadow-lift backdrop-blur-sm">
+        <div className="grid lg:grid-cols-[1fr_380px]">
 
-        {/* Bottom: CTAs + terms */}
-        <div>
-          <div className="flex flex-col gap-2.5">
-            <Link
-              href="/signup"
-              className="flex h-[50px] items-center justify-center rounded-full text-sm font-medium lowercase"
-              style={{ background: "#1a1416", color: "#faf7f5" }}
-            >
-              create account
-            </Link>
-            <Link
-              href="/login"
-              className="flex h-[50px] items-center justify-center rounded-full border text-sm font-medium lowercase"
-              style={{ borderColor: "currentColor", color: "#faf7f5" }}
-            >
-              i already have one
-            </Link>
-          </div>
-          <p className="mt-3.5 text-center text-xs" style={{ color: "#faf7f5", opacity: 0.85 }}>
-            by continuing you agree to our{" "}
-            <Link href="/terms" className="underline">terms</Link>
-            {" "}&amp;{" "}
-            <Link href="/privacy" className="underline">privacy</Link>
-          </p>
-        </div>
-      </div>
+          {/* Left — brand + tagline */}
+          <div className="flex flex-col justify-center border-b border-line px-8 py-10 lg:border-b-0 lg:border-r lg:px-12 lg:py-14">
+            <p className="font-display text-[64px] leading-none text-pink-deep sm:text-[80px]" style={{ letterSpacing: "-0.02em" }}>
+              checkd
+            </p>
+            <h1 className="mt-5 max-w-sm text-2xl leading-snug text-ink sm:text-3xl">
+              your daily fit, kept close,<br />shared with the girls.
+            </h1>
+            <p className="mt-4 max-w-md text-sm leading-7 text-ink-soft">
+              log outfits, coordinate with friends, and turn great nights into reusable style history.
+            </p>
 
-      {/* Desktop / laptop — two-column card layout */}
-      <div className="relative hidden min-h-screen md:flex md:items-center md:justify-center md:px-8 md:py-12">
-        <section className="w-full max-w-4xl overflow-hidden rounded-2xl border border-pink-deep/40 bg-paper/90 shadow-lift backdrop-blur-sm">
-          <div className="grid lg:grid-cols-[1fr_380px]">
-            {/* Left — brand + tagline */}
-            <div className="flex flex-col justify-center border-b border-line px-8 py-10 lg:border-b-0 lg:border-r lg:px-12 lg:py-14">
-              <p className="font-display text-[80px] leading-none text-pink-deep" style={{ letterSpacing: "-0.02em" }}>
-                checkd
-              </p>
-              <h1 className="mt-5 max-w-sm text-3xl leading-snug text-ink">
-                your daily fit, kept close,<br />shared with the girls.
-              </h1>
-              <p className="mt-4 max-w-md text-sm leading-7 text-ink-soft">
-                log outfits, coordinate with friends, and turn great nights into reusable style history.
-              </p>
-
-              <div className="mt-8 flex flex-wrap gap-2">
-                {["personal fit archive", "share with friends", "AI-generated captions"].map((tag) => (
-                  <span
-                    key={tag}
-                    className="rounded-full border border-line bg-paper px-3.5 py-1.5 text-xs lowercase text-mute"
-                  >
-                    {tag}
-                  </span>
-                ))}
-              </div>
-            </div>
-
-            {/* Right — CTA */}
-            <div className="flex flex-col justify-center gap-8 px-8 py-10 lg:px-8 lg:py-14">
-              <div>
-                <h2 className="font-display text-3xl text-ink">
-                  a soft place for outfits.
-                </h2>
-                <p className="mt-3 text-sm leading-6 text-ink-soft">
-                  start your archive, discover your friends&rsquo; fits, and share to your story in one tap.
-                </p>
-              </div>
-
-              <div className="grid gap-3">
-                <Link href="/signup" className="btn-primary text-center">
-                  get started
-                </Link>
-                <Link href="/login" className="btn-secondary text-center">
-                  log in
-                </Link>
-              </div>
+            <div className="mt-8 flex flex-wrap gap-2">
+              {["personal fit archive", "share with friends", "AI-generated captions"].map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded-full border border-line bg-paper px-3.5 py-1.5 text-xs lowercase text-mute"
+                >
+                  {tag}
+                </span>
+              ))}
             </div>
           </div>
-        </section>
-      </div>
+
+          {/* Right — CTA */}
+          <div className="flex flex-col justify-center gap-8 px-8 py-10 lg:px-8 lg:py-14">
+            <div>
+              <h2 className="font-display text-3xl text-ink">
+                a soft place for outfits.
+              </h2>
+              <p className="mt-3 text-sm leading-6 text-ink-soft">
+                start your archive, discover your friends&rsquo; fits, and share to your story in one tap.
+              </p>
+            </div>
+
+            <div className="grid gap-3">
+              <Link href="/signup" className="btn-primary text-center">
+                get started
+              </Link>
+              <Link href="/login" className="btn-secondary text-center">
+                log in
+              </Link>
+            </div>
+
+            <p className="text-center text-xs text-mute">
+              by continuing you agree to our{" "}
+              <Link href="/terms" className="underline hover:text-ink">terms</Link>
+              {" "}&amp;{" "}
+              <Link href="/privacy" className="underline hover:text-ink">privacy</Link>
+            </p>
+          </div>
+
+        </div>
+      </section>
     </main>
   );
 }

--- a/services/api/app/services/vibe_check.py
+++ b/services/api/app/services/vibe_check.py
@@ -40,13 +40,13 @@ VALID_TONES = {
 }
 
 _PROMPT = """\
-You are a fashion-savvy friend giving a vibe check on someone's outfit photo.{caption_line}
+You are a fashion-savvy friend giving a vibe check on someone's outfit.{caption_line}
 
 Respond with ONLY a JSON object in this exact format (no markdown, no extra text):
 {{"vibe_check_text": "...", "vibe_check_tone": "..."}}
 
 Rules:
-- vibe_check_text: exactly 1 punchy, encouraging sentence (under 15 words) about the overall vibe. Be specific and fun.
+- vibe_check_text: exactly 1 punchy, encouraging sentence (under 15 words) about the OUTFIT ONLY — the clothes, styling, and overall aesthetic. Focus on the pieces, color palette, silhouette, layering, accessories, or style energy. Do NOT comment on the person's appearance, body, face, or any physical attributes.
 - vibe_check_tone: pick EXACTLY ONE word from this list: {tones}
 """
 


### PR DESCRIPTION
## Summary

**Vibe check prompt**
- The previous prompt could generate comments about the person's appearance. New rule explicitly scopes it to the outfit only: pieces, color palette, silhouette, layering, accessories, style energy. The person is never mentioned.

**Home page**
- The old mobile layout was a completely different design (full-bleed pink background, white text) that diverged from the desktop card. Removed it entirely.
- The card layout now renders on all screen sizes: single column on mobile (brand section stacked above CTA), two columns on `lg+` — exactly matching the laptop view.
- T&C links moved into the card (right column, below buttons) so they're always visible.
- `checkd` wordmark scales down slightly on small screens (`text-[64px]` → `sm:text-[80px]`) so it doesn't overflow narrow phones.

## Test plan
- [ ] iPhone: home page shows the white card centered on pink background, same as laptop
- [ ] iPhone: both sections stack vertically (brand on top, CTA + buttons below)
- [ ] New vibe checks reference the outfit, not the person
- [ ] Existing vibe checks on old outfits are unaffected (prompt only applies to new uploads)