### PR TITLE
feat: page transitions, story card redesign, clean vibe prompt

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -60,6 +60,52 @@ button:active:not(:disabled),
   opacity: 0.78;
 }
 
+/* ── Page transitions ────────────────────────────────────────────────────── */
+@keyframes page-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+main {
+  animation: page-enter 0.24s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+/* ── Sheet / overlay animations ─────────────────────────────────────────── */
+@keyframes fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.animate-fade-in {
+  animation: fade-in 0.18s ease-out both;
+}
+
+.animate-fade-up {
+  animation: fade-up 0.26s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+/* ── Smoother link / interactive transitions ────────────────────────────── */
+a {
+  transition: color 0.15s ease, opacity 0.15s ease;
+}
+
 @layer components {
   /* Card — 1px line border, no heavy shadow */
   .soft-panel {

--- a/apps/web/components/outfits/story-card-sheet.tsx
+++ b/apps/web/components/outfits/story-card-sheet.tsx
@@ -12,20 +12,6 @@ type StoryCardSheetProps = {
   onClose: () => void;
 };
 
-// Tone accent colours — match the Python story_card.py palette
-const TONE_ACCENT: Record<string, string> = {
-  athletic:   "#22d3ee",
-  boho:       "#c084fc",
-  business:   "#93c5fd",
-  casual:     "#60a5fa",
-  formal:     "#fbbf24",
-  maximalist: "#f472b6",
-  minimalist: "#cbd5e1",
-  preppy:     "#4ade80",
-  streetwear: "#fb7185",
-  vintage:    "#fb923c",
-};
-
 /** Wrap text to fit maxWidth on a canvas context. Returns array of lines. */
 function wrapLines(ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string[] {
   const words = text.split(" ");
@@ -56,23 +42,6 @@ function formatShareDate(dateStr?: string | null): string {
   return d.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" });
 }
 
-function roundRect(
-  ctx: CanvasRenderingContext2D,
-  x: number, y: number, w: number, h: number, r: number
-) {
-  ctx.beginPath();
-  ctx.moveTo(x + r, y);
-  ctx.lineTo(x + w - r, y);
-  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
-  ctx.lineTo(x + w, y + h - r);
-  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
-  ctx.lineTo(x + r, y + h);
-  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
-  ctx.lineTo(x, y + r);
-  ctx.quadraticCurveTo(x, y, x + r, y);
-  ctx.closePath();
-}
-
 export function StoryCardSheet({ outfitId, imageUrl, wornOn, createdAt, vibeCheckText, vibeCheckTone, onClose }: StoryCardSheetProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [rendered, setRendered] = useState(false);
@@ -95,17 +64,16 @@ export function StoryCardSheet({ outfitId, imageUrl, wornOn, createdAt, vibeChec
     canvas.height = H;
 
     const img = new Image();
-    // Load through the Next.js proxy so the image is same-origin.
-    // Direct S3 URLs fail with crossOrigin="anonymous" unless the bucket
-    // has CORS headers — the proxy adds them server-side.
     const proxiedSrc = `/api/proxy-image?url=${encodeURIComponent(imageUrl)}`;
 
     img.onload = () => {
-      // Background
+      const PAD = 64;
+
+      // ── 1. Background ───────────────────────────────────────────────────────
       ctx.fillStyle = "#faf7f5";
       ctx.fillRect(0, 0, W, H);
 
-      // Cover-fit the outfit photo
+      // ── 2. Cover-fit outfit photo ───────────────────────────────────────────
       const imgAspect = img.naturalWidth / img.naturalHeight;
       const canvasAspect = W / H;
       let sx = 0, sy = 0, sw = img.naturalWidth, sh = img.naturalHeight;
@@ -118,139 +86,67 @@ export function StoryCardSheet({ outfitId, imageUrl, wornOn, createdAt, vibeChec
       }
       ctx.drawImage(img, sx, sy, sw, sh, 0, 0, W, H);
 
-      // Bottom gradient for text legibility
-      const grad = ctx.createLinearGradient(0, H * 0.6, 0, H);
-      grad.addColorStop(0, "rgba(0,0,0,0)");
-      grad.addColorStop(1, "rgba(0,0,0,0.5)");
-      ctx.fillStyle = grad;
+      // ── 3. Dual gradient — darkens top (logo) and bottom (vibe text) ────────
+      const topGrad = ctx.createLinearGradient(0, 0, 0, H * 0.30);
+      topGrad.addColorStop(0, "rgba(0,0,0,0.52)");
+      topGrad.addColorStop(1, "rgba(0,0,0,0)");
+      ctx.fillStyle = topGrad;
       ctx.fillRect(0, 0, W, H);
 
-      // ── Vibe check — above branding pill ─────────────────────────────
-      const PAD = 52;
-      const VIBE_MAX_W = W - PAD * 2;
+      const botGrad = ctx.createLinearGradient(0, H * 0.58, 0, H);
+      botGrad.addColorStop(0, "rgba(0,0,0,0)");
+      botGrad.addColorStop(1, "rgba(0,0,0,0.68)");
+      ctx.fillStyle = botGrad;
+      ctx.fillRect(0, 0, W, H);
 
-      try {
-        if (vibeCheckText?.trim() || vibeCheckTone?.trim()) {
-          const vibe = vibeCheckText?.trim() ? firstSentence(vibeCheckText) : null;
-          const accentColor = TONE_ACCENT[(vibeCheckTone ?? "").toLowerCase()] ?? "rgba(255,255,255,0.7)";
-
-          // Measure how many lines the vibe text needs so we can position from the bottom up
-          let vibeLineCount = 0;
-          if (vibe) {
-            ctx.font = `italic 400 34px Georgia, serif`;
-            vibeLineCount = wrapLines(ctx, vibe, VIBE_MAX_W).length;
-          }
-
-          const TONE_H   = vibeCheckTone?.trim() ? 44 : 0;
-          const VIBE_H   = vibeLineCount * 42;
-          const BLOCK_H  = TONE_H + (TONE_H && VIBE_H ? 14 : 0) + VIBE_H;
-          const PILL_H   = 72;
-          const PILL_GAP = 24;
-
-          // Start block this many pixels above the pill
-          let vy = H - PAD - PILL_H - PILL_GAP - BLOCK_H;
-
-          // Tone badge — use the polyfill roundRect so it works on all browsers
-          if (vibeCheckTone?.trim()) {
-            ctx.save();
-            ctx.font = `600 22px -apple-system, sans-serif`;
-            const badgeText = vibeCheckTone.toUpperCase();
-            const bw = ctx.measureText(badgeText).width;
-            const bpad = 14;
-            const bh = 32;
-            const rx = PAD, ry = vy;
-            // Badge background
-            ctx.globalAlpha = 0.18;
-            ctx.fillStyle = accentColor;
-            roundRect(ctx, rx, ry, bw + bpad * 2, bh, bh / 2);
-            ctx.fill();
-            ctx.globalAlpha = 1;
-            // Badge border
-            ctx.strokeStyle = accentColor;
-            ctx.lineWidth = 1.5;
-            roundRect(ctx, rx, ry, bw + bpad * 2, bh, bh / 2);
-            ctx.stroke();
-            // Badge text
-            ctx.fillStyle = accentColor;
-            ctx.textAlign = "left";
-            ctx.textBaseline = "middle";
-            ctx.fillText(badgeText, rx + bpad, ry + bh / 2);
-            ctx.restore();
-            vy += bh + 14;
-          }
-
-          // Vibe text
-          if (vibe) {
-            ctx.save();
-            ctx.font = `italic 400 34px Georgia, serif`;
-            ctx.fillStyle = "rgba(255,255,255,0.92)";
-            ctx.textAlign = "left";
-            ctx.textBaseline = "top";
-            const lines = wrapLines(ctx, vibe, VIBE_MAX_W);
-            for (const line of lines) {
-              ctx.fillText(line, PAD, vy);
-              vy += 42;
-            }
-            ctx.restore();
-          }
-        }
-      } catch (e) {
-        // Vibe check rendering failed — canvas continues without it
-        console.warn("Story card vibe check render failed:", e);
-      }
-
-      // ── Branding pill — bottom-left ──────────────────────────────────
-      const PILL_H = 72;
-      const PILL_PAD_X = 30;
-      const LOGO_SIZE = 40;
+      // ── 4. Top-right: "checkd" logo + date ─────────────────────────────────
+      const LOGO_SIZE = 58;
       const DATE_SIZE = 27;
-      const SEP = 20;
 
-      ctx.font = `italic 400 ${LOGO_SIZE}px Georgia, serif`;
-      const logoW = ctx.measureText("checkd").width;
-      ctx.font = `400 ${DATE_SIZE}px Georgia, serif`;
-      const dateW = dateLabel ? ctx.measureText(dateLabel).width : 0;
-
-      const innerW = logoW + (dateLabel ? SEP + dateW : 0);
-      const pillW = innerW + PILL_PAD_X * 2;
-      const pillX = PAD;
-      const pillY = H - PAD - PILL_H;
-      const textY = pillY + PILL_H / 2;
-
-      // Frosted pill
-      ctx.save();
-      ctx.globalAlpha = 0.2;
-      ctx.fillStyle = "#ffffff";
-      roundRect(ctx, pillX, pillY, pillW, PILL_H, PILL_H / 2);
-      ctx.fill();
-      ctx.restore();
-
-      ctx.save();
-      ctx.globalAlpha = 0.4;
-      ctx.strokeStyle = "rgba(255,255,255,0.6)";
-      ctx.lineWidth = 1.5;
-      roundRect(ctx, pillX, pillY, pillW, PILL_H, PILL_H / 2);
-      ctx.stroke();
-      ctx.restore();
-
-      // "checkd" — italic, pink
       ctx.save();
       ctx.font = `italic 400 ${LOGO_SIZE}px Georgia, serif`;
       ctx.fillStyle = "#F9A8D4";
-      ctx.textAlign = "left";
-      ctx.textBaseline = "middle";
-      ctx.fillText("checkd", pillX + PILL_PAD_X, textY);
+      ctx.textAlign = "right";
+      ctx.textBaseline = "top";
+      ctx.fillText("checkd", W - PAD, PAD);
       ctx.restore();
 
-      // Date — white, smaller
       if (dateLabel) {
         ctx.save();
         ctx.font = `400 ${DATE_SIZE}px Georgia, serif`;
-        ctx.fillStyle = "rgba(255,255,255,0.85)";
-        ctx.textAlign = "left";
-        ctx.textBaseline = "middle";
-        ctx.fillText(dateLabel, pillX + PILL_PAD_X + logoW + SEP, textY + 1);
+        ctx.fillStyle = "rgba(255,255,255,0.68)";
+        ctx.textAlign = "right";
+        ctx.textBaseline = "top";
+        ctx.fillText(dateLabel, W - PAD, PAD + LOGO_SIZE + 8);
         ctx.restore();
+      }
+
+      // ── 5. Bottom-left: vibe check text ─────────────────────────────────────
+      const vibeStr = vibeCheckText?.trim() ? firstSentence(vibeCheckText) : null;
+      if (vibeStr) {
+        try {
+          const VIBE_SIZE = 48;
+          const LINE_H = 62;
+          const VIBE_MAX_W = W - PAD * 2.2;
+
+          ctx.save();
+          ctx.font = `italic 400 ${VIBE_SIZE}px Georgia, serif`;
+          ctx.fillStyle = "rgba(255,255,255,0.95)";
+          ctx.textAlign = "left";
+          ctx.textBaseline = "bottom";
+
+          const lines = wrapLines(ctx, vibeStr, VIBE_MAX_W);
+
+          // Draw lines from bottom up so the last line sits at H - PAD
+          let ty = H - PAD;
+          for (const line of [...lines].reverse()) {
+            ctx.fillText(line, PAD, ty);
+            ty -= LINE_H;
+          }
+          ctx.restore();
+        } catch (e) {
+          console.warn("Story card vibe text render failed:", e);
+        }
       }
 
       setRendered(true);
@@ -315,12 +211,12 @@ export function StoryCardSheet({ outfitId, imageUrl, wornOn, createdAt, vibeChec
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-end justify-center bg-[rgba(26,20,22,0.55)] px-4 pb-4 sm:items-center sm:pb-0 backdrop-blur-sm"
+      className="animate-fade-in fixed inset-0 z-50 flex items-end justify-center bg-[rgba(26,20,22,0.55)] px-4 pb-4 backdrop-blur-sm sm:items-center sm:pb-0"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
-      <div className="soft-panel w-full max-w-sm overflow-hidden">
+      <div className="animate-fade-up soft-panel w-full max-w-sm overflow-hidden">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 pt-5 pb-4">
+        <div className="flex items-center justify-between px-6 pb-4 pt-5">
           <h2 className="font-display text-2xl tracking-[-0.03em] text-ink">share look</h2>
           <button
             type="button"
@@ -333,7 +229,7 @@ export function StoryCardSheet({ outfitId, imageUrl, wornOn, createdAt, vibeChec
           </button>
         </div>
 
-        {/* Card preview — shows the canvas at display scale */}
+        {/* Card preview */}
         <div className="mx-6 mb-5 overflow-hidden rounded-[1.2rem] border border-line bg-pink-soft">
           <div className="relative aspect-[9/16] w-full">
             <canvas

--- a/services/api/app/services/vibe_check.py
+++ b/services/api/app/services/vibe_check.py
@@ -45,9 +45,9 @@ You are a fashion-savvy friend giving a vibe check on someone's outfit.{caption_
 Respond with ONLY a JSON object in this exact format (no markdown, no extra text):
 {{"vibe_check_text": "...", "vibe_check_tone": "..."}}
 
-Rules:
-- vibe_check_text: exactly 1 punchy, encouraging sentence (under 15 words) about the OUTFIT ONLY — the clothes, styling, and overall aesthetic. Focus on the pieces, color palette, silhouette, layering, accessories, or style energy. Do NOT comment on the person's appearance, body, face, or any physical attributes.
-- vibe_check_tone: pick EXACTLY ONE word from this list: {tones}
+vibe_check_text must be exactly 1 punchy, encouraging sentence under 15 words about the OUTFIT ONLY. Comment on the clothes, styling, and overall aesthetic. Focus on pieces, color palette, silhouette, layering, accessories, or style energy. Never comment on the person's appearance, body, face, or any physical attributes.
+
+vibe_check_tone must be exactly one word chosen from this list: {tones}
 """
 
 


### PR DESCRIPTION
## Summary

**Page transitions**
Every `<main>` element now fades + slides up (8px, 0.24s ease-out) on enter via a CSS keyframe — no library needed, zero bundle cost. Sheet overlays (e.g. share card) get a separate fade-in backdrop and slide-up panel so they feel native.

**Story card redesign**
The canvas layout is completely reworked:
- Tone badge (PREPPY / CASUAL etc.) removed entirely
- `checkd` logo moved to **top right**, pink italic, right-aligned with PAD from edge
- Date sits just below the logo, smaller, white, right-aligned
- Vibe check text is now **bottom left**, 48px italic Georgia, bottom-anchored so the last line always sits at PAD from the bottom edge — no badge, just clean type
- Dual gradient: top 30% darkens to 0.52 opacity for logo legibility, bottom 42% darkens to 0.68 for vibe text legibility
- Removed all polyfill complexity (`roundRect` is gone since the badge is gone)

**Vibe check prompt**
- No more dashes in the rule list — rewritten as plain prose sentences
- Still enforces outfit-only commentary, no appearance comments

## Test plan
- [ ] Navigate between pages — each entry animates in smoothly
- [ ] Open share sheet — backdrop fades, panel slides up from bottom
- [ ] Story card shows `checkd` top right in pink italic with date below
- [ ] Story card shows vibe text bottom left, large italic white, no badge
- [ ] Story card looks correct when no vibe check data (just logo + date)
- [ ] New uploads produce vibe checks with no dashes in the text