### PR TITLE
perf: use next/image in outfit cards + configure remote patterns

### DIFF
--- a/apps/web/components/outfits/outfit-card.tsx
+++ b/apps/web/components/outfits/outfit-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 
 type OutfitCardAuthor = {
@@ -175,12 +176,15 @@ export function OutfitCard({
   if (compact) {
     return (
       <Link href={href} className="group relative block overflow-hidden bg-pink-soft/30">
-        <img
-          src={outfit.imageUrl}
-          alt={outfit.caption?.trim() || "Outfit photo"}
-          loading="lazy"
-          className="aspect-[3/4] w-full object-cover transition duration-300 group-hover:brightness-95"
-        />
+        <div className="relative aspect-[3/4] w-full overflow-hidden">
+          <Image
+            src={outfit.imageUrl}
+            alt={outfit.caption?.trim() || "Outfit photo"}
+            fill
+            sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+            className="object-cover transition duration-300 group-hover:brightness-95"
+          />
+        </div>
         {toneClasses && toneLabel ? (
           <div className="pointer-events-none absolute left-1.5 top-1.5">
             <span
@@ -219,12 +223,13 @@ export function OutfitCard({
       href={href}
       className="group overflow-hidden rounded-xl border border-line bg-white transition hover:-translate-y-0.5 hover:border-pink-deep"
     >
-      <div className="relative overflow-hidden bg-pink-soft/30">
-        <img
+      <div className="relative aspect-[4/5] overflow-hidden bg-pink-soft/30">
+        <Image
           src={outfit.imageUrl}
           alt={outfit.caption?.trim() || "Outfit card photo"}
-          loading="lazy"
-          className="aspect-[4/5] w-full object-cover transition duration-300 group-hover:scale-[1.02]"
+          fill
+          sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+          className="object-cover transition duration-300 group-hover:scale-[1.02]"
         />
 
         {showAccentMarker ? (
@@ -280,9 +285,11 @@ export function OutfitCard({
         {showAuthor ? (
           <div className="flex items-center gap-2.5">
             {outfit.author?.profileImageUrl ? (
-              <img
+              <Image
                 src={outfit.author.profileImageUrl}
                 alt={getAuthorLabel(outfit.author)}
+                width={32}
+                height={32}
                 className="h-8 w-8 rounded-full border border-line object-cover"
               />
             ) : (

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,25 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      // Production: S3 bucket in any region
+      {
+        protocol: "https",
+        hostname: "**.amazonaws.com",
+      },
+      // Development: local FastAPI upload server
+      {
+        protocol: "http",
+        hostname: "localhost",
+        port: "8000",
+        pathname: "/uploads/**",
+      },
+    ],
+    // Serve modern formats (WebP/AVIF) automatically
+    formats: ["image/avif", "image/webp"],
+  },
 };
 
 export default nextConfig;

--- a/apps/web/tests/smoke.spec.ts
+++ b/apps/web/tests/smoke.spec.ts
@@ -18,7 +18,7 @@ const authUser = {
 const mockOutfit = {
   id: "22222222-2222-4222-8222-222222222222",
   user_id: authUser.id,
-  image_url: "https://cdn.example.com/outfits/test-fit.jpg",
+  image_url: "https://example-bucket.s3.amazonaws.com/outfits/test-fit.jpg",
   caption: "Smoke test fit",
   event_name: null,
   worn_on: null,
@@ -220,8 +220,8 @@ test.describe("vault page", () => {
 
     await page.goto("/vault");
 
-    // Grid renders — outfit image should be present
-    await expect(page.locator(`img[src="${mockOutfit.image_url}"]`).first()).toBeVisible();
+    // Grid renders — outfit image should be present (next/image changes src, match on alt instead)
+    await expect(page.locator(`img[alt="${mockOutfit.caption}"]`).first()).toBeVisible();
     // Stat line shows count
     await expect(page.getByText(/1 fits/i)).toBeVisible();
   });
@@ -258,7 +258,7 @@ test.describe("feed page", () => {
 
     await page.goto("/feed");
 
-    await expect(page.locator(`img[src="${mockOutfit.image_url}"]`).first()).toBeVisible();
+    await expect(page.locator(`img[alt="${mockOutfit.caption}"]`).first()).toBeVisible();
   });
 
   test("navigation icons link to correct pages", async ({ page }) => {
@@ -311,7 +311,7 @@ test.describe("profile page", () => {
 
     await page.goto("/profile");
 
-    await expect(page.locator(`img[src="${mockOutfit.image_url}"]`).first()).toBeVisible();
+    await expect(page.locator(`img[alt="${mockOutfit.caption}"]`).first()).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Summary

- **`next.config.ts`**: configures `images.remotePatterns` for `*.amazonaws.com` (prod S3) and `localhost:8000/uploads` (dev); enables AVIF and WebP output formats
- **`outfit-card.tsx`**: replaces raw `<img>` with `next/image` in all three image locations:
  - Compact card outfit photo — `fill` layout with `sizes` for grid context
  - Full card outfit photo — `fill` layout with `sizes` for grid context
  - Author avatar — explicit `32×32` dimensions

**What next/image gives us:**
- Automatically serves AVIF/WebP instead of the original JPEG/PNG (typically 40-60% smaller)
- Resizes images to the actual display size — mobile gets a small image, desktop gets a larger one
- Vercel caches resized copies at the CDN edge
- `loading="lazy"` is the default (cards below the fold don't load until visible)

The `sizes` prop is set accurately for the card grid layout so the browser picks the right srcset breakpoint.

## Test plan

- [ ] Feed and explore pages — verify outfit cards render images correctly
- [ ] Compact grid (vault/profile) — verify compact card images load
- [ ] Author avatars — verify profile photos appear in cards with `showAuthor`
- [ ] Network tab — confirm images are served as WebP or AVIF (not JPEG) from `/_next/image`
- [ ] Mobile viewport — verify smaller images are fetched than on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)