### PR TITLE
hotfix: revert vault_hidden until migration is applied

### DIFF
--- a/services/api/app/crud/outfit.py
+++ b/services/api/app/crud/outfit.py
@@ -21,7 +21,6 @@ def create_outfit(
     worn_on: date | None = None,
     vibe_check_text: str | None = None,
     vibe_check_tone: str | None = None,
-    vault_hidden: bool = False,
 ) -> Outfit:
     """
     Insert one outfit row and all its clothing_items in a single transaction.
@@ -35,7 +34,6 @@ def create_outfit(
         worn_on=worn_on,
         vibe_check_text=vibe_check_text,
         vibe_check_tone=vibe_check_tone,
-        vault_hidden=vault_hidden,
     )
     db.add(outfit)
     db.flush()  # get outfit.id without committing yet
@@ -80,7 +78,7 @@ def get_user_outfits(
     query = (
         db.query(Outfit)
         .options(selectinload(Outfit.clothing_items))
-        .filter(Outfit.user_id == user_id, Outfit.vault_hidden.is_(False))
+        .filter(Outfit.user_id == user_id)
     )
 
     if cursor:
@@ -119,7 +117,6 @@ def search_user_outfits(
         db.query(Outfit.id)
         .filter(
             Outfit.user_id == user_id,
-            Outfit.vault_hidden.is_(False),
             or_(
                 func.lower(Outfit.caption).like(term),
                 func.lower(Outfit.event_name).like(term),
@@ -133,7 +130,6 @@ def search_user_outfits(
         .join(Outfit, Outfit.id == ClothingItem.outfit_id)
         .filter(
             Outfit.user_id == user_id,
-            Outfit.vault_hidden.is_(False),
             or_(
                 func.lower(ClothingItem.brand).like(term),
                 func.lower(ClothingItem.category).like(term),

--- a/services/api/app/models/outfit.py
+++ b/services/api/app/models/outfit.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import date, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Index, String, text
+from sqlalchemy import Date, DateTime, ForeignKey, Index, String, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -29,7 +29,6 @@ class Outfit(Base):
     worn_on: Mapped[date | None] = mapped_column(Date, nullable=True)
     vibe_check_text: Mapped[str | None] = mapped_column(String, nullable=True)
     vibe_check_tone: Mapped[str | None] = mapped_column(String, nullable=True)
-    vault_hidden: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=text("now()")
     )

--- a/services/api/app/routers/outfits.py
+++ b/services/api/app/routers/outfits.py
@@ -101,7 +101,6 @@ def create_outfit(
         clothing_items=meta.clothing_items,
         vibe_check_text=vibe_check_text,
         vibe_check_tone=vibe_check_tone,
-        vault_hidden=not meta.save_to_vault,
     )
 
     return OutfitOut.model_validate(outfit)

--- a/services/api/app/schemas/outfit.py
+++ b/services/api/app/schemas/outfit.py
@@ -33,7 +33,6 @@ class OutfitMetadata(BaseModel):
     event_name: str | None = None
     worn_on: date | None = None
     clothing_items: list[ClothingItemIn] = Field(default_factory=list)
-    save_to_vault: bool = True
 
 
 # ------------------------------------------------------------------ output


### PR DESCRIPTION
## What broke

`feat(api): add vault_hidden to outfits` (8cb2770) added a new `vault_hidden` column to the Outfit SQLAlchemy model and made all outfit queries filter on it. The DB migration (`20260512_d7e8f9a0`) was never applied on Railway, so every outfit query fails with:

```
Internal Server Error  (column outfits.vault_hidden does not exist)
```

This is why the live site shows **"something went wrong"** on every page that displays outfits (vault, feed, explore).

## Fix

Reverts the four Python files changed in 8cb2770 (model, schema, crud, router) so outfit queries work again. The migration file is kept in place.

## After merging

Run the migration on Railway before re-introducing the feature:

```
railway run alembic upgrade head
```

Then Tomi's vault_hidden / save_to_vault functionality can be re-added on top of the applied migration.