### PR TITLE
feat(web): pink-deep nav bar with white search bar

### DIFF
--- a/apps/web/components/chrome/desktop-nav.tsx
+++ b/apps/web/components/chrome/desktop-nav.tsx
@@ -20,7 +20,7 @@ export function DesktopNav() {
   if (AUTH_PATHS.some((p) => pathname.startsWith(p)) || pathname === "/") return null;
 
   return (
-    <nav className="fixed inset-x-0 top-0 z-50 hidden h-16 items-center border-b border-line bg-paper px-8 lg:flex">
+    <nav className="fixed inset-x-0 top-0 z-50 hidden h-16 items-center border-b border-pink-deep/30 bg-pink-deep px-8 lg:flex">
       {/* Left: wordmark + links */}
       <div className="flex items-center gap-8">
         <Link
@@ -49,7 +49,7 @@ export function DesktopNav() {
       <div className="ml-auto flex items-center gap-3">
         <Link
           href="/search"
-          className="flex h-9 items-center gap-2 rounded-full bg-pink-soft px-4 text-sm text-mute transition hover:text-ink-soft"
+          className="flex h-9 items-center gap-2 rounded-full bg-white px-4 text-sm text-mute transition hover:text-ink-soft"
           style={{ width: 260 }}
         >
           <svg


### PR DESCRIPTION
## Summary
- Nav bar background changed to `pink-deep` (matches the logo pink)
- Nav border updated to `pink-deep/30` for a subtle separator
- Search bar background changed from `pink-soft` to `white` for contrast against the pink bar

## Files changed
- `apps/web/components/chrome/desktop-nav.tsx`