### PR TITLE
perf: fix N+1 queries in feed/explore/vault

### DIFF
--- a/services/api/app/crud/outfit.py
+++ b/services/api/app/crud/outfit.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, timezone
 from fastapi import HTTPException, status as http_status
 
 from sqlalchemy import or_
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from app.models.clothing_item import ClothingItem
 from app.models.outfit import Outfit
@@ -56,7 +56,12 @@ def create_outfit(
 
 
 def get_outfit_with_items(db: Session, outfit_id: uuid.UUID) -> Outfit | None:
-    return db.query(Outfit).filter(Outfit.id == outfit_id).first()
+    return (
+        db.query(Outfit)
+        .options(selectinload(Outfit.clothing_items))
+        .filter(Outfit.id == outfit_id)
+        .first()
+    )
 
 
 def get_user_outfits(
@@ -70,7 +75,11 @@ def get_user_outfits(
     cursor is the ISO timestamp of the last item seen.
     Returns (outfits, next_cursor).
     """
-    query = db.query(Outfit).filter(Outfit.user_id == user_id)
+    query = (
+        db.query(Outfit)
+        .options(selectinload(Outfit.clothing_items))
+        .filter(Outfit.user_id == user_id)
+    )
 
     if cursor:
         try:
@@ -153,7 +162,11 @@ def get_feed(
     if not following_ids:
         return [], None
 
-    query = db.query(Outfit).filter(Outfit.user_id.in_(following_ids))
+    query = (
+        db.query(Outfit)
+        .options(selectinload(Outfit.clothing_items))
+        .filter(Outfit.user_id.in_(following_ids))
+    )
 
     if cursor:
         try:
@@ -181,7 +194,10 @@ def get_explore(
     All outfits on the platform, newest first.
     No user filter — public explore feed. Cursor-paginated.
     """
-    query = db.query(Outfit)
+    query = (
+        db.query(Outfit)
+        .options(selectinload(Outfit.clothing_items))
+    )
 
     if cursor:
         try:
@@ -198,7 +214,6 @@ def get_explore(
         next_cursor = outfits[-1].created_at.isoformat()
 
     return outfits, next_cursor
-
 
 
 def delete_outfit(db: Session, outfit: "Outfit") -> None:

--- a/services/api/app/crud/user.py
+++ b/services/api/app/crud/user.py
@@ -20,6 +20,13 @@ def get_by_id(db: Session, user_id: uuid.UUID) -> User | None:
     return db.query(User).filter(User.id == user_id).first()
 
 
+def get_by_ids(db: Session, user_ids: list[uuid.UUID]) -> dict[uuid.UUID, User]:
+    if not user_ids:
+        return {}
+    rows = db.query(User).filter(User.id.in_(user_ids)).all()
+    return {u.id: u for u in rows}
+
+
 def create_user(db: Session, username: str, email: str, password_hash: str) -> User:
     user = User(
         username=username,

--- a/services/api/app/routers/outfits.py
+++ b/services/api/app/routers/outfits.py
@@ -107,24 +107,19 @@ def get_feed(
     ids = follow_crud.following_ids(db, current_user.id)
     outfits, next_cursor = outfit_crud.get_feed(db, ids, cursor, limit)
 
-    author_cache: dict[str, FeedAuthor] = {}
+    author_by_id = user_crud.get_by_ids(db, list({o.user_id for o in outfits}))
     feed_items: list[FeedOutfitOut] = []
 
     for outfit in outfits:
-        cache_key = str(outfit.user_id)
-
-        if cache_key not in author_cache:
-            author = user_crud.get_by_id(db, outfit.user_id)
-            author_cache[cache_key] = FeedAuthor(
-                id=outfit.user_id,
-                username=author.username if author else None,
-                profile_image_url=author.profile_image_url if author else None,
-            )
-
+        author = author_by_id.get(outfit.user_id)
         feed_items.append(
             FeedOutfitOut(
                 **OutfitOut.model_validate(outfit).model_dump(),
-                author=author_cache[cache_key],
+                author=FeedAuthor(
+                    id=outfit.user_id,
+                    username=author.username if author else None,
+                    profile_image_url=author.profile_image_url if author else None,
+                ),
             )
         )
 
@@ -145,22 +140,19 @@ def get_explore(
     """
     outfits, next_cursor = outfit_crud.get_explore(db, cursor, limit)
 
-    author_cache: dict[str, FeedAuthor] = {}
+    author_by_id = user_crud.get_by_ids(db, list({o.user_id for o in outfits}))
     feed_items: list[FeedOutfitOut] = []
 
     for outfit in outfits:
-        cache_key = str(outfit.user_id)
-        if cache_key not in author_cache:
-            author = user_crud.get_by_id(db, outfit.user_id)
-            author_cache[cache_key] = FeedAuthor(
-                id=outfit.user_id,
-                username=author.username if author else None,
-                profile_image_url=author.profile_image_url if author else None,
-            )
+        author = author_by_id.get(outfit.user_id)
         feed_items.append(
             FeedOutfitOut(
                 **OutfitOut.model_validate(outfit).model_dump(),
-                author=author_cache[cache_key],
+                author=FeedAuthor(
+                    id=outfit.user_id,
+                    username=author.username if author else None,
+                    profile_image_url=author.profile_image_url if author else None,
+                ),
             )
         )
 


### PR DESCRIPTION
## Summary

- Added `get_by_ids()` to `user_crud` — fetches all unique outfit authors in one `SELECT … WHERE id IN (…)` instead of one query per outfit
- Added `selectinload(Outfit.clothing_items)` to `get_feed`, `get_explore`, and `get_user_outfits` in `outfit_crud` — clothing items now load in a single batch query instead of one lazy-load per outfit
- Removed the manual `author_cache` loop in `GET /outfits/feed` and `GET /outfits/explore` and replaced it with a single up-front bulk fetch

**Before:** a 20-item feed page triggered ~41 queries (1 outfit list + 20 clothing item loads + up to 20 author lookups)
**After:** 3 queries (1 outfit list + 1 clothing items batch + 1 authors batch)

## Test plan

- [x] `python3 -m py_compile` passes on all modified files
- [ ] Load `/outfits/feed` and `/outfits/explore` — verify outfits render with correct authors and clothing items
- [ ] Paginate feed (pass `cursor`) — verify cursor pagination still works
- [ ] Load vault page — verify outfits show correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)