### PR TITLE
perf: add request duration logging middleware

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -1,12 +1,18 @@
+import logging
+import time
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from app.config import settings
 from app.routers import auth, boards, health, notifications, outfits, users
 from app.services.storage import LOCAL_UPLOADS_DIR
+
+logger = logging.getLogger("ootd.api")
+
+SLOW_REQUEST_MS = 500
 
 
 @asynccontextmanager
@@ -19,6 +25,23 @@ app = FastAPI(
     version="0.1.0",
     lifespan=lifespan,
 )
+
+
+@app.middleware("http")
+async def log_request_duration(request: Request, call_next):
+    start = time.perf_counter()
+    response = await call_next(request)
+    duration_ms = (time.perf_counter() - start) * 1000
+    log = logger.warning if duration_ms > SLOW_REQUEST_MS else logger.info
+    log(
+        "%s %s %d %.0fms",
+        request.method,
+        request.url.path,
+        response.status_code,
+        duration_ms,
+    )
+    return response
+
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary

- Adds an `@app.middleware("http")` timing middleware to the FastAPI app
- Logs `METHOD /path STATUS Xms` for every request using Python's stdlib `logging`
- Requests over **500ms** log at `WARNING` level; everything else at `INFO`
- No third-party dependencies added

This gives Railway's log stream the per-endpoint p95 data needed to measure the impact of the other perf PRs in this series before and after each change.

## Test plan

- [ ] Start the API locally — confirm log lines appear for every request
- [ ] Hit a slow endpoint (e.g. explore with no DB optimizations) — confirm WARNING fires at > 500ms
- [ ] Verify health check endpoint still returns 200 (middleware doesn't break routing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)