### PR TITLE
perf: collapse auth bootstrap from 2 serial requests to 1

### DIFF
--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -34,6 +34,7 @@ export type AuthSessionResponse = {
 export type AuthRefreshResponse = {
   access_token: string;
   token_type: string;
+  user: AuthUser;
 };
 
 export type AuthLogoutResponse = {

--- a/apps/web/lib/auth-context.tsx
+++ b/apps/web/lib/auth-context.tsx
@@ -78,30 +78,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         clearAccessToken();
       }
 
-      // ── Slow path: ask the backend to exchange the refresh-token cookie ───
+      // ── Slow path: exchange refresh-token cookie for token + user in one request ───
       const refreshResult = await authApiClient.refresh();
 
       if (!isActive) {
         return;
       }
 
-      if (!refreshResult.ok) {
-        clearAccessToken();
-        clearAuthSessionCookie();
-        setUser(null);
-        setIsLoading(false);
-        return;
-      }
-
-      const meResult = await authApiClient.me();
-
-      if (!isActive) {
-        return;
-      }
-
-      if (meResult.ok) {
+      if (refreshResult.ok) {
         setAuthSessionCookie();
-        setUser(meResult.data);
+        setUser(refreshResult.data.user);
       } else {
         clearAccessToken();
         clearAuthSessionCookie();

--- a/apps/web/tests/smoke.spec.ts
+++ b/apps/web/tests/smoke.spec.ts
@@ -92,7 +92,7 @@ async function mockAuthenticatedApi(
 
     // Auth
     if (url.pathname === "/auth/refresh") {
-      await route.fulfill(jsonResponse({ access_token: "test-token", token_type: "bearer" }));
+      await route.fulfill(jsonResponse({ access_token: "test-token", token_type: "bearer", user: authUser }));
       return;
     }
     if (url.pathname === "/auth/me") {

--- a/services/api/app/routers/auth.py
+++ b/services/api/app/routers/auth.py
@@ -90,7 +90,14 @@ def refresh(
     )
     auth_service.set_refresh_cookie(response, new_refresh_token)
 
-    return RefreshResponse(access_token=auth_service.create_access_token(session.user_id))
+    user = user_crud.get_by_id(db, session.user_id)
+    if not user:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="User not found.")
+
+    return RefreshResponse(
+        access_token=auth_service.create_access_token(session.user_id),
+        user=UserResponse.model_validate(user),
+    )
 
 
 @router.post("/logout", response_model=MessageResponse)

--- a/services/api/app/schemas/auth.py
+++ b/services/api/app/schemas/auth.py
@@ -48,6 +48,7 @@ class TokenResponse(BaseModel):
 class RefreshResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
+    user: UserResponse
 
 
 class MessageResponse(BaseModel):


### PR DESCRIPTION
## Summary

- `POST /auth/refresh` now returns the full user object alongside the access token (matching the shape of `POST /auth/login` and `POST /auth/register`)
- Frontend auth bootstrap (`auth-context.tsx`) uses the user from the refresh response directly — no longer calls `GET /auth/me` after a successful refresh
- `AuthRefreshResponse` TypeScript type updated to include `user: AuthUser`

**Before:** cold page load = `POST /auth/refresh` → `GET /auth/me` (2 serial cross-origin requests)
**After:** cold page load = `POST /auth/refresh` (1 request, user bundled in response)

The fast path (cached token in sessionStorage still valid) is unchanged — it still calls `GET /auth/me` once to verify, which is correct since the token may have been invalidated server-side.

## Test plan

- [ ] Log out, reload page — verify you are still logged in after reload (refresh flow works)
- [ ] Log in fresh — verify user profile loads correctly
- [ ] Expire/clear sessionStorage manually and reload — verify refresh flow picks up the user from the refresh response
- [ ] Network tab: confirm only one auth request fires on cold load instead of two

🤖 Generated with [Claude Code](https://claude.com/claude-code)