### PR TITLE
fix(ui): match vault/feed grid to discover layout; fix font across al…

### DIFF
--- a/apps/web/app/boards/[id]/page.tsx
+++ b/apps/web/app/boards/[id]/page.tsx
@@ -446,7 +446,7 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
                   </div>
                 ) : (
                   <div className="flex items-center gap-2">
-                    <h1 className="font-display text-3xl leading-tight tracking-[-0.03em] text-ink">{board?.name}</h1>
+                    <h1 className="font-display italic text-3xl leading-tight tracking-[-0.03em] text-ink">{board?.name}</h1>
                     {isCreator ? (
                       <button
                         type="button"
@@ -541,7 +541,7 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
         {/* Outfits section */}
         <section>
           <div className="mb-4 flex items-center justify-between">
-            <h2 className="font-display text-xl tracking-[-0.02em] text-ink">looks</h2>
+            <h2 className="font-display italic text-xl tracking-[-0.02em] text-ink">looks</h2>
             <Link
               href={`/boards/${id}/upload`}
               className="inline-flex items-center gap-1.5 rounded-full border border-line bg-white px-4 py-2 text-[0.78rem] font-semibold text-ink transition hover:border-pink-deep"

--- a/apps/web/app/boards/[id]/upload/page.tsx
+++ b/apps/web/app/boards/[id]/upload/page.tsx
@@ -210,7 +210,7 @@ export default function BoardUploadPage({ params }: { params: Promise<{ id: stri
         {/* Step 1: photo + caption */}
         {step === 1 ? (
           <>
-            <h1 className="font-display text-[2rem] leading-tight text-ink">add a look</h1>
+            <h1 className="font-display italic text-[2rem] leading-tight text-ink">add a look</h1>
             <p className="mt-1 text-sm text-mute">post your outfit to this board.</p>
 
             <div
@@ -275,7 +275,7 @@ export default function BoardUploadPage({ params }: { params: Promise<{ id: stri
         {/* Step 2: review */}
         {step === 2 ? (
           <>
-            <h1 className="font-display text-[2rem] leading-tight text-ink">looking good.</h1>
+            <h1 className="font-display italic text-[2rem] leading-tight text-ink">looking good.</h1>
             <p className="mt-1 text-sm text-mute">review before posting to the board.</p>
 
             <div className="mt-6 overflow-hidden rounded-[1.75rem] border border-line bg-white">

--- a/apps/web/app/boards/join/[code]/page.tsx
+++ b/apps/web/app/boards/join/[code]/page.tsx
@@ -108,7 +108,7 @@ export default function JoinBoardPage({ params }: { params: Promise<{ code: stri
               <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
               <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
             </svg>
-            <h1 className="font-display text-2xl tracking-[-0.03em] text-ink mb-2">link not found</h1>
+            <h1 className="font-display italic text-2xl tracking-[-0.03em] text-ink mb-2">link not found</h1>
             <p className="text-sm leading-6 text-ink-soft mb-6">
               This invite link is invalid or has expired.
             </p>
@@ -144,7 +144,7 @@ export default function JoinBoardPage({ params }: { params: Promise<{ code: stri
             <p className="text-[0.65rem] font-semibold uppercase tracking-[0.22em] text-pink-deep/60 mb-3">
               you&apos;re invited to
             </p>
-            <h1 className="font-display text-[2rem] leading-[1.1] tracking-[-0.04em] text-ink">
+            <h1 className="font-display italic text-[2rem] leading-[1.1] tracking-[-0.04em] text-ink">
               {board?.name}
             </h1>
             {eventLabel ? (

--- a/apps/web/app/boards/page.tsx
+++ b/apps/web/app/boards/page.tsx
@@ -60,7 +60,7 @@ function CreateBoardModal({ onClose, onCreate }: {
     <div className="fixed inset-0 z-50 flex items-end justify-center bg-[rgba(36,21,28,0.38)] px-4 pb-4 sm:items-center sm:pb-0 backdrop-blur-sm">
       <div className="soft-panel w-full max-w-md px-6 py-7">
         <div className="mb-5 flex items-center justify-between">
-          <h2 className="font-display text-2xl tracking-[-0.03em] text-ink">new board</h2>
+          <h2 className="font-display italic text-2xl tracking-[-0.03em] text-ink">new board</h2>
           <button
             type="button"
             onClick={onClose}
@@ -151,7 +151,7 @@ function BoardCard({ board }: { board: Board }) {
       </div>
 
       <div className="px-5 py-4 space-y-1">
-        <h3 className="font-display text-xl tracking-[-0.02em] text-ink leading-tight">{board.name}</h3>
+        <h3 className="font-display italic text-xl tracking-[-0.02em] text-ink leading-tight">{board.name}</h3>
         {eventLabel ? (
           <p className="text-[0.72rem] uppercase tracking-[0.18em] text-mute">{eventLabel}</p>
         ) : null}

--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -184,7 +184,7 @@ function VaultFeedTab({ displayName }: { displayName: string }) {
 
   if (status === "loading") {
     return (
-      <section className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-3">
+      <section className="grid grid-cols-2 gap-3 sm:gap-4">
         {Array.from({ length: 6 }).map((_, i) => <OutfitCardSkeleton key={i} />)}
       </section>
     );
@@ -222,7 +222,7 @@ function VaultFeedTab({ displayName }: { displayName: string }) {
 
   return (
     <>
-      <section className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-3">
+      <section className="grid grid-cols-2 gap-3 sm:gap-4">
         {outfits.map((outfit) => (
           <OutfitCard key={outfit.id} outfit={toVaultCardData(outfit)} showAccentMarker />
         ))}
@@ -332,7 +332,7 @@ function BoardsActivityTab() {
         {Array.from({ length: 2 }).map((_, i) => (
           <div key={i}>
             <div className="mb-4 h-5 w-36 animate-pulse rounded-full bg-pink-soft" />
-            <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-3">
+            <div className="grid grid-cols-2 gap-3 sm:gap-4">
               {Array.from({ length: 4 }).map((_, j) => <OutfitCardSkeleton key={j} showAuthor={false} />)}
             </div>
           </div>
@@ -371,7 +371,7 @@ function BoardsActivityTab() {
           {/* Board header */}
           <div className="mb-4 flex items-baseline justify-between gap-3">
             <div className="min-w-0">
-              <h2 className="font-display truncate text-xl tracking-[-0.02em] text-ink">
+              <h2 className="font-display italic truncate text-xl tracking-[-0.02em] text-ink">
                 {section.board.name}
               </h2>
               {section.board.event_date ? (
@@ -394,7 +394,7 @@ function BoardsActivityTab() {
             </p>
           ) : (
             <>
-              <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-3">
+              <div className="grid grid-cols-2 gap-3 sm:gap-4">
                 {section.outfits.map((outfit) => (
                   <BoardActivityCard
                     key={outfit.id}
@@ -448,7 +448,7 @@ export default function FeedPage() {
 
   return (
     <main className="pb-28 lg:pb-0 lg:pt-16">
-      <div className="mx-auto max-w-7xl">
+      <div className="mx-auto max-w-3xl">
 
         {/* ── Topbar ─────────────────────────────────────────────────── */}
         <div

--- a/apps/web/app/forgot-password/page.tsx
+++ b/apps/web/app/forgot-password/page.tsx
@@ -6,7 +6,7 @@ export default function ForgotPasswordPage() {
     <AuthShell mode="login">
       <div className="space-y-5">
         <div>
-          <h2 className="font-display text-xl text-ink">forgot your password?</h2>
+          <h2 className="font-display italic text-xl text-ink">forgot your password?</h2>
           <p className="mt-2 text-sm leading-6 text-mute">
             Password reset is coming soon. For now, reach out to us at{" "}
             <a

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -7,7 +7,7 @@ export default function NotFound() {
         <p className="font-display italic text-4xl text-pink-deep mb-8">checkd</p>
         <div className="soft-panel px-6 py-10">
           <p className="font-display text-6xl text-ink/10 mb-4">404</p>
-          <h1 className="font-display text-2xl tracking-[-0.03em] text-ink mb-2">
+          <h1 className="font-display italic text-2xl tracking-[-0.03em] text-ink mb-2">
             page not found
           </h1>
           <p className="text-sm leading-6 text-ink-soft mb-6">

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -110,7 +110,7 @@ export default async function HomePage() {
     <main className="min-h-screen overflow-x-hidden bg-paper">
       <header className="fixed inset-x-0 top-0 z-50 flex h-14 items-center justify-between border-b border-line/50 bg-paper/80 px-6 backdrop-blur-md sm:px-10">
         <span
-          className="font-display text-2xl leading-none text-ink"
+          className="font-display italic text-2xl leading-none text-ink"
           style={{ letterSpacing: "-0.01em" }}
         >
           checkd
@@ -156,7 +156,7 @@ export default async function HomePage() {
           </span>
 
           <h1
-            className="font-display leading-none text-ink"
+            className="font-display italic leading-none text-ink"
             style={{ fontSize: "clamp(72px, 10vw, 108px)", letterSpacing: "-0.03em" }}
           >
             checkd.
@@ -218,7 +218,7 @@ export default async function HomePage() {
           everything you need
         </p>
         <p
-          className="mb-14 text-center font-display text-3xl text-ink"
+          className="mb-14 text-center font-display italic text-3xl text-ink"
           style={{ letterSpacing: "-0.02em" }}
         >
           your whole wardrobe story, in one place.
@@ -233,7 +233,7 @@ export default async function HomePage() {
               <div className="mb-5 inline-flex h-10 w-10 items-center justify-center rounded-full bg-pink-soft text-pink-deep">
                 {f.icon}
               </div>
-              <h3 className="font-display text-lg text-ink">{f.title}</h3>
+              <h3 className="font-display italic text-lg text-ink">{f.title}</h3>
               <p className="mt-2 text-sm leading-6 text-ink-soft">{f.description}</p>
             </div>
           ))}
@@ -247,7 +247,7 @@ export default async function HomePage() {
       >
         <div className="mx-auto max-w-2xl text-center">
           <p
-            className="font-display text-4xl leading-tight text-ink sm:text-5xl"
+            className="font-display italic text-4xl leading-tight text-ink sm:text-5xl"
             style={{ letterSpacing: "-0.025em" }}
           >
             never forget what you wore<br className="hidden sm:block" /> on your best night out.
@@ -268,7 +268,7 @@ export default async function HomePage() {
               <span className="text-xs uppercase tracking-widest text-pink-deep">
                 0{i + 1}
               </span>
-              <h4 className="mt-3 font-display text-base text-ink">{step.label}</h4>
+              <h4 className="mt-3 font-display italic text-base text-ink">{step.label}</h4>
               <p className="mt-1.5 text-sm leading-6 text-ink-soft">{step.body}</p>
             </div>
           ))}
@@ -281,7 +281,7 @@ export default async function HomePage() {
         style={{ background: "linear-gradient(150deg, #F8C8DC 0%, #E8A8C0 50%, #FDEDF3 100%)" }}
       >
         <h2
-          className="font-display text-5xl text-ink sm:text-6xl"
+          className="font-display italic text-5xl text-ink sm:text-6xl"
           style={{ letterSpacing: "-0.03em" }}
         >
           archive the fits.
@@ -320,7 +320,7 @@ export default async function HomePage() {
       <footer className="border-t border-line px-6 py-8 sm:px-10">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <span
-            className="font-display text-lg text-ink-soft"
+            className="font-display italic text-lg text-ink-soft"
             style={{ letterSpacing: "-0.01em" }}
           >
             checkd

--- a/apps/web/app/profile/[username]/page.tsx
+++ b/apps/web/app/profile/[username]/page.tsx
@@ -49,7 +49,7 @@ function Avatar({ src, initial }: { src?: string | null; initial: string }) {
 function StatPill({ value, label }: { value: number; label: string }) {
   return (
     <div className="flex flex-col items-center gap-0.5">
-      <span className="font-display text-2xl leading-none tracking-[-0.04em] text-ink">
+      <span className="font-display italic text-2xl leading-none tracking-[-0.04em] text-ink">
         {value.toLocaleString()}
       </span>
       <span className="text-[0.68rem] uppercase tracking-[0.18em] text-mute">{label}</span>
@@ -249,7 +249,7 @@ export default function PublicProfilePage({
               />
 
               <div className="min-w-0 flex-1">
-                <h1 className="font-display text-3xl leading-tight tracking-[-0.03em] text-ink">
+                <h1 className="font-display italic text-3xl leading-tight tracking-[-0.03em] text-ink">
                   {displayName}
                 </h1>
                 <p className="mt-0.5 text-sm text-mute">@{username}</p>
@@ -294,7 +294,7 @@ export default function PublicProfilePage({
 
         {/* ── Outfit grid ─────────────────────────────────────────────────── */}
         <section>
-          <h2 className="mb-4 font-display text-xl tracking-[-0.02em] text-ink">
+          <h2 className="mb-4 font-display italic text-xl tracking-[-0.02em] text-ink">
             {status === "ready" ? `${displayName?.split(" ")[0]}'s looks` : "Looks"}
           </h2>
 

--- a/apps/web/app/profile/edit/page.tsx
+++ b/apps/web/app/profile/edit/page.tsx
@@ -272,7 +272,7 @@ export default function EditProfilePage() {
 
         {/* ── Title ───────────────────────────────────────────────────────── */}
         <div className="mb-6">
-          <h1 className="font-display text-3xl tracking-[-0.03em] text-ink">edit profile</h1>
+          <h1 className="font-display italic text-3xl tracking-[-0.03em] text-ink">edit profile</h1>
           <p className="mt-1 text-sm text-mute">Changes are visible on your public profile</p>
         </div>
 

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -159,7 +159,7 @@ export default function ProfilePage() {
 
         {/* ── Top bar — @username + ⋯ per design ─────────────────────────── */}
         <header className="flex items-center justify-between border-b border-line bg-paper px-5 py-3.5">
-          <p className="font-display text-[22px] leading-none text-ink" style={{ letterSpacing: "-0.005em" }}>
+          <p className="font-display italic text-[22px] leading-none text-ink" style={{ letterSpacing: "-0.005em" }}>
             @{username}
           </p>
           <div className="relative">
@@ -233,7 +233,7 @@ export default function ProfilePage() {
 
           {/* Name — 28px serif italic */}
           <h1
-            className="font-display text-ink"
+            className="font-display italic text-ink"
             style={{ fontSize: 28, lineHeight: 1, margin: 0 }}
           >
             {displayName}
@@ -335,7 +335,7 @@ export default function ProfilePage() {
 
             {status === "ready" && outfits.length === 0 ? (
               <div className="px-6 py-10 text-center">
-                <p className="font-display text-2xl text-ink">start your archive</p>
+                <p className="font-display italic text-2xl text-ink">start your archive</p>
                 <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-ink-soft">
                   upload your first outfit and it will live here.
                 </p>
@@ -431,7 +431,7 @@ export default function ProfilePage() {
         >
           <div className="soft-panel w-full max-w-sm overflow-hidden">
             <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-line">
-              <h2 className="font-display text-2xl tracking-[-0.03em] text-ink">
+              <h2 className="font-display italic text-2xl tracking-[-0.03em] text-ink">
                 {followSheet === "followers" ? "followers" : "following"}
               </h2>
               <button

--- a/apps/web/app/vault/page.tsx
+++ b/apps/web/app/vault/page.tsx
@@ -205,7 +205,7 @@ export default function VaultPage() {
 
   return (
     <main className="pb-28 lg:pb-0 lg:pt-16">
-      <div className="mx-auto max-w-7xl">
+      <div className="mx-auto max-w-3xl">
         {/* vault header */}
         <header className="bg-paper" style={{ padding: "16px 20px 10px" }}>
           <h1 className="font-display italic text-ink" style={{ fontSize: 32, lineHeight: 1, letterSpacing: "-0.02em" }}>
@@ -239,16 +239,16 @@ export default function VaultPage() {
           </div>
         </div>
 
-        {/* ── Vault grid — 3-col, 2px gap, per design vault-grid ─────── */}
-        <section>
+        {/* ── Vault grid ─────────────────────────────────────────────── */}
+        <section className="px-4 sm:px-5">
           {errorMessage && vaultStatus !== "loading" ? (
-            <div className="mx-5 my-3 rounded-xl border border-pink-deep/30 bg-pink-soft px-4 py-3 text-sm text-error">
+            <div className="my-3 rounded-xl border border-pink-deep/30 bg-pink-soft px-4 py-3 text-sm text-error">
               {errorMessage}
             </div>
           ) : null}
 
           {vaultStatus === "loading" ? (
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-2 gap-3 sm:gap-4">
               {Array.from({ length: 9 }).map((_, i) => (
                 <div key={i} className="aspect-[3/4] w-full animate-pulse bg-pink-soft skeleton-stripe" />
               ))}
@@ -258,14 +258,14 @@ export default function VaultPage() {
           {/* Search results — API-powered, shows all matching outfits across the full vault */}
           {searchQuery.trim() ? (
             searchLoading ? (
-              <div className="grid grid-cols-2 gap-3">
+              <div className="grid grid-cols-2 gap-3 sm:gap-4">
                 {Array.from({ length: 6 }).map((_, i) => (
                   <div key={i} className="aspect-[3/4] w-full animate-pulse bg-pink-soft skeleton-stripe" />
                 ))}
               </div>
             ) : searchResults !== null && searchResults.length === 0 ? (
               <div className="px-5 py-10 text-center">
-                <p className="font-display text-2xl text-ink">no matches.</p>
+                <p className="font-display italic text-2xl text-ink">no matches.</p>
                 <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-ink-soft">
                   try searching by brand, event, color, or vibe.
                 </p>
@@ -278,7 +278,7 @@ export default function VaultPage() {
                 </button>
               </div>
             ) : searchResults !== null ? (
-              <div className="grid grid-cols-2 gap-3">
+              <div className="grid grid-cols-2 gap-3 sm:gap-4">
                 {searchResults.map((outfit) => (
                   <OutfitCard
                     key={outfit.id}
@@ -294,7 +294,7 @@ export default function VaultPage() {
 
           {vaultStatus === "ready" && outfits.length === 0 && !searchQuery.trim() ? (
             <div className="px-5 py-16 text-center">
-              <p className="font-display text-2xl text-ink">your archive is ready.</p>
+              <p className="font-display italic text-2xl text-ink">your archive is ready.</p>
               <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-ink-soft">
                 it just needs your first look.
               </p>
@@ -308,7 +308,7 @@ export default function VaultPage() {
 
           {vaultStatus === "ready" && outfits.length > 0 && !searchQuery.trim() ? (
             <>
-              <div className="grid grid-cols-2 gap-3">
+              <div className="grid grid-cols-2 gap-3 sm:gap-4">
                 {outfits.map((outfit) => (
                   <OutfitCard
                     key={outfit.id}

--- a/apps/web/components/auth/auth-shell.tsx
+++ b/apps/web/components/auth/auth-shell.tsx
@@ -47,7 +47,7 @@ export function AuthShell({ mode, children }: AuthShellProps) {
       <div className="flex flex-1 flex-col" style={{ paddingBottom: 32 }}>
         {/* Heading — serif italic per design */}
         <h1
-          className="font-display text-ink"
+          className="font-display italic text-ink"
           style={{
             fontSize: copy.headingSize,
             margin: `${copy.headingMarginTop}px 0 0`,

--- a/apps/web/components/boards/event-date-picker.tsx
+++ b/apps/web/components/boards/event-date-picker.tsx
@@ -112,7 +112,7 @@ export function EventDatePicker({ value, onChange }: EventDatePickerProps) {
                 <path d="m15 18-6-6 6-6" />
               </svg>
             </button>
-            <span className="font-display text-[1.05rem] tracking-[-0.02em] text-ink">
+            <span className="font-display italic text-[1.05rem] tracking-[-0.02em] text-ink">
               {MONTHS[viewMonth]} {viewYear}
             </span>
             <button

--- a/apps/web/components/outfits/comments-sheet.tsx
+++ b/apps/web/components/outfits/comments-sheet.tsx
@@ -204,7 +204,7 @@ export function CommentsSheet({ outfitId, onClose }: CommentsSheetProps) {
 
         {/* Header */}
         <div className="flex shrink-0 items-center justify-between border-b border-line/60 px-6 pb-4 pt-6">
-          <h2 className="font-display text-2xl tracking-[-0.03em] text-ink">Comments</h2>
+          <h2 className="font-display italic text-2xl tracking-[-0.03em] text-ink">Comments</h2>
           <button
             type="button"
             onClick={onClose}

--- a/apps/web/components/outfits/story-card-sheet.tsx
+++ b/apps/web/components/outfits/story-card-sheet.tsx
@@ -217,7 +217,7 @@ export function StoryCardSheet({ outfitId, imageUrl, wornOn, createdAt, vibeChec
       <div className="animate-fade-up soft-panel w-full max-w-sm overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between px-6 pb-4 pt-5">
-          <h2 className="font-display text-2xl tracking-[-0.03em] text-ink">share look</h2>
+          <h2 className="font-display italic text-2xl tracking-[-0.03em] text-ink">share look</h2>
           <button
             type="button"
             onClick={onClose}

--- a/apps/web/components/upload/upload-flow.tsx
+++ b/apps/web/components/upload/upload-flow.tsx
@@ -273,7 +273,7 @@ export function UploadFlow() {
 
         {/* Step heading */}
         <p
-          className="font-display text-ink"
+          className="font-display italic text-ink"
           style={{ fontSize: 28, lineHeight: 1.1, letterSpacing: "-0.02em", marginBottom: 6 }}
         >
           {currentStep === 1 && "add your photo"}


### PR DESCRIPTION
…l pages

Vault: narrow container to max-w-3xl (was max-w-7xl) so image size matches discover, add section padding and sm:gap-4 to grids.

Feed: remove lg:grid-cols-3 so grid stays 2-wide on all screen sizes, matching discover layout.

Font: Instrument Serif is italic-only but 'italic' class was missing from every font-display element across vault, feed, boards, profile, components, auth, landing page, and more. Added italic everywhere so the correct font renders on mobile and desktop.