### PR TITLE
Security hardening for public launch

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -36,7 +36,7 @@ In the AWS console → S3 → your bucket → Permissions:
 
 | Variable | Value |
 |----------|-------|
-| `SECRET_KEY` | `e6d8f9685403192a4334ceb63fe27a7395df934cf15da3dc6901b42b1f5675f1` |
+| `SECRET_KEY` | Generate a new value with `openssl rand -hex 32`. Never reuse a value from docs, chat, or local dev. |
 | `ANTHROPIC_API_KEY` | *(your key)* |
 | `S3_BUCKET` | `ootd-outfits-prod-696360034317-us-east-2-an` |
 | `AWS_ACCESS_KEY_ID` | *(from .env)* |
@@ -89,7 +89,7 @@ PUBLIC_BASE_URL=https://checkd.vercel.app
 ```env
 NEXT_PUBLIC_API_URL=http://localhost:8000
 DATABASE_URL=postgresql://ootd:ootd@localhost:5432/ootd
-SECRET_KEY=e6d8f9685403192a4334ceb63fe27a7395df934cf15da3dc6901b42b1f5675f1
+SECRET_KEY=replace-with-output-from-openssl-rand-hex-32
 ENVIRONMENT=development
 DEBUG=false
 ANTHROPIC_API_KEY=<your key>
@@ -98,3 +98,14 @@ AWS_ACCESS_KEY_ID=<your key id>
 AWS_SECRET_ACCESS_KEY=<your secret>
 AWS_REGION=us-east-2
 ```
+
+## Security launch checklist
+
+Before making the app public:
+
+- Rotate any `SECRET_KEY` that was ever copied from this file or shared in chat, commits, screenshots, or deployment notes.
+- Rotate AWS and Anthropic keys if they were ever committed, pasted into support tools, or exposed in logs.
+- Use least-privilege AWS IAM credentials: only the exact S3 bucket/actions needed for uploads and reads.
+- Keep production secrets only in Railway/Vercel environment variables; do not commit `.env` files.
+- Set `CORS_ORIGINS` to the exact Vercel/custom domain only. Do not include localhost or `*` in production.
+- Set a long random `ADMIN_SECRET` before enabling admin maintenance endpoints, or leave it empty to keep them disabled.

--- a/apps/web/app/api/proxy-image/route.ts
+++ b/apps/web/app/api/proxy-image/route.ts
@@ -1,11 +1,14 @@
 import { type NextRequest, NextResponse } from "next/server";
 
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+const FETCH_TIMEOUT_MS = 5_000;
+
 /**
  * GET /api/proxy-image?url=<encoded-url>
  *
  * Fetches an image server-side and returns it with CORS headers so the
  * client-side Canvas can draw it without being tainted. Needed because
- * S3 buckets don't ship CORS headers by default, and setting
+ * S3 buckets don"t ship CORS headers by default, and setting
  * crossOrigin="anonymous" on an <img> causes the browser to reject the
  * response, firing onerror instead of onload.
  */
@@ -16,7 +19,6 @@ export async function GET(request: NextRequest) {
     return new NextResponse("Missing url param", { status: 400 });
   }
 
-  // Basic allowlist — only proxy from known S3 / CDN origins
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -24,30 +26,51 @@ export async function GET(request: NextRequest) {
     return new NextResponse("Invalid url", { status: 400 });
   }
 
+  if (parsed.protocol !== "https:") {
+    return new NextResponse("Only HTTPS image URLs are allowed", { status: 400 });
+  }
+
+  if (parsed.username || parsed.password) {
+    return new NextResponse("Image URL credentials are not allowed", { status: 400 });
+  }
+
   const allowed =
     parsed.hostname.endsWith(".amazonaws.com") ||
     parsed.hostname.endsWith(".cloudfront.net") ||
-    parsed.hostname === "cdn.example.com"; // local dev mock
+    parsed.hostname === "cdn.example.com";
 
   if (!allowed) {
     return new NextResponse("Origin not allowed", { status: 403 });
   }
 
-  const upstream = await fetch(url, { cache: "force-cache" });
+  const abort = AbortSignal.timeout(FETCH_TIMEOUT_MS);
+  const upstream = await fetch(url, { cache: "force-cache", signal: abort });
 
   if (!upstream.ok) {
     return new NextResponse("Upstream fetch failed", { status: 502 });
   }
 
   const contentType = upstream.headers.get("Content-Type") ?? "image/jpeg";
+  if (!contentType.toLowerCase().startsWith("image/")) {
+    return new NextResponse("Upstream response is not an image", { status: 415 });
+  }
+
+  const contentLength = Number(upstream.headers.get("Content-Length") ?? "0");
+  if (contentLength > MAX_IMAGE_BYTES) {
+    return new NextResponse("Image too large", { status: 413 });
+  }
+
   const buffer = await upstream.arrayBuffer();
+  if (buffer.byteLength > MAX_IMAGE_BYTES) {
+    return new NextResponse("Image too large", { status: 413 });
+  }
 
   return new NextResponse(buffer, {
     status: 200,
     headers: {
       "Content-Type": contentType,
       "Access-Control-Allow-Origin": "*",
-      "Cache-Control": "public, max-age=86400, immutable",
-    },
+      "Cache-Control": "public, max-age=86400, immutable"
+    }
   });
 }

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -1,5 +1,8 @@
 import type { ApiFieldErrors } from "@/lib/api-client";
 
+export const MIN_PASSWORD_LENGTH = 12;
+export const MAX_PASSWORD_BYTES = 72;
+
 export type AuthMode = "login" | "signup";
 
 export type AuthValues = {
@@ -33,10 +36,14 @@ export function validateAuthForm(mode: AuthMode, values: AuthValues): AuthErrors
     errors.email = "Enter a valid email address.";
   }
 
+  const passwordByteLength = new TextEncoder().encode(values.password).length;
+
   if (!values.password) {
     errors.password = "Password is required.";
-  } else if (values.password.length < 8) {
-    errors.password = "Password must be at least 8 characters long.";
+  } else if (mode === "signup" && values.password.length < MIN_PASSWORD_LENGTH) {
+    errors.password = `Password must be at least ${MIN_PASSWORD_LENGTH} characters long.`;
+  } else if (passwordByteLength > MAX_PASSWORD_BYTES) {
+    errors.password = `Password must be ${MAX_PASSWORD_BYTES} bytes or fewer.`;
   }
 
   if (mode === "signup") {

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -8,6 +8,14 @@ import {
 const AUTH_ROUTES = new Set(["/login", "/signup"]);
 const PROTECTED_ROUTE_PREFIXES = ["/feed", "/vault", "/upload", "/outfits"];
 
+function withSecurityHeaders(response: NextResponse) {
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  response.headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+  response.headers.set("X-Frame-Options", "DENY");
+  return response;
+}
+
 function isProtectedRoute(pathname: string) {
   return PROTECTED_ROUTE_PREFIXES.some(
     (route) => pathname === route || pathname.startsWith(`${route}/`)
@@ -23,7 +31,7 @@ export function middleware(request: NextRequest) {
   const isAuthenticated = hasActiveSession(request);
 
   if (AUTH_ROUTES.has(pathname) && isAuthenticated) {
-    return NextResponse.redirect(new URL("/", request.url));
+    return withSecurityHeaders(NextResponse.redirect(new URL("/", request.url)));
   }
 
   if (isProtectedRoute(pathname) && !isAuthenticated) {
@@ -34,10 +42,10 @@ export function middleware(request: NextRequest) {
       loginUrl.searchParams.set("next", nextPath);
     }
 
-    return NextResponse.redirect(loginUrl);
+    return withSecurityHeaders(NextResponse.redirect(loginUrl));
   }
 
-  return NextResponse.next();
+  return withSecurityHeaders(NextResponse.next());
 }
 
 export const config = {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,30 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**.amazonaws.com"
+      },
+      {
+        protocol: "https",
+        hostname: "**.cloudfront.net"
+      },
+      {
+        protocol: "https",
+        hostname: "cdn.example.com"
+      },
+      {
+        protocol: "http",
+        hostname: "localhost",
+        port: "8000",
+        pathname: "/uploads/**"
+      }
+    ],
+    formats: ["image/avif", "image/webp"]
+  }
 };
 
 export default nextConfig;

--- a/apps/web/tests/smoke.spec.ts
+++ b/apps/web/tests/smoke.spec.ts
@@ -221,7 +221,7 @@ test.describe("vault page", () => {
     await page.goto("/vault");
 
     // Grid renders — outfit image should be present
-    await expect(page.locator(`img[src="${mockOutfit.image_url}"]`).first()).toBeVisible();
+    await expect(page.getByAltText(/smoke test fit/i).first()).toBeVisible();
     // Stat line shows count
     await expect(page.getByText(/1 fits/i)).toBeVisible();
   });
@@ -258,7 +258,7 @@ test.describe("feed page", () => {
 
     await page.goto("/feed");
 
-    await expect(page.locator(`img[src="${mockOutfit.image_url}"]`).first()).toBeVisible();
+    await expect(page.getByAltText(/smoke test fit/i).first()).toBeVisible();
   });
 
   test("navigation icons link to correct pages", async ({ page }) => {
@@ -311,7 +311,7 @@ test.describe("profile page", () => {
 
     await page.goto("/profile");
 
-    await expect(page.locator(`img[src="${mockOutfit.image_url}"]`).first()).toBeVisible();
+    await expect(page.getByAltText(/smoke test fit/i).first()).toBeVisible();
   });
 });
 

--- a/docs/security-plan.md
+++ b/docs/security-plan.md
@@ -1,0 +1,155 @@
+# Public launch security plan
+
+This plan focuses on password and API key vulnerabilities first, then the surrounding controls that keep those two areas from becoming production incidents.
+
+## Immediate risk inventory
+
+### Critical
+
+1. A concrete JWT `SECRET_KEY` was present in `DEPLOY.md`.
+   - Impact: anyone with that value can forge valid access tokens for production if the same value is deployed.
+   - Fix in this PR: removed the hardcoded value from deployment docs and added production config validation that rejects weak/placeholder secrets.
+   - Required operational action: rotate production `SECRET_KEY` before public launch if this value was ever deployed or copied.
+
+2. API keys and cloud credentials depend on human handling discipline.
+   - Impact: leaked AWS or Anthropic keys can lead to data exposure, account abuse, and unexpected billing.
+   - Fix in this PR: added explicit launch checklist guidance for rotation, least privilege, and env-only storage.
+   - Required operational action: rotate any key that has appeared in local files, chat, support tools, screenshots, or logs.
+
+3. Login endpoints had no brute-force protection.
+   - Impact: public login can be attacked with credential stuffing or password spraying.
+   - Fix in this PR: added dependency-free rate limiting on login/register attempts by IP and login email.
+   - Required operational action: add provider/edge or Redis-backed rate limiting for multi-instance production.
+
+### High
+
+4. Password minimum was too low for a public app without MFA.
+   - Impact: weak passwords are easier to guess and more likely to appear in credential stuffing lists.
+   - Fix in this PR: raised signup password minimum to 12 characters in frontend and backend.
+   - Recommended next step: add optional MFA before wider launch, then revisit password policy and recovery flows.
+
+5. Bcrypt password truncation was not explicitly handled.
+   - Impact: bcrypt only uses the first 72 bytes; users could create passwords that appear different but verify the same after byte 72.
+   - Fix in this PR: reject passwords longer than 72 bytes and fail verification for oversized login inputs.
+
+6. Production startup did not reject unsafe security config.
+   - Impact: a deploy can accidentally go public with placeholder secrets, wildcard/localhost CORS, or short admin secrets.
+   - Fix in this PR: production config validation now rejects weak `SECRET_KEY`, wildcard/localhost CORS origins, too-short `ADMIN_SECRET`, and incomplete S3 credential config.
+
+### Medium
+
+7. Refresh cookie deletion did not mirror production cookie attributes.
+   - Impact: logout can fail to clear a production cross-site refresh cookie in some browsers.
+   - Fix in this PR: cookie deletion now uses matching `SameSite` and `Secure` settings for the current environment.
+
+8. Refresh tokens are SHA-256 hashed without a server-side pepper.
+   - Current status: acceptable because refresh tokens are high entropy, random, and rotated.
+   - Recommended next step: consider HMAC-SHA-256 with a separate server secret for refresh token hashes.
+
+9. Auth tokens are returned to client JavaScript.
+   - Current status: access tokens are short-lived and stored in memory/sessionStorage.
+   - Risk: XSS can steal access tokens from sessionStorage.
+   - Recommended next step: add strict Content Security Policy and consider moving access-token handling to an httpOnly same-site pattern if frontend/API are unified under one domain.
+
+10. Password recovery UI exists, but a secure reset flow needs a dedicated review.
+    - Risk: reset-token leakage or account takeover if implemented casually.
+    - Required before launch: single-use reset tokens, short expiry, hashed token storage, generic responses, rate limiting, and email verification.
+
+## Fixes made in this PR
+
+- Removed hardcoded JWT secret from `DEPLOY.md`.
+- Added production config validation for:
+  - random `SECRET_KEY` length/placeholder checks,
+  - exact production `CORS_ORIGINS`,
+  - minimum `ADMIN_SECRET` length when enabled,
+  - complete AWS credential config when S3 is configured.
+- Raised signup password minimum from 8 to 12 characters.
+- Added 72-byte password maximum to prevent bcrypt truncation ambiguity.
+- Added login/register rate limiting.
+- Made refresh-cookie clearing mirror production cookie attributes.
+- Added baseline frontend security headers.
+- Tightened the image proxy to HTTPS image responses from allowed hosts with timeout and size limits.
+- Updated auth contract and deployment docs.
+- Added tests for password byte limit and auth rate limiting.
+
+## Required launch actions outside the repo
+
+1. Rotate production `SECRET_KEY`.
+   - Use: `openssl rand -hex 32`
+   - Set only in Railway production env vars.
+   - This invalidates existing access tokens; users may need to log in again.
+
+2. Rotate exposed or uncertain API keys.
+   - AWS access key.
+   - Anthropic API key.
+   - Any admin/cron secret.
+
+3. Lock down AWS IAM.
+   - Use a dedicated IAM user or role for this app only.
+   - Scope permissions to the exact S3 bucket.
+   - Allow only required actions, for example object put/get/delete/list as needed.
+   - Disable console access for app credentials.
+
+4. Verify provider secrets.
+   - Railway: backend secrets only.
+   - Vercel: frontend public values only, unless using server-side route handlers.
+   - Never put private secrets in `NEXT_PUBLIC_*`; those are browser-visible.
+
+5. Add production-grade distributed rate limiting.
+   - The in-process limiter is useful but does not coordinate across multiple server instances.
+   - Preferred: edge/WAF rate limit, Redis-backed limiter, or managed API gateway limit.
+
+6. Add secret scanning in GitHub.
+   - Enable GitHub secret scanning and push protection.
+   - Add a CI job using a scanner such as Gitleaks or TruffleHog.
+
+7. Add security headers.
+   - Content-Security-Policy.
+   - Strict-Transport-Security.
+   - X-Content-Type-Options.
+   - Referrer-Policy.
+   - Permissions-Policy.
+
+8. Run dependency scanning.
+   - Dependabot alerts.
+   - `npm audit` for the web app.
+   - `pip-audit` or equivalent for the API.
+
+## Password policy
+
+Current policy after this PR:
+
+- Signup passwords must be at least 12 characters.
+- Passwords must be 72 bytes or fewer because bcrypt truncates beyond 72 bytes.
+- Login responses remain generic.
+- Password hashes use bcrypt.
+
+Recommended next additions:
+
+- Check new passwords against breached-password corpuses, preferably k-anonymity lookup.
+- Add MFA before larger public launch.
+- Add email verification before social graph growth.
+- Add secure password reset with one-time hashed reset tokens.
+
+## API key policy
+
+Rules:
+
+- Private keys must never use `NEXT_PUBLIC_*`.
+- Private keys must live only in provider environment variable stores.
+- Keys must be rotated after any suspected exposure.
+- Keys must be least-privilege and app-specific.
+- Logs must never print key values, signed URLs, bearer tokens, refresh tokens, or cookies.
+
+Rotation cadence:
+
+- Immediate rotation after any exposure.
+- Scheduled rotation every 90 days for AWS/admin secrets.
+- Anthropic key rotation based on provider support and billing-risk tolerance.
+
+## Sources
+
+- OWASP Password Storage Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
+- OWASP Authentication Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html
+- OWASP Secrets Management Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+- OWASP API Security Top 10 2023: https://owasp.org/API-Security/editions/2023/en/0x11-t10/

--- a/packages/contracts/auth-contract.md
+++ b/packages/contracts/auth-contract.md
@@ -42,7 +42,7 @@ Create a new account.
 |---|---|---|---|
 | `username` | string | yes | min 3 characters |
 | `email` | string | yes | must be a valid email |
-| `password` | string | yes | min 8 characters |
+| `password` | string | yes | 12-72 bytes |
 
 **Response `201 Created`**
 ```json

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -1,4 +1,15 @@
+from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+_PLACEHOLDER_SECRET_KEYS = {
+    "changeme",
+    "change-me",
+    "changeme-replace-with-a-secure-random-string",
+    "secret",
+    "dev-secret",
+    "test-secret",
+}
 
 
 class Settings(BaseSettings):
@@ -34,6 +45,34 @@ class Settings(BaseSettings):
     allowed_origins: list[str] = []
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    @model_validator(mode="after")
+    def validate_public_launch_security(self) -> "Settings":
+        if self.environment != "production":
+            return self
+
+        secret_key = self.secret_key.strip()
+        if (
+            len(secret_key) < 32
+            or secret_key.lower() in _PLACEHOLDER_SECRET_KEYS
+            or len(set(secret_key)) < 8
+        ):
+            raise ValueError("Production SECRET_KEY must be a unique random value with at least 32 characters.")
+
+        origins = self.cors_origin_list
+        if not origins:
+            raise ValueError("Production CORS_ORIGINS must be set to the public frontend origin.")
+        disallowed = {"*", "http://localhost:3000", "http://127.0.0.1:3000"}
+        if any(origin in disallowed for origin in origins):
+            raise ValueError("Production CORS_ORIGINS cannot include wildcards or localhost origins.")
+
+        if self.admin_secret and len(self.admin_secret) < 32:
+            raise ValueError("Production ADMIN_SECRET must be at least 32 characters when enabled.")
+
+        if self.s3_bucket and (not self.aws_access_key_id or not self.aws_secret_access_key):
+            raise ValueError("S3 uploads require AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.")
+
+        return self
 
     @property
     def cors_origin_list(self) -> list[str]:

--- a/services/api/app/routers/auth.py
+++ b/services/api/app/routers/auth.py
@@ -17,8 +17,27 @@ from app.schemas.auth import (
     UserResponse,
 )
 from app.services import auth as auth_service
+from app.services.rate_limit import login_rate_limiter, register_rate_limiter
 
 router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+def _client_ip(request: Request) -> str:
+    forwarded_for = request.headers.get("x-forwarded-for")
+    if forwarded_for:
+        return forwarded_for.split(",", 1)[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def _enforce_rate_limit(key: str, limiter) -> None:
+    decision = limiter.check(key)
+    if decision.allowed:
+        return
+    raise HTTPException(
+        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        detail="Too many attempts. Please try again later.",
+        headers={"Retry-After": str(decision.retry_after_seconds)},
+    )
 
 
 @router.post("/register", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
@@ -28,6 +47,8 @@ def register(
     request: Request,
     db: Session = Depends(get_db),
 ) -> TokenResponse:
+    _enforce_rate_limit(f"register:ip:{_client_ip(request)}", register_rate_limiter)
+
     if user_crud.get_by_email(db, body.email):
         raise HTTPException(status.HTTP_409_CONFLICT, detail="Email already registered.")
     if user_crud.get_by_username(db, body.username):
@@ -51,7 +72,12 @@ def login(
     request: Request,
     db: Session = Depends(get_db),
 ) -> TokenResponse:
-    user = user_crud.get_by_email(db, body.email)
+    normalized_email = body.email.lower()
+    client_ip = _client_ip(request)
+    _enforce_rate_limit(f"login:ip:{client_ip}", login_rate_limiter)
+    _enforce_rate_limit(f"login:email:{normalized_email}", login_rate_limiter)
+
+    user = user_crud.get_by_email(db, normalized_email)
     if not user or not auth_service.verify_password(body.password, user.password_hash):
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Invalid email or password.")
 

--- a/services/api/app/schemas/auth.py
+++ b/services/api/app/schemas/auth.py
@@ -2,6 +2,8 @@ import uuid
 
 from pydantic import BaseModel, EmailStr, field_validator
 
+from app.services.auth import MAX_PASSWORD_BYTES, MIN_PASSWORD_LENGTH
+
 
 class RegisterRequest(BaseModel):
     username: str
@@ -17,9 +19,11 @@ class RegisterRequest(BaseModel):
 
     @field_validator("password")
     @classmethod
-    def password_min_length(cls, v: str) -> str:
-        if len(v) < 8:
-            raise ValueError("Password must be at least 8 characters.")
+    def password_strength(cls, v: str) -> str:
+        if len(v) < MIN_PASSWORD_LENGTH:
+            raise ValueError(f"Password must be at least {MIN_PASSWORD_LENGTH} characters.")
+        if len(v.encode("utf-8")) > MAX_PASSWORD_BYTES:
+            raise ValueError(f"Password must be {MAX_PASSWORD_BYTES} bytes or fewer.")
         return v
 
 

--- a/services/api/app/services/auth.py
+++ b/services/api/app/services/auth.py
@@ -13,13 +13,19 @@ ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 15
 REFRESH_TOKEN_EXPIRE_DAYS = 7
 COOKIE_NAME = "refresh_token"
+MIN_PASSWORD_LENGTH = 12
+MAX_PASSWORD_BYTES = 72
 
 
 def hash_password(password: str) -> str:
+    if len(password.encode("utf-8")) > MAX_PASSWORD_BYTES:
+        raise ValueError(f"Password must be {MAX_PASSWORD_BYTES} bytes or fewer.")
     return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
 
 
 def verify_password(plain: str, hashed: str) -> bool:
+    if len(plain.encode("utf-8")) > MAX_PASSWORD_BYTES:
+        return False
     return bcrypt.checkpw(plain.encode(), hashed.encode())
 
 
@@ -66,4 +72,11 @@ def set_refresh_cookie(response: Response, token: str) -> None:
 
 
 def clear_refresh_cookie(response: Response) -> None:
-    response.delete_cookie(key=COOKIE_NAME, path="/auth", samesite="none")
+    is_production = settings.environment == "production"
+    response.delete_cookie(
+        key=COOKIE_NAME,
+        path="/auth",
+        samesite="none" if is_production else "lax",
+        secure=is_production,
+        httponly=True,
+    )

--- a/services/api/app/services/rate_limit.py
+++ b/services/api/app/services/rate_limit.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+
+
+@dataclass
+class RateLimitDecision:
+    allowed: bool
+    retry_after_seconds: int
+
+
+class FixedWindowRateLimiter:
+    """Small in-process limiter for auth endpoints.
+
+    This is intentionally dependency-free. In production, keep this as a local
+    safety net and add a shared edge/Redis limiter so limits hold across
+    multiple API instances.
+    """
+
+    def __init__(self, max_attempts: int, window_seconds: int) -> None:
+        self.max_attempts = max_attempts
+        self.window_seconds = window_seconds
+        self._attempts: dict[str, list[float]] = {}
+        self._lock = threading.Lock()
+
+    def check(self, key: str) -> RateLimitDecision:
+        now = time.monotonic()
+        cutoff = now - self.window_seconds
+
+        with self._lock:
+            attempts = [ts for ts in self._attempts.get(key, []) if ts > cutoff]
+
+            if len(attempts) >= self.max_attempts:
+                retry_after = max(1, int(self.window_seconds - (now - attempts[0])))
+                self._attempts[key] = attempts
+                return RateLimitDecision(False, retry_after)
+
+            attempts.append(now)
+            self._attempts[key] = attempts
+            return RateLimitDecision(True, 0)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._attempts.clear()
+
+
+login_rate_limiter = FixedWindowRateLimiter(max_attempts=10, window_seconds=60)
+register_rate_limiter = FixedWindowRateLimiter(max_attempts=5, window_seconds=60)
+
+
+def reset_auth_rate_limiters() -> None:
+    login_rate_limiter.reset()
+    register_rate_limiter.reset()

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -9,6 +9,7 @@ import app.models  # noqa: F401 — registers all models with Base.metadata
 from app.dependencies import get_db
 from app.main import app
 from app.models.base import Base
+from app.services.rate_limit import reset_auth_rate_limiters
 
 # In CI, DATABASE_URL points directly at the test database.
 # Locally, set TEST_DATABASE_URL in your .env to a separate test database,
@@ -32,6 +33,7 @@ def create_tables():
 @pytest.fixture(autouse=True)
 def clean_tables():
     """Wipe all rows before each test so tests are fully isolated."""
+    reset_auth_rate_limiters()
     yield
     with engine.connect() as conn:
         for table in reversed(Base.metadata.sorted_tables):

--- a/services/api/tests/test_auth.py
+++ b/services/api/tests/test_auth.py
@@ -14,7 +14,7 @@ ME_URL = "/auth/me"
 VALID_USER = {
     "username": "testuser",
     "email": "test@example.com",
-    "password": "securepassword123",
+    "password": "securepassword12345",
 }
 
 
@@ -82,6 +82,10 @@ class TestRegister:
         res = _register(client, {**VALID_USER, "password": "short"})
         assert res.status_code == 422
 
+    def test_bcrypt_truncation_length_password_returns_422(self, client):
+        res = _register(client, {**VALID_USER, "password": "a" * 73})
+        assert res.status_code == 422
+
     def test_short_username_returns_422(self, client):
         res = _register(client, {**VALID_USER, "username": "ab"})
         assert res.status_code == 422
@@ -122,6 +126,15 @@ class TestLogin:
     def test_unregistered_user_returns_401(self, client):
         res = _login(client)
         assert res.status_code == 401
+
+    def test_repeated_login_attempts_are_rate_limited(self, client):
+        for _ in range(10):
+            res = _login(client, email="nobody@example.com", password="wrongpassword")
+            assert res.status_code == 401
+
+        res = _login(client, email="nobody@example.com", password="wrongpassword")
+        assert res.status_code == 429
+        assert "Retry-After" in res.headers
 
     def test_password_never_returned(self, client):
         _register(client)

--- a/services/api/tests/test_boards.py
+++ b/services/api/tests/test_boards.py
@@ -7,9 +7,9 @@ import pytest
 REGISTER_URL = "/auth/register"
 BOARDS_URL = "/boards"
 
-USER_A = {"username": "board_a", "email": "board_a@example.com", "password": "password123"}
-USER_B = {"username": "board_b", "email": "board_b@example.com", "password": "password123"}
-USER_C = {"username": "board_c", "email": "board_c@example.com", "password": "password123"}
+USER_A = {"username": "board_a", "email": "board_a@example.com", "password": "password12345"}
+USER_B = {"username": "board_b", "email": "board_b@example.com", "password": "password12345"}
+USER_C = {"username": "board_c", "email": "board_c@example.com", "password": "password12345"}
 
 
 def _register(client, payload):

--- a/services/api/tests/test_caption_search_expiry.py
+++ b/services/api/tests/test_caption_search_expiry.py
@@ -7,8 +7,8 @@ import pytest
 
 REGISTER_URL = "/auth/register"
 
-USER_A = {"username": "cse_a", "email": "cse_a@example.com", "password": "password123"}
-USER_B = {"username": "cse_b", "email": "cse_b@example.com", "password": "password123"}
+USER_A = {"username": "cse_a", "email": "cse_a@example.com", "password": "password12345"}
+USER_B = {"username": "cse_b", "email": "cse_b@example.com", "password": "password12345"}
 
 
 def _register(client, payload):

--- a/services/api/tests/test_feed.py
+++ b/services/api/tests/test_feed.py
@@ -9,9 +9,9 @@ FEED_URL = "/outfits/feed"
 MY_VAULT_URL = "/outfits/me"
 USER_VAULT_URL = "/outfits/user/{username}"
 
-USER_A = {"username": "usera", "email": "a@example.com", "password": "password123"}
-USER_B = {"username": "userb", "email": "b@example.com", "password": "password123"}
-USER_C = {"username": "userc", "email": "c@example.com", "password": "password123"}
+USER_A = {"username": "usera", "email": "a@example.com", "password": "password12345"}
+USER_B = {"username": "userb", "email": "b@example.com", "password": "password12345"}
+USER_C = {"username": "userc", "email": "c@example.com", "password": "password12345"}
 
 
 def _register(client, payload):

--- a/services/api/tests/test_follows.py
+++ b/services/api/tests/test_follows.py
@@ -6,8 +6,8 @@ REGISTER_URL = "/auth/register"
 FOLLOW_URL = "/users/{username}/follow"
 PROFILE_URL = "/users/{username}"
 
-USER_A = {"username": "usera", "email": "a@example.com", "password": "password123"}
-USER_B = {"username": "userb", "email": "b@example.com", "password": "password123"}
+USER_A = {"username": "usera", "email": "a@example.com", "password": "password12345"}
+USER_B = {"username": "userb", "email": "b@example.com", "password": "password12345"}
 
 
 def _register(client: TestClient, payload: dict) -> dict:

--- a/services/api/tests/test_notifications.py
+++ b/services/api/tests/test_notifications.py
@@ -10,8 +10,8 @@ NOTIF_URL = "/notifications"
 UNSEEN_URL = "/notifications/unseen-count"
 SEEN_URL = "/notifications/seen"
 
-USER_A = {"username": "usera", "email": "a@example.com", "password": "password123"}
-USER_B = {"username": "userb", "email": "b@example.com", "password": "password123"}
+USER_A = {"username": "usera", "email": "a@example.com", "password": "password12345"}
+USER_B = {"username": "userb", "email": "b@example.com", "password": "password12345"}
 
 
 def _register(client: TestClient, payload: dict) -> dict:

--- a/services/api/tests/test_outfit_detail.py
+++ b/services/api/tests/test_outfit_detail.py
@@ -4,8 +4,8 @@ import io
 
 REGISTER_URL = "/auth/register"
 
-USER_A = {"username": "detail_a", "email": "detail_a@example.com", "password": "password123"}
-USER_B = {"username": "detail_b", "email": "detail_b@example.com", "password": "password123"}
+USER_A = {"username": "detail_a", "email": "detail_a@example.com", "password": "password12345"}
+USER_B = {"username": "detail_b", "email": "detail_b@example.com", "password": "password12345"}
 
 
 def _register(client, payload):

--- a/services/api/tests/test_profile.py
+++ b/services/api/tests/test_profile.py
@@ -9,9 +9,9 @@ SEARCH_URL = "/users/search"
 SUGGESTED_URL = "/users/suggested"
 FOLLOW_URL = "/users/{username}/follow"
 
-USER_A = {"username": "usera", "email": "a@example.com", "password": "password123"}
-USER_B = {"username": "userb", "email": "b@example.com", "password": "password123"}
-USER_C = {"username": "userc", "email": "c@example.com", "password": "password123"}
+USER_A = {"username": "usera", "email": "a@example.com", "password": "password12345"}
+USER_B = {"username": "userb", "email": "b@example.com", "password": "password12345"}
+USER_C = {"username": "userc", "email": "c@example.com", "password": "password12345"}
 
 
 def _register(client, payload):

--- a/services/api/tests/test_social.py
+++ b/services/api/tests/test_social.py
@@ -4,9 +4,9 @@ import io
 
 REGISTER_URL = "/auth/register"
 
-USER_A = {"username": "social_a", "email": "social_a@example.com", "password": "password123"}
-USER_B = {"username": "social_b", "email": "social_b@example.com", "password": "password123"}
-USER_C = {"username": "social_c", "email": "social_c@example.com", "password": "password123"}
+USER_A = {"username": "social_a", "email": "social_a@example.com", "password": "password12345"}
+USER_B = {"username": "social_b", "email": "social_b@example.com", "password": "password12345"}
+USER_C = {"username": "social_c", "email": "social_c@example.com", "password": "password12345"}
 
 
 def _register(client, payload):

--- a/services/api/tests/test_story_card.py
+++ b/services/api/tests/test_story_card.py
@@ -7,7 +7,7 @@ REGISTER_URL = "/auth/register"
 CREATE_OUTFIT_URL = "/outfits"
 STORY_CARD_URL = "/outfits/{outfit_id}/story-card"
 
-USER_A = {"username": "usera", "email": "a@example.com", "password": "password123"}
+USER_A = {"username": "usera", "email": "a@example.com", "password": "password12345"}
 
 
 def _register(client, payload):

--- a/services/api/tests/test_vibe_check.py
+++ b/services/api/tests/test_vibe_check.py
@@ -5,7 +5,7 @@ import io
 REGISTER_URL = "/auth/register"
 CREATE_OUTFIT_URL = "/outfits"
 
-USER_A = {"username": "usera", "email": "a@example.com", "password": "password123"}
+USER_A = {"username": "usera", "email": "a@example.com", "password": "password12345"}
 
 
 def _register(client, payload):

--- a/services/api/tests/test_wrapped.py
+++ b/services/api/tests/test_wrapped.py
@@ -6,7 +6,7 @@ REGISTER_URL = "/auth/register"
 CREATE_OUTFIT_URL = "/outfits"
 WRAPPED_URL = "/users/me/wrapped"
 
-USER_A = {"username": "usera", "email": "a@example.com", "password": "password123"}
+USER_A = {"username": "usera", "email": "a@example.com", "password": "password12345"}
 
 
 def _register(client, payload):


### PR DESCRIPTION
## Summary
- remove hardcoded JWT secret guidance and add a launch security plan
- enforce stronger password bounds, production config checks, and auth rate limiting
- add baseline web security headers and harden the image proxy

## Tests
- DATABASE_URL=postgresql://ootd:ootd@localhost:5433/ootd_test SECRET_KEY=test-secret-for-local-tests-only-32chars CORS_ORIGINS=http://localhost:3000 .venv/bin/pytest
- npm run build
- PORT=3101 PLAYWRIGHT_BASE_URL=http://localhost:3101 npm run test:smoke

## Launch note
Rotate any SECRET_KEY, AWS, Anthropic, or admin secret that was ever copied from docs, chat, screenshots, local files, or deployment notes before going public.