### PR TITLE
feat: outfit streaks

### DIFF
--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -418,6 +418,33 @@ function BoardsActivityTab() {
   );
 }
 
+// ── Streak rail card ─────────────────────────────────────────────────────────
+
+function StreakCard({ streak, longest }: { streak: number; longest: number }) {
+  const isAlive = streak > 0;
+  return (
+    <div className="rounded-2xl bg-pink-soft p-5">
+      <p className="text-[10px] uppercase tracking-widest text-mute">your streak</p>
+      <p
+        className="mt-1 font-display leading-none text-ink"
+        style={{ fontSize: 40, letterSpacing: "-0.02em" }}
+      >
+        {streak} {streak === 1 ? "day" : "days"}
+      </p>
+      <p className="mt-2 text-xs leading-5 text-ink-soft">
+        {isAlive
+          ? "post today's fit before midnight to keep it going."
+          : "post today's fit to start your streak."}
+      </p>
+      {longest > 1 && (
+        <p className="mt-3 text-[10px] text-mute">
+          best: {longest} days
+        </p>
+      )}
+    </div>
+  );
+}
+
 // ── Page ──────────────────────────────────────────────────────────────────────
 
 export default function FeedPage() {
@@ -496,13 +523,25 @@ export default function FeedPage() {
         {/* ── Pill tabs ──────────────────────────────────────────────── */}
         <TabSwitcher active={activeTab} onChange={setActiveTab} />
 
-        {/* ── Tab content ──────────────────────────────────────────── */}
-        <div className="px-4 sm:px-5">
-          {activeTab === "vault" ? (
-            <VaultFeedTab displayName={displayName} />
-          ) : (
-            <BoardsActivityTab />
-          )}
+        {/* ── Tab content + desktop streak rail ────────────────────── */}
+        <div className="lg:grid lg:grid-cols-[1fr_256px] lg:gap-8 lg:px-8">
+          <div className="px-4 sm:px-5 lg:px-0">
+            {activeTab === "vault" ? (
+              <VaultFeedTab displayName={displayName} />
+            ) : (
+              <BoardsActivityTab />
+            )}
+          </div>
+
+          {/* Streak rail — desktop only */}
+          <aside className="hidden lg:block">
+            <div className="sticky top-20 space-y-3 pt-1">
+              <StreakCard
+                streak={user?.current_streak ?? 0}
+                longest={user?.longest_streak ?? 0}
+              />
+            </div>
+          </aside>
         </div>
       </div>
 

--- a/apps/web/app/vault/page.tsx
+++ b/apps/web/app/vault/page.tsx
@@ -213,7 +213,7 @@ export default function VaultPage() {
               my vault.
             </h1>
             <p className="text-mute" style={{ fontSize: 11.5, marginTop: 3 }}>
-              {outfits.length} fits · {displayName}
+              {outfits.length} fits{user?.current_streak ? ` · ${user.current_streak} day streak` : ""} · {displayName}
             </p>
           </div>
           <Link

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -23,6 +23,8 @@ export type AuthUser = {
   display_name?: string | null;
   bio?: string | null;
   profile_image_url?: string | null;
+  current_streak?: number | null;
+  longest_streak?: number | null;
 };
 
 export type AuthSessionResponse = {

--- a/services/api/alembic/versions/20260512_f0a1b2c3_add_user_streaks.py
+++ b/services/api/alembic/versions/20260512_f0a1b2c3_add_user_streaks.py
@@ -1,7 +1,7 @@
 """add user streaks
 
 Revision ID: f0a1b2c3
-Revises: d7e8f9a0
+Revises: e8f9a0b1
 Create Date: 2026-05-12
 """
 
@@ -9,7 +9,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = "f0a1b2c3"
-down_revision = "d7e8f9a0"
+down_revision = "e8f9a0b1"
 branch_labels = None
 depends_on = None
 

--- a/services/api/alembic/versions/20260512_f0a1b2c3_add_user_streaks.py
+++ b/services/api/alembic/versions/20260512_f0a1b2c3_add_user_streaks.py
@@ -1,0 +1,26 @@
+"""add user streaks
+
+Revision ID: f0a1b2c3
+Revises: d7e8f9a0
+Create Date: 2026-05-12
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "f0a1b2c3"
+down_revision = "d7e8f9a0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("current_streak", sa.Integer(), nullable=False, server_default="0"))
+    op.add_column("users", sa.Column("longest_streak", sa.Integer(), nullable=False, server_default="0"))
+    op.add_column("users", sa.Column("last_outfit_date", sa.Date(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "last_outfit_date")
+    op.drop_column("users", "longest_streak")
+    op.drop_column("users", "current_streak")

--- a/services/api/app/crud/outfit.py
+++ b/services/api/app/crud/outfit.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 from fastapi import HTTPException, status as http_status
 
@@ -8,7 +8,27 @@ from sqlalchemy.orm import Session, selectinload
 
 from app.models.clothing_item import ClothingItem
 from app.models.outfit import Outfit
+from app.models.user import User
 from app.schemas.outfit import ClothingItemIn
+
+
+def _update_streak(db: Session, user_id: uuid.UUID, outfit_date: date) -> None:
+    user = db.query(User).filter(User.id == user_id).with_for_update().first()
+    if user is None:
+        return
+    prev = user.last_outfit_date
+    if prev is None:
+        user.current_streak = 1
+    elif outfit_date == prev:
+        return
+    elif outfit_date == prev + timedelta(days=1):
+        user.current_streak = (user.current_streak or 0) + 1
+    elif outfit_date > prev:
+        user.current_streak = 1
+    else:
+        return  # retroactive post for an older date — don't touch streak
+    user.last_outfit_date = outfit_date
+    user.longest_streak = max(user.longest_streak or 0, user.current_streak)
 
 
 def create_outfit(
@@ -39,6 +59,8 @@ def create_outfit(
     )
     db.add(outfit)
     db.flush()  # get outfit.id without committing yet
+
+    _update_streak(db, user_id, worn_on or date.today())
 
     for item in clothing_items:
         db.add(

--- a/services/api/app/models/user.py
+++ b/services/api/app/models/user.py
@@ -1,7 +1,7 @@
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 
-from sqlalchemy import DateTime, Index, String, text
+from sqlalchemy import Boolean, Date, DateTime, Index, Integer, String, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -20,6 +20,9 @@ class User(Base):
     display_name: Mapped[str | None] = mapped_column(String, nullable=True)
     profile_image_url: Mapped[str | None] = mapped_column(String, nullable=True)
     bio: Mapped[str | None] = mapped_column(String, nullable=True)
+    current_streak: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+    longest_streak: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+    last_outfit_date: Mapped[date | None] = mapped_column(Date, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=text("now()")
     )

--- a/services/api/app/schemas/auth.py
+++ b/services/api/app/schemas/auth.py
@@ -39,6 +39,8 @@ class UserResponse(BaseModel):
     display_name: str | None
     bio: str | None
     profile_image_url: str | None
+    current_streak: int = 0
+    longest_streak: int = 0
 
     model_config = {"from_attributes": True}
 


### PR DESCRIPTION
## Summary
- Consecutive-day posting streak tracked per user
- Streak increments when you post a fit on the next calendar day; resets on a gap; unchanged for same-day re-posts or retroactive past dates
- Longest streak is stored and shown as a personal best

## Backend
- **Migration** `20260512_f0a1b2c3`: adds `current_streak INT DEFAULT 0`, `longest_streak INT DEFAULT 0`, `last_outfit_date DATE` to `users`
- **User model**: three new mapped columns
- **Outfit CRUD** `create_outfit`: calls `_update_streak()` in the same DB transaction as the outfit insert — atomic, race-safe via `SELECT ... FOR UPDATE`
- **Auth schema** `UserResponse`: exposes `current_streak` and `longest_streak` so every login / token-refresh response includes the live streak

## Frontend
- **`api-client.ts`**: `AuthUser` type gains `current_streak` and `longest_streak` optional fields
- **Feed page** (desktop `lg:` only): two-column layout with a sticky right rail showing a `StreakCard` — day count in large display font, "post before midnight" motivator, personal best below it
- **Vault subtitle**: appends `· N day streak` when streak > 0

## Deploy note
Reagan: run `alembic upgrade head` on next deploy to apply the migration.