### PR TITLE
fix(explore): remove duplicate search bar, keep icon button

### DIFF
--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -266,19 +266,6 @@ export default function ExplorePage() {
             </Link>
           </div>
 
-          {/* Search tap-target → /search */}
-          <Link
-            href="/search"
-            className="search-shell mb-5 block"
-            aria-label="Search people"
-          >
-            <svg aria-hidden="true" viewBox="0 0 24 24" className="h-4 w-4 shrink-0 text-mute" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-              <circle cx="11" cy="11" r="6.5" />
-              <path d="m16 16 4 4" />
-            </svg>
-            <span className="search-input text-mute">Find people…</span>
-          </Link>
-
           {/* Who to follow rail */}
           <WhoToFollowRail
             users={suggested}


### PR DESCRIPTION
## Summary
- Removed the full-width `search-shell` tap-target from the Explore page header
- The small search icon button in the top-right remains

## Test plan
- [ ] Visit /explore — header shows only the magnifying glass icon, no search bar below the title