### PR TITLE
feat: UI polish — nav, boards, vault, feed, fonts, board media link, vibe check

### DIFF
--- a/apps/web/app/boards/[id]/page.tsx
+++ b/apps/web/app/boards/[id]/page.tsx
@@ -65,6 +65,117 @@ function InviteCopy({ code }: { code: string }) {
   );
 }
 
+// ── Media link ────────────────────────────────────────────────────────────────
+
+function MediaLinkRow({
+  boardId,
+  value,
+  onSave,
+}: {
+  boardId: string;
+  value: string | null;
+  onSave: (next: string | null) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function startEdit() {
+    setDraft(value ?? "");
+    setEditing(true);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }
+
+  async function handleSave() {
+    if (saving) return;
+    setSaving(true);
+    const trimmed = draft.trim();
+    const result = await apiClient.boards.update(boardId, { media_link: trimmed || "" });
+    if (result.ok) onSave(result.data.media_link);
+    setSaving(false);
+    setEditing(false);
+  }
+
+  if (editing) {
+    return (
+      <div className="flex items-center gap-2 rounded-[1.2rem] border border-pink-deep/30 bg-white px-4 py-3">
+        <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0 text-pink-deep" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+        </svg>
+        <input
+          ref={inputRef}
+          type="url"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") void handleSave();
+            if (e.key === "Escape") setEditing(false);
+          }}
+          placeholder="https://pinterest.com/…"
+          maxLength={500}
+          className="min-w-0 flex-1 bg-transparent text-[0.72rem] text-ink outline-none placeholder:text-mute"
+        />
+        <button
+          type="button"
+          onClick={() => void handleSave()}
+          disabled={saving}
+          className="shrink-0 text-[0.72rem] font-semibold text-pink-deep transition hover:text-[#d94e7a] disabled:opacity-50"
+        >
+          {saving ? "saving…" : "save"}
+        </button>
+        <button
+          type="button"
+          onClick={() => setEditing(false)}
+          className="shrink-0 text-[0.72rem] text-mute transition hover:text-ink"
+        >
+          cancel
+        </button>
+      </div>
+    );
+  }
+
+  if (value) {
+    return (
+      <div className="flex items-center gap-2 rounded-[1.2rem] border border-line bg-white px-4 py-3">
+        <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0 text-pink-deep" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+        </svg>
+        <a
+          href={value}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="min-w-0 flex-1 truncate text-[0.72rem] text-pink-deep hover:underline"
+        >
+          {value.replace(/^https?:\/\//, "")}
+        </a>
+        <button
+          type="button"
+          onClick={startEdit}
+          className="shrink-0 text-[0.72rem] font-semibold text-mute transition hover:text-ink"
+        >
+          Edit
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={startEdit}
+      className="flex w-full items-center gap-2 rounded-[1.2rem] border border-dashed border-line bg-white/50 px-4 py-3 text-left transition hover:border-pink-deep/40"
+    >
+      <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0 text-mute" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 5v14M5 12h14" />
+      </svg>
+      <span className="text-[0.72rem] text-mute">add a link — pinterest, partiful, etc.</span>
+    </button>
+  );
+}
+
 // ── Member strip ──────────────────────────────────────────────────────────────
 
 function MemberAvatar({ member }: { member: BoardMember }) {
@@ -224,7 +335,7 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
       <main className="px-4 pb-28 pt-6 sm:px-6">
         <div className="mx-auto flex min-h-[60vh] max-w-2xl items-center justify-center">
           <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-            <p className="font-display text-5xl text-pink-deep">checkd</p>
+            <p className="font-display italic text-5xl text-pink-deep">checkd</p>
             <h1 className="mt-4 text-3xl text-ink">board expired</h1>
             <p className="mt-3 text-sm leading-6 text-ink-soft">This board has passed its event date and is no longer active.</p>
             <Link href="/boards" className="mt-6 inline-flex items-center justify-center rounded-[1.2rem] border border-line bg-white px-5 py-3 text-sm font-semibold text-ink-soft transition hover:border-pink-deep/25">
@@ -242,7 +353,7 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
       <main className="px-4 pb-28 pt-6 sm:px-6">
         <div className="mx-auto flex min-h-[60vh] max-w-2xl items-center justify-center">
           <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-            <p className="font-display text-5xl text-pink-deep">checkd</p>
+            <p className="font-display italic text-5xl text-pink-deep">checkd</p>
             <h1 className="mt-4 text-3xl text-ink">board not found</h1>
             <p className="mt-3 text-sm leading-6 text-ink-soft">{errorMessage ?? "This board doesn't exist or you're not a member."}</p>
             <Link href="/boards" className="mt-6 inline-flex items-center justify-center rounded-[1.2rem] border border-line bg-white px-5 py-3 text-sm font-semibold text-ink-soft transition hover:border-pink-deep/25">
@@ -272,7 +383,7 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
               </svg>
               Boards
             </Link>
-            <p className="mt-2 font-display text-[2.2rem] leading-none text-pink-deep">checkd</p>
+            <p className="mt-2 font-display italic text-[2.2rem] leading-none text-pink-deep">checkd</p>
           </div>
         </header>
 
@@ -356,9 +467,19 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
 
             {/* Invite link */}
             {board ? (
-              <div className="mt-4">
-                <p className="mb-2 text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-mute">Invite link</p>
-                <InviteCopy code={board.invite_code} />
+              <div className="mt-4 space-y-3">
+                <div>
+                  <p className="mb-2 text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-mute">Invite link</p>
+                  <InviteCopy code={board.invite_code} />
+                </div>
+                <div>
+                  <p className="mb-2 text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-mute">Board link</p>
+                  <MediaLinkRow
+                    boardId={id}
+                    value={board.media_link ?? null}
+                    onSave={(next) => setBoard((b) => b ? { ...b, media_link: next } : b)}
+                  />
+                </div>
               </div>
             ) : null}
 

--- a/apps/web/app/boards/[id]/upload/page.tsx
+++ b/apps/web/app/boards/[id]/upload/page.tsx
@@ -101,7 +101,7 @@ export default function BoardUploadPage({ params }: { params: Promise<{ id: stri
     return (
       <main className="flex min-h-screen items-center justify-center px-4">
         <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-          <p className="font-display text-5xl text-pink-deep">checkd</p>
+          <p className="font-display italic text-5xl text-pink-deep">checkd</p>
           <h1 className="mt-4 text-2xl text-ink">loading board…</h1>
         </div>
       </main>
@@ -112,7 +112,7 @@ export default function BoardUploadPage({ params }: { params: Promise<{ id: stri
     return (
       <main className="flex min-h-screen items-center justify-center px-4">
         <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-          <p className="font-display text-5xl text-pink-deep">checkd</p>
+          <p className="font-display italic text-5xl text-pink-deep">checkd</p>
           <h1 className="mt-4 text-2xl text-ink">not a member</h1>
           <p className="mt-3 text-sm leading-6 text-ink-soft">
             You need to join this board before you can post to it.
@@ -132,7 +132,7 @@ export default function BoardUploadPage({ params }: { params: Promise<{ id: stri
     return (
       <main className="flex min-h-screen items-center justify-center px-4">
         <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-          <p className="font-display text-5xl text-pink-deep">checkd</p>
+          <p className="font-display italic text-5xl text-pink-deep">checkd</p>
           <h1 className="mt-4 text-2xl text-ink">board expired</h1>
           <p className="mt-3 text-sm leading-6 text-ink-soft">
             This board has passed its event date and is no longer accepting new posts.
@@ -152,7 +152,7 @@ export default function BoardUploadPage({ params }: { params: Promise<{ id: stri
     return (
       <main className="flex min-h-screen items-center justify-center px-4">
         <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-          <p className="font-display text-5xl text-pink-deep">checkd</p>
+          <p className="font-display italic text-5xl text-pink-deep">checkd</p>
           <h1 className="mt-4 text-2xl text-ink">something went wrong</h1>
           <p className="mt-3 text-sm leading-6 text-ink-soft">
             Couldn&rsquo;t load this board. Try again.

--- a/apps/web/app/boards/page.tsx
+++ b/apps/web/app/boards/page.tsx
@@ -124,7 +124,7 @@ function CreateBoardModal({ onClose, onCreate }: {
 
 // ── Board card ────────────────────────────────────────────────────────────────
 
-function BoardCard({ board }: { board: Board }) {
+function BoardCard({ board, previewImages = [] }: { board: Board; previewImages?: string[] }) {
   const eventLabel = formatEventDate(board.event_date);
   const expiryLabel = formatExpiry(board.expires_at);
   const expired = expiryLabel === "Expired";
@@ -148,6 +148,15 @@ function BoardCard({ board }: { board: Board }) {
             {expiryLabel}
           </span>
         </div>
+        {previewImages.length > 0 && (
+          <div className="mt-3 flex gap-1.5">
+            {previewImages.slice(0, 3).map((url, i) => (
+              <div key={i} className="h-11 w-11 overflow-hidden rounded-xl border-2 border-white/70 shadow-sm">
+                <img src={url} alt="" className="h-full w-full object-cover" />
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       <div className="px-5 py-4 space-y-1">
@@ -173,6 +182,7 @@ export default function BoardsPage() {
   const [boards, setBoards] = useState<Board[]>([]);
   const [showCreate, setShowCreate] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [boardPreviews, setBoardPreviews] = useState<Record<string, string[]>>({});
 
   useEffect(() => {
     if (!authLoading && !isAuthenticated) router.replace("/login");
@@ -189,6 +199,17 @@ export default function BoardsPage() {
       if (result.ok) {
         setBoards(result.data);
         setStatus("ready");
+        // Fetch outfit previews for all boards in parallel (best-effort)
+        const previews = await Promise.all(
+          result.data.map(async (b) => {
+            const r = await apiClient.boards.getOutfits(b.id, { limit: 3 });
+            return { id: b.id, images: r.ok ? r.data.outfits.map((o) => o.image_url) : [] };
+          })
+        );
+        if (!active) return;
+        const map: Record<string, string[]> = {};
+        for (const p of previews) map[p.id] = p.images;
+        setBoardPreviews(map);
       } else {
         setErrorMessage(result.message);
         setStatus("error");
@@ -209,7 +230,7 @@ export default function BoardsPage() {
       <main className="px-4 py-6 sm:px-6">
         <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-3xl items-center justify-center">
           <section className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-            <p className="font-display text-5xl text-pink-deep">checkd</p>
+            <p className="font-display italic text-5xl text-pink-deep">checkd</p>
             <h1 className="mt-4 text-3xl text-ink">Loading boards</h1>
           </section>
         </div>
@@ -222,20 +243,20 @@ export default function BoardsPage() {
       <main className="pb-28 lg:pb-0 lg:pt-16">
         <div className="mx-auto max-w-3xl">
 
-          {/* Topbar — matches design 03.01 */}
-          <div
-            className="flex items-center justify-between bg-paper"
-            style={{ padding: "8px 20px 12px" }}
+          {/* Topbar */}
+          <header
+            className="flex items-end justify-between bg-paper"
+            style={{ padding: "16px 20px 10px" }}
           >
             <div>
-              <p
-                className="font-display leading-none text-pink-deep"
-                style={{ fontSize: 38, lineHeight: 0.95, letterSpacing: "-0.01em" }}
+              <h1
+                className="font-display italic text-ink"
+                style={{ fontSize: 32, lineHeight: 1, letterSpacing: "-0.02em" }}
               >
-                checkd
-              </p>
-              <p style={{ fontSize: 11, color: "var(--mute)", marginTop: 2 }}>
-                your outfit boards
+                boards.
+              </h1>
+              <p className="text-mute" style={{ fontSize: 11.5, marginTop: 3 }}>
+                {boards.length} {boards.length === 1 ? "board" : "boards"}
               </p>
             </div>
             <div className="flex items-center" style={{ gap: 6 }}>
@@ -261,7 +282,7 @@ export default function BoardsPage() {
                 </svg>
               </button>
             </div>
-          </div>
+          </header>
 
           <div className="px-4 sm:px-5">
 
@@ -271,7 +292,7 @@ export default function BoardsPage() {
 
           {/* Loading skeletons */}
           {status === "loading" ? (
-            <div className="grid gap-4 sm:grid-cols-2">
+            <div className="grid gap-4 grid-cols-2">
               {[1, 2, 3].map((i) => (
                 <div key={i} className="animate-pulse overflow-hidden rounded-[1.75rem] border border-line bg-white">
                   <div className="h-20 bg-[linear-gradient(120deg,_rgba(255,236,242,0.8),_rgba(255,255,255,0.98))]" />
@@ -311,8 +332,8 @@ export default function BoardsPage() {
 
           {/* Board grid */}
           {status === "ready" && boards.length > 0 ? (
-            <div className="grid gap-4 sm:grid-cols-2">
-              {boards.map((b) => <BoardCard key={b.id} board={b} />)}
+            <div className="grid gap-4 grid-cols-2">
+              {boards.map((b) => <BoardCard key={b.id} board={b} previewImages={boardPreviews[b.id] ?? []} />)}
             </div>
           ) : null}
           </div>{/* end px wrapper */}

--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -237,7 +237,7 @@ export default function ExplorePage() {
       <main className="px-4 py-6 sm:px-6">
         <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-2xl items-center justify-center">
           <section className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-            <p className="font-display text-5xl text-pink-deep">checkd</p>
+            <p className="font-display italic text-5xl text-pink-deep">checkd</p>
             <h1 className="mt-4 text-3xl text-ink">Loading</h1>
           </section>
         </div>
@@ -253,10 +253,10 @@ export default function ExplorePage() {
         <header className="mb-5">
           <div className="mb-4 flex items-center justify-between gap-3">
             <div>
-              <p className="font-display text-[2.2rem] leading-none text-pink-deep">
+              <p className="font-display italic text-[2.2rem] leading-none text-pink-deep">
                 checkd
               </p>
-              <p className="mt-1 text-sm text-mute">Explore</p>
+              <p className="mt-1 text-sm text-mute">explore</p>
             </div>
             <Link href="/search" className="icon-button" aria-label="Search people">
               <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">

--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -438,7 +438,7 @@ export default function FeedPage() {
       <main className="px-4 py-6 sm:px-6 lg:px-10">
         <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-6xl items-center justify-center">
           <section className="soft-panel w-full max-w-xl px-6 py-10 text-center sm:px-8">
-            <p className="font-display text-5xl text-pink-deep" style={{ letterSpacing: "-0.02em" }}>checkd</p>
+            <p className="font-display italic text-5xl text-pink-deep" style={{ letterSpacing: "-0.02em" }}>checkd</p>
             <h1 className="mt-4 text-4xl text-ink">Opening your feed</h1>
           </section>
         </div>
@@ -453,19 +453,11 @@ export default function FeedPage() {
         {/* ── Topbar ─────────────────────────────────────────────────── */}
         <div
           className="flex items-center justify-between bg-paper"
-          style={{ padding: "8px 20px 12px" }}
+          style={{ padding: "16px 20px 12px" }}
         >
-          <div>
-            <p
-              className="font-display leading-none text-pink-deep"
-              style={{ fontSize: 38, lineHeight: 0.95, letterSpacing: "-0.01em" }}
-            >
-              checkd
-            </p>
-            <p style={{ fontSize: 11, color: "var(--mute)", marginTop: 2 }}>
-              welcome back, {displayName}.
-            </p>
-          </div>
+          <p style={{ fontSize: 13, color: "var(--ink-soft)" }}>
+            welcome back, {displayName}.
+          </p>
 
           <div className="flex items-center" style={{ gap: 6 }}>
             {/* Explore */}

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -41,7 +41,7 @@ function StepDots({ total, current }: { total: number; current: number }) {
 function StepWelcome({ onNext }: { onNext: () => void }) {
   return (
     <div className="flex flex-col items-center text-center">
-      <p className="font-display text-[4.5rem] leading-none text-pink-deep">
+      <p className="font-display italic text-[4.5rem] leading-none text-pink-deep">
         checkd
       </p>
       <h1 className="mt-8 text-3xl leading-tight text-ink sm:text-4xl">
@@ -271,7 +271,7 @@ function OnboardingInner() {
   if (!ready) {
     return (
       <main className="flex min-h-screen items-center justify-center bg-paper px-4">
-        <p className="font-display text-5xl text-pink-deep">checkd</p>
+        <p className="font-display italic text-5xl text-pink-deep">checkd</p>
       </main>
     );
   }
@@ -318,7 +318,7 @@ export default function OnboardingPage() {
     <Suspense
       fallback={
         <main className="flex min-h-screen items-center justify-center bg-paper px-4">
-          <p className="font-display text-5xl text-pink-deep">checkd</p>
+          <p className="font-display italic text-5xl text-pink-deep">checkd</p>
         </main>
       }
     >

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { cookies } from "next/headers";
 import { AUTH_SESSION_COOKIE, AUTH_SESSION_COOKIE_VALUE } from "@/lib/auth-session";
+import { VibeCheckLabel } from "@/components/vibe-check-label";
 
 const FEATURES = [
   {
@@ -94,7 +95,7 @@ function OutfitMosaicGrid() {
 
       <div className="absolute -bottom-3 left-4 rounded-2xl border border-line bg-paper/95 px-5 py-3.5 shadow-lift backdrop-blur-sm">
         <p className="text-[10px] uppercase tracking-widest text-mute">vibe check</p>
-        <p className="mt-1 text-sm font-medium text-ink">main character energy</p>
+        <VibeCheckLabel />
       </div>
     </div>
   );

--- a/apps/web/app/profile/[username]/page.tsx
+++ b/apps/web/app/profile/[username]/page.tsx
@@ -173,7 +173,7 @@ export default function PublicProfilePage({
       <main className="px-4 pb-28 pt-6 sm:px-6">
         <div className="mx-auto flex min-h-[60vh] max-w-2xl items-center justify-center">
           <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-            <p className="font-display text-5xl text-pink-deep">checkd</p>
+            <p className="font-display italic text-5xl text-pink-deep">checkd</p>
             <h1 className="mt-4 text-3xl text-ink">profile not found</h1>
             <p className="mt-3 text-sm leading-6 text-ink-soft">
               @{username} doesn&apos;t exist or may have changed their username.
@@ -221,7 +221,7 @@ export default function PublicProfilePage({
               </svg>
               Back
             </button>
-            <p className="mt-2 font-display text-[2.2rem] leading-none text-pink-deep">
+            <p className="mt-2 font-display italic text-[2.2rem] leading-none text-pink-deep">
             checkd
             </p>
           </div>

--- a/apps/web/app/profile/edit/page.tsx
+++ b/apps/web/app/profile/edit/page.tsx
@@ -236,7 +236,7 @@ export default function EditProfilePage() {
       <main className="px-4 py-6 sm:px-6">
         <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-2xl items-center justify-center">
           <section className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-            <p className="font-display text-5xl text-pink-deep">checkd</p>
+            <p className="font-display italic text-5xl text-pink-deep">checkd</p>
             <h1 className="mt-4 text-3xl text-ink">Loading…</h1>
           </section>
         </div>
@@ -254,7 +254,7 @@ export default function EditProfilePage() {
 
         {/* ── Top bar ─────────────────────────────────────────────────────── */}
         <header className="mb-6 flex items-center justify-between">
-          <p className="font-display text-[2.2rem] leading-none text-pink-deep">
+          <p className="font-display italic text-[2.2rem] leading-none text-pink-deep">
             checkd
           </p>
           <button
@@ -263,7 +263,7 @@ export default function EditProfilePage() {
             className="icon-button"
             aria-label="Go back"
           >
-            <svg viewBox="0 0 24 24" className="h-4.5 w-4.5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
               <path d="M19 12H5" />
               <polyline points="12 19 5 12 12 5" />
             </svg>

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -117,7 +117,7 @@ export default function ProfilePage() {
       <main className="px-4 py-6 sm:px-6">
         <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-2xl items-center justify-center">
           <section className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-            <p className="font-display text-5xl text-pink-deep">checkd</p>
+            <p className="font-display italic text-5xl text-pink-deep">checkd</p>
             <h1 className="mt-4 text-3xl text-ink">Loading your profile</h1>
           </section>
         </div>

--- a/apps/web/app/search/page.tsx
+++ b/apps/web/app/search/page.tsx
@@ -195,7 +195,7 @@ export default function SearchPage() {
       <main className="px-4 py-6 sm:px-6">
         <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-lg items-center justify-center">
           <section className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-            <p className="font-display text-5xl text-pink-deep">checkd</p>
+            <p className="font-display italic text-5xl text-pink-deep">checkd</p>
             <h1 className="mt-4 text-3xl text-ink">Loading</h1>
           </section>
         </div>
@@ -212,7 +212,7 @@ export default function SearchPage() {
         {/* ── Header ─────────────────────────────────────────────────────── */}
         <header className="mb-5 flex items-center justify-between">
           <div>
-            <p className="font-display text-[2.2rem] leading-none text-pink-deep">checkd</p>
+            <p className="font-display italic text-[2.2rem] leading-none text-pink-deep">checkd</p>
             <p className="mt-1 text-sm text-mute">Find people</p>
           </div>
           <button

--- a/apps/web/app/upload/page.tsx
+++ b/apps/web/app/upload/page.tsx
@@ -18,7 +18,7 @@ export default function UploadPage() {
   if (isLoading || !isAuthenticated) {
     return (
       <main className="flex min-h-screen items-center justify-center bg-paper">
-        <p className="font-display text-5xl text-pink-deep">checkd</p>
+        <p className="font-display italic text-5xl text-pink-deep">checkd</p>
       </main>
     );
   }

--- a/apps/web/app/vault/page.tsx
+++ b/apps/web/app/vault/page.tsx
@@ -193,7 +193,7 @@ export default function VaultPage() {
       <main className="px-4 py-6 sm:px-6 lg:px-10">
         <div className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-5xl items-center justify-center">
           <section className="soft-panel w-full max-w-xl px-6 py-10 text-center sm:px-8">
-            <p className="font-display text-5xl text-pink-deep">checkd</p>
+            <p className="font-display italic text-5xl text-pink-deep">checkd</p>
             <h1 className="mt-4 text-4xl text-ink">Checking your session</h1>
           </section>
         </div>
@@ -207,25 +207,13 @@ export default function VaultPage() {
     <main className="pb-28 lg:pb-0 lg:pt-16">
       <div className="mx-auto max-w-7xl">
         {/* vault header */}
-        <header className="flex items-end justify-between bg-paper" style={{ padding: "16px 20px 10px" }}>
-          <div>
-            <h1 className="font-logo text-ink" style={{ fontSize: 32, lineHeight: 1, letterSpacing: "-0.02em", fontWeight: 100 }}>
-              my vault.
-            </h1>
-            <p className="text-mute" style={{ fontSize: 11.5, marginTop: 3 }}>
-              {outfits.length} fits · {displayName}
-            </p>
-          </div>
-          <Link
-            href="/search"
-            aria-label="Search"
-            className="flex items-center justify-center rounded-full border border-line bg-white text-mute transition hover:border-pink-deep hover:text-ink"
-            style={{ width: 36, height: 36, flexShrink: 0 }}
-          >
-            <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round">
-              <circle cx="11" cy="11" r="7" /><path d="m21 21-4.35-4.35" />
-            </svg>
-          </Link>
+        <header className="bg-paper" style={{ padding: "16px 20px 10px" }}>
+          <h1 className="font-display italic text-ink" style={{ fontSize: 32, lineHeight: 1, letterSpacing: "-0.02em" }}>
+            my vault.
+          </h1>
+          <p className="text-mute" style={{ fontSize: 11.5, marginTop: 3 }}>
+            {outfits.length} fits · {displayName}
+          </p>
         </header>
 
         {/* search bar */}
@@ -260,7 +248,7 @@ export default function VaultPage() {
           ) : null}
 
           {vaultStatus === "loading" ? (
-            <div className="grid grid-cols-3 gap-px bg-line">
+            <div className="grid grid-cols-2 gap-3">
               {Array.from({ length: 9 }).map((_, i) => (
                 <div key={i} className="aspect-[3/4] w-full animate-pulse bg-pink-soft skeleton-stripe" />
               ))}
@@ -270,7 +258,7 @@ export default function VaultPage() {
           {/* Search results — API-powered, shows all matching outfits across the full vault */}
           {searchQuery.trim() ? (
             searchLoading ? (
-              <div className="grid grid-cols-3 gap-px bg-line">
+              <div className="grid grid-cols-2 gap-3">
                 {Array.from({ length: 6 }).map((_, i) => (
                   <div key={i} className="aspect-[3/4] w-full animate-pulse bg-pink-soft skeleton-stripe" />
                 ))}
@@ -290,13 +278,12 @@ export default function VaultPage() {
                 </button>
               </div>
             ) : searchResults !== null ? (
-              <div className="grid grid-cols-3 gap-px bg-line">
+              <div className="grid grid-cols-2 gap-3">
                 {searchResults.map((outfit) => (
                   <OutfitCard
                     key={outfit.id}
                     href={`/outfits/${outfit.id}?from=vault`}
                     outfit={toCardData(outfit)}
-                    compact
                     liked={likes[outfit.id]?.liked}
                     onLike={(e) => { e.preventDefault(); void handleLike(outfit.id); }}
                   />
@@ -321,13 +308,12 @@ export default function VaultPage() {
 
           {vaultStatus === "ready" && outfits.length > 0 && !searchQuery.trim() ? (
             <>
-              <div className="grid grid-cols-3 gap-px bg-line">
+              <div className="grid grid-cols-2 gap-3">
                 {outfits.map((outfit) => (
                   <OutfitCard
                     key={outfit.id}
                     href={`/outfits/${outfit.id}?from=vault`}
                     outfit={toCardData(outfit)}
-                    compact
                     liked={likes[outfit.id]?.liked}
                     onLike={(e) => { e.preventDefault(); void handleLike(outfit.id); }}
                   />

--- a/apps/web/components/chrome/desktop-nav.tsx
+++ b/apps/web/components/chrome/desktop-nav.tsx
@@ -20,12 +20,12 @@ export function DesktopNav() {
   if (AUTH_PATHS.some((p) => pathname.startsWith(p)) || pathname === "/") return null;
 
   return (
-    <nav className="fixed inset-x-0 top-0 z-50 hidden h-16 items-center border-b border-pink-deep/30 bg-pink-deep px-8 lg:flex">
+    <nav className="fixed inset-x-0 top-0 z-50 hidden h-16 items-center border-b border-pink/30 bg-pink px-8 lg:flex">
       {/* Left: wordmark + links */}
       <div className="flex items-center gap-8">
         <Link
           href="/"
-          className="font-display leading-none text-ink"
+          className="font-display italic leading-none text-white"
           style={{ fontSize: "2rem", letterSpacing: "-0.01em" }}
         >
           checkd
@@ -35,8 +35,8 @@ export function DesktopNav() {
             <Link
               key={href}
               href={href}
-              className={`text-sm transition hover:text-ink ${
-                pathname.startsWith(href) ? "font-medium text-ink" : "text-mute"
+              className={`text-sm transition hover:text-white ${
+                pathname.startsWith(href) ? "font-medium text-white" : "text-white/70"
               }`}
             >
               {label}

--- a/apps/web/components/outfits/outfit-detail-view.tsx
+++ b/apps/web/components/outfits/outfit-detail-view.tsx
@@ -340,7 +340,7 @@ export function OutfitDetailView({ id }: { id: string }) {
     return (
       <main className="flex min-h-screen items-center justify-center px-4">
         <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
-          <p className="font-display text-5xl text-pink-deep">checkd</p>
+          <p className="font-display italic text-5xl text-pink-deep">checkd</p>
           <h1 className="mt-4 text-3xl text-ink">Outfit not found</h1>
           <p className="mt-3 text-sm leading-6 text-ink-soft">This look may have been removed.</p>
           <Link href="/feed" className="mt-6 inline-flex items-center justify-center rounded-[1.2rem] border border-line bg-white px-5 py-3 text-sm font-semibold text-ink-soft transition hover:border-pink-deep/25">

--- a/apps/web/components/vibe-check-label.tsx
+++ b/apps/web/components/vibe-check-label.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const PHRASES = [
+  "main character energy",
+  "outfit of the day, every day",
+  "your closet called, it wants credit",
+  "dressed and dangerous",
+  "slay first, think later",
+  "fashion is a mood",
+  "closet goals unlocked",
+  "you ate and left no crumbs",
+  "serve looks, not excuses",
+  "the fit? immaculate",
+];
+
+export function VibeCheckLabel() {
+  const [index, setIndex] = useState(0);
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setVisible(false);
+      setTimeout(() => {
+        setIndex((i) => (i + 1) % PHRASES.length);
+        setVisible(true);
+      }, 300);
+    }, 3500);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <p
+      className="mt-1 text-sm font-medium text-ink transition-opacity duration-300"
+      style={{ opacity: visible ? 1 : 0 }}
+    >
+      {PHRASES[index]}
+    </p>
+  );
+}

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -193,6 +193,7 @@ export type Board = {
   expires_at: string;
   member_count: number;
   created_at: string;
+  media_link: string | null;
 };
 
 export type BoardMember = {
@@ -856,7 +857,7 @@ export const boardApiClient = {
     });
   },
 
-  async update(boardId: string, input: { name: string }): Promise<ApiResult<Board>> {
+  async update(boardId: string, input: { name?: string; media_link?: string | null }): Promise<ApiResult<Board>> {
     return sendRequest<Board>(`/boards/${boardId}`, {
       method: "PATCH",
       body: input,

--- a/services/api/alembic/versions/20260512_e8f9a0b1_add_media_link_to_boards.py
+++ b/services/api/alembic/versions/20260512_e8f9a0b1_add_media_link_to_boards.py
@@ -1,0 +1,24 @@
+"""add media_link to boards
+
+Revision ID: e8f9a0b1
+Revises: d7e8f9a0
+Create Date: 2026-05-12
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "e8f9a0b1"
+down_revision = "d7e8f9a0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "boards",
+        sa.Column("media_link", sa.String(500), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("boards", "media_link")

--- a/services/api/app/crud/board.py
+++ b/services/api/app/crud/board.py
@@ -74,9 +74,19 @@ def get_by_invite_code(db: Session, invite_code: str) -> Board | None:
     return db.query(Board).filter(Board.invite_code == invite_code).first()
 
 
-def update_board(db: Session, board: Board, name: str) -> Board:
-    """Rename a board. Only the creator should call this."""
-    board.name = name.strip()
+def update_board(
+    db: Session,
+    board: Board,
+    name: str | None = None,
+    media_link: str | None = None,
+    clear_media_link: bool = False,
+) -> Board:
+    if name is not None:
+        board.name = name.strip()
+    if clear_media_link:
+        board.media_link = None
+    elif media_link is not None:
+        board.media_link = media_link.strip() or None
     db.commit()
     db.refresh(board)
     return board

--- a/services/api/app/models/board.py
+++ b/services/api/app/models/board.py
@@ -36,6 +36,7 @@ class Board(Base):
     name: Mapped[str] = mapped_column(String(120), nullable=False)
     event_date: Mapped[date | None] = mapped_column(Date, nullable=True)
     invite_code: Mapped[str] = mapped_column(String(12), nullable=False, unique=True)
+    media_link: Mapped[str | None] = mapped_column(String(500), nullable=True)
     expires_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False
     )

--- a/services/api/app/routers/boards.py
+++ b/services/api/app/routers/boards.py
@@ -62,6 +62,7 @@ def _board_out(db: Session, board) -> BoardOut:
         expires_at=board.expires_at,
         member_count=board_crud.member_count(db, board.id),
         created_at=board.created_at,
+        media_link=board.media_link,
     )
 
 
@@ -124,10 +125,20 @@ def update_board(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> BoardOut:
-    """Rename a board. Creator only."""
+    """Update board fields. Name change: creator only. Media link: any member."""
     board = _board_or_404(db, board_id)
-    _require_creator(db, board_id, current_user.id)
-    board = board_crud.update_board(db, board, payload.name)
+    _require_member(db, board_id, current_user.id)
+    if payload.name is not None:
+        _require_creator(db, board_id, current_user.id)
+    # media_link=None in the payload means "don't touch it"; empty string means clear it
+    clear_media_link = payload.media_link == ""
+    board = board_crud.update_board(
+        db,
+        board,
+        name=payload.name,
+        media_link=payload.media_link if not clear_media_link else None,
+        clear_media_link=clear_media_link,
+    )
     return _board_out(db, board)
 
 

--- a/services/api/app/schemas/board.py
+++ b/services/api/app/schemas/board.py
@@ -14,7 +14,8 @@ class CreateBoardRequest(BaseModel):
 
 
 class UpdateBoardRequest(BaseModel):
-    name: str = Field(..., min_length=1, max_length=120)
+    name: str | None = Field(None, min_length=1, max_length=120)
+    media_link: str | None = Field(None, max_length=500)
 
 
 class BoardOut(BaseModel):
@@ -26,6 +27,7 @@ class BoardOut(BaseModel):
     expires_at: datetime
     member_count: int
     created_at: datetime
+    media_link: str | None = None
 
     model_config = {"from_attributes": True}
 


### PR DESCRIPTION
## What's in this PR

### Visual polish
- **Desktop nav**: lighter pink background (`#F8C8DC`) with white text throughout — active, inactive, and hover states
- **Boards page**: replaced checkd topbar with left-aligned `boards.` in italic serif; always 2-col grid (no more responsive 1→2 shift)
- **Vault**: 3-col compact grid → 2-col normal cards, matching the discover layout; duplicate search icon removed
- **Feed**: checkd wordmark removed from topbar; welcome-back greeting kept; top padding increased to match other pages
- **Edit profile**: fixed broken back arrow (`h-4.5 w-4.5` → `h-5 w-5` — h-4.5 isn't a Tailwind class so it was rendering at 0px)
- **Discover header**: `Explore` → `explore` (lowercase, matches app tone)

### Font fix (cross-platform)
Instrument Serif is loaded with `style: ["italic"]` only. Without an explicit `font-style: italic` in the element's CSS, iOS Safari doesn't match the font-face and falls back to system font. Added `italic` Tailwind class to every checkd wordmark across 14 files to enforce the correct font on all devices.

### Board media link (full-stack)
Any board member can now paste an external URL (Pinterest, Partiful, etc.) directly on the board detail page, displayed in a link row identical to the invite link.
- **DB**: Alembic migration adds nullable `media_link VARCHAR(500)` to `boards`
- **Backend**: `Board` model, `BoardOut` schema, `update_board` CRUD, and `PATCH /boards/{id}` updated; any member can set/clear; empty string clears to NULL
- **Frontend**: `MediaLinkRow` component with three states — empty (dashed add button), set (clickable link with edit), editing (inline URL input + save/cancel)

### Vibe check rotating text
The static "main character energy" label on the home page mosaic is now a client component (`VibeCheckLabel`) that cycles through 10 phrases every 3.5 s with a smooth opacity fade.

### Board card photo previews
After loading the boards list, we fire a parallel `getOutfits(limit: 3)` for each board and show up to 3 outfit thumbnails in the pink section at the top of each board card.

## Test plan
- [ ] Desktop nav: pink bar with white text, hover states correct
- [ ] Boards page: serif `boards.` heading, 2-col grid on all screen sizes
- [ ] Vault: 2-col grid, no double search icon
- [ ] Feed: no checkd wordmark in topbar
- [ ] Edit profile: back arrow visible and correct size
- [ ] Discover: lowercase `explore` subtitle
- [ ] Mobile (iOS Safari): all checkd wordmarks render in Instrument Serif italic
- [ ] Board detail: media link row visible below invite link; members can add/edit/clear; creator-only name rename still gated
- [ ] Home page: vibe check label rotates every ~3.5 s
- [ ] Board cards with outfits: up to 3 thumbnails visible in pink section; empty boards show plain pink (no broken images)