### PR TITLE
feat(vault): back button + board upload vault toggle

### DIFF
--- a/apps/web/app/boards/[id]/upload/page.tsx
+++ b/apps/web/app/boards/[id]/upload/page.tsx
@@ -20,6 +20,7 @@ export default function BoardUploadPage({ params }: { params: Promise<{ id: stri
   const [photo, setPhoto] = useState<File | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
   const [caption, setCaption] = useState("");
+  const [saveToVault, setSaveToVault] = useState(false);
   const [submitStatus, setSubmitStatus] = useState<SubmitStatus>("idle");
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -70,7 +71,7 @@ export default function BoardUploadPage({ params }: { params: Promise<{ id: stri
 
     const createResult = await apiClient.outfits.create({
       image: photo,
-      metadata: { caption: caption.trim() || undefined, clothing_items: [] },
+      metadata: { caption: caption.trim() || undefined, clothing_items: [], save_to_vault: saveToVault },
     });
 
     if (!createResult.ok) {
@@ -291,6 +292,29 @@ export default function BoardUploadPage({ params }: { params: Promise<{ id: stri
                 </div>
               )}
             </div>
+
+            {/* Vault toggle */}
+            <button
+              type="button"
+              onClick={() => setSaveToVault((v) => !v)}
+              className="mt-4 flex w-full items-center justify-between rounded-2xl border border-line bg-white px-5 py-4 transition hover:border-pink-deep/30"
+            >
+              <div className="text-left">
+                <p className="text-sm font-medium text-ink">save to my vault</p>
+                <p className="mt-0.5 text-xs text-mute">keep this look in your personal archive</p>
+              </div>
+              <div
+                className={`relative h-6 w-10 flex-shrink-0 rounded-full border transition-colors duration-200 ${
+                  saveToVault ? "border-ink bg-ink" : "border-line bg-line"
+                }`}
+              >
+                <span
+                  className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200 ${
+                    saveToVault ? "translate-x-4" : "translate-x-0"
+                  }`}
+                />
+              </div>
+            </button>
 
             {errorMsg ? (
               <div className="mt-4 rounded-2xl border border-pink-deep/30 bg-pink-soft px-4 py-3 text-sm text-error">

--- a/apps/web/app/vault/page.tsx
+++ b/apps/web/app/vault/page.tsx
@@ -294,6 +294,7 @@ export default function VaultPage() {
                 {searchResults.map((outfit) => (
                   <OutfitCard
                     key={outfit.id}
+                    href={`/outfits/${outfit.id}?from=vault`}
                     outfit={toCardData(outfit)}
                     compact
                     liked={likes[outfit.id]?.liked}
@@ -324,6 +325,7 @@ export default function VaultPage() {
                 {outfits.map((outfit) => (
                   <OutfitCard
                     key={outfit.id}
+                    href={`/outfits/${outfit.id}?from=vault`}
                     outfit={toCardData(outfit)}
                     compact
                     liked={likes[outfit.id]?.liked}

--- a/apps/web/components/outfits/outfit-detail-view.tsx
+++ b/apps/web/components/outfits/outfit-detail-view.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { apiClient, type Comment, type OutfitDetailResponse } from "@/lib/api-client";
 import { MobileNav } from "@/components/chrome/mobile-nav";
 import { StoryCardSheet } from "@/components/outfits/story-card-sheet";
@@ -275,6 +275,8 @@ function CommentRow({ comment, isOwn, editing, onStartEdit, onCancelEdit, onSave
 
 export function OutfitDetailView({ id }: { id: string }) {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const fromVault = searchParams.get("from") === "vault";
   const { user, isAuthenticated } = useAuth();
 
   const [status, setStatus] = useState<PageStatus>("loading");
@@ -364,9 +366,9 @@ export function OutfitDetailView({ id }: { id: string }) {
             <button
               type="button"
               onClick={() => {
-                // If there's browser history, go back. Otherwise fall back to /feed
-                // so users who opened a shared link don't end up on an external page.
-                if (typeof window !== "undefined" && window.history.length > 1) {
+                if (fromVault) {
+                  router.push("/vault");
+                } else if (typeof window !== "undefined" && window.history.length > 1) {
                   router.back();
                 } else {
                   router.push("/feed");
@@ -377,7 +379,7 @@ export function OutfitDetailView({ id }: { id: string }) {
               <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="m15 18-6-6 6-6" />
               </svg>
-              back
+              {fromVault ? "vault" : "back"}
             </button>
 
             <button

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -227,6 +227,7 @@ export type CreateOutfitInput = {
       display_order: number;
       link_url?: string;
     }>;
+    save_to_vault?: boolean;
   };
 };
 

--- a/services/api/alembic/versions/20260512_d7e8f9a0_add_vault_hidden_to_outfits.py
+++ b/services/api/alembic/versions/20260512_d7e8f9a0_add_vault_hidden_to_outfits.py
@@ -1,0 +1,29 @@
+"""add vault_hidden to outfits
+
+Revision ID: d7e8f9a0
+Revises: c5d6e7f8
+Create Date: 2026-05-12
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "d7e8f9a0"
+down_revision = "c5d6e7f8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "outfits",
+        sa.Column(
+            "vault_hidden",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("outfits", "vault_hidden")

--- a/services/api/app/crud/outfit.py
+++ b/services/api/app/crud/outfit.py
@@ -21,6 +21,7 @@ def create_outfit(
     worn_on: date | None = None,
     vibe_check_text: str | None = None,
     vibe_check_tone: str | None = None,
+    vault_hidden: bool = False,
 ) -> Outfit:
     """
     Insert one outfit row and all its clothing_items in a single transaction.
@@ -34,6 +35,7 @@ def create_outfit(
         worn_on=worn_on,
         vibe_check_text=vibe_check_text,
         vibe_check_tone=vibe_check_tone,
+        vault_hidden=vault_hidden,
     )
     db.add(outfit)
     db.flush()  # get outfit.id without committing yet
@@ -78,7 +80,7 @@ def get_user_outfits(
     query = (
         db.query(Outfit)
         .options(selectinload(Outfit.clothing_items))
-        .filter(Outfit.user_id == user_id)
+        .filter(Outfit.user_id == user_id, Outfit.vault_hidden.is_(False))
     )
 
     if cursor:
@@ -117,6 +119,7 @@ def search_user_outfits(
         db.query(Outfit.id)
         .filter(
             Outfit.user_id == user_id,
+            Outfit.vault_hidden.is_(False),
             or_(
                 func.lower(Outfit.caption).like(term),
                 func.lower(Outfit.event_name).like(term),
@@ -130,6 +133,7 @@ def search_user_outfits(
         .join(Outfit, Outfit.id == ClothingItem.outfit_id)
         .filter(
             Outfit.user_id == user_id,
+            Outfit.vault_hidden.is_(False),
             or_(
                 func.lower(ClothingItem.brand).like(term),
                 func.lower(ClothingItem.category).like(term),

--- a/services/api/app/models/outfit.py
+++ b/services/api/app/models/outfit.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import date, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Date, DateTime, ForeignKey, Index, String, text
+from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Index, String, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -29,6 +29,7 @@ class Outfit(Base):
     worn_on: Mapped[date | None] = mapped_column(Date, nullable=True)
     vibe_check_text: Mapped[str | None] = mapped_column(String, nullable=True)
     vibe_check_tone: Mapped[str | None] = mapped_column(String, nullable=True)
+    vault_hidden: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=text("now()")
     )

--- a/services/api/app/routers/outfits.py
+++ b/services/api/app/routers/outfits.py
@@ -101,6 +101,7 @@ def create_outfit(
         clothing_items=meta.clothing_items,
         vibe_check_text=vibe_check_text,
         vibe_check_tone=vibe_check_tone,
+        vault_hidden=not meta.save_to_vault,
     )
 
     return OutfitOut.model_validate(outfit)

--- a/services/api/app/schemas/outfit.py
+++ b/services/api/app/schemas/outfit.py
@@ -33,6 +33,7 @@ class OutfitMetadata(BaseModel):
     event_name: str | None = None
     worn_on: date | None = None
     clothing_items: list[ClothingItemIn] = Field(default_factory=list)
+    save_to_vault: bool = True
 
 
 # ------------------------------------------------------------------ output


### PR DESCRIPTION
## Summary
- **Back button**: vault outfit cards now pass `?from=vault` in their href. The outfit detail view reads this param — when present, the back button says "← vault" and navigates directly to `/vault` instead of relying on browser history
- **Board upload vault toggle**: step 2 of the board upload flow now has a "save to my vault" toggle (default OFF). Wires `save_to_vault` to the outfit create API call

## Backend note
The vault toggle is frontend-ready but needs backend support to function. Reagan needs to add a `vault_hidden` (or equivalent) field to the Outfit model and honor the `save_to_vault` flag in `POST /outfits`. Until then, board uploads always land in vault regardless of the toggle state.

## Test plan
- [ ] Tap an outfit in vault → detail view shows "← vault" back button
- [ ] Tap back → returns to `/vault`
- [ ] Open an outfit detail from feed → back button still says "back" and uses browser history
- [ ] Board upload step 2 → "save to my vault" toggle appears, defaults OFF
- [ ] Toggle switches on/off visually