### PR TITLE
hotfix: revert media_link + fix Railway migrations never running

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,4 +1,8 @@
+[build]
+buildCommand = "pip install -r requirements.txt"
+
 [deploy]
+startCommand = "sh start.sh"
 healthcheckPath = "/health"
 healthcheckTimeout = 300
 restartPolicyType = "on_failure"

--- a/services/api/app/crud/board.py
+++ b/services/api/app/crud/board.py
@@ -74,19 +74,9 @@ def get_by_invite_code(db: Session, invite_code: str) -> Board | None:
     return db.query(Board).filter(Board.invite_code == invite_code).first()
 
 
-def update_board(
-    db: Session,
-    board: Board,
-    name: str | None = None,
-    media_link: str | None = None,
-    clear_media_link: bool = False,
-) -> Board:
-    if name is not None:
-        board.name = name.strip()
-    if clear_media_link:
-        board.media_link = None
-    elif media_link is not None:
-        board.media_link = media_link.strip() or None
+def update_board(db: Session, board: Board, name: str) -> Board:
+    """Rename a board. Only the creator should call this."""
+    board.name = name.strip()
     db.commit()
     db.refresh(board)
     return board

--- a/services/api/app/models/board.py
+++ b/services/api/app/models/board.py
@@ -36,7 +36,6 @@ class Board(Base):
     name: Mapped[str] = mapped_column(String(120), nullable=False)
     event_date: Mapped[date | None] = mapped_column(Date, nullable=True)
     invite_code: Mapped[str] = mapped_column(String(12), nullable=False, unique=True)
-    media_link: Mapped[str | None] = mapped_column(String(500), nullable=True)
     expires_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False
     )

--- a/services/api/app/routers/boards.py
+++ b/services/api/app/routers/boards.py
@@ -62,7 +62,6 @@ def _board_out(db: Session, board) -> BoardOut:
         expires_at=board.expires_at,
         member_count=board_crud.member_count(db, board.id),
         created_at=board.created_at,
-        media_link=board.media_link,
     )
 
 
@@ -125,20 +124,10 @@ def update_board(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> BoardOut:
-    """Update board fields. Name change: creator only. Media link: any member."""
+    """Rename a board. Creator only."""
     board = _board_or_404(db, board_id)
-    _require_member(db, board_id, current_user.id)
-    if payload.name is not None:
-        _require_creator(db, board_id, current_user.id)
-    # media_link=None in the payload means "don't touch it"; empty string means clear it
-    clear_media_link = payload.media_link == ""
-    board = board_crud.update_board(
-        db,
-        board,
-        name=payload.name,
-        media_link=payload.media_link if not clear_media_link else None,
-        clear_media_link=clear_media_link,
-    )
+    _require_creator(db, board_id, current_user.id)
+    board = board_crud.update_board(db, board, payload.name)
     return _board_out(db, board)
 
 

--- a/services/api/app/schemas/board.py
+++ b/services/api/app/schemas/board.py
@@ -14,8 +14,7 @@ class CreateBoardRequest(BaseModel):
 
 
 class UpdateBoardRequest(BaseModel):
-    name: str | None = Field(None, min_length=1, max_length=120)
-    media_link: str | None = Field(None, max_length=500)
+    name: str = Field(..., min_length=1, max_length=120)
 
 
 class BoardOut(BaseModel):
@@ -27,7 +26,6 @@ class BoardOut(BaseModel):
     expires_at: datetime
     member_count: int
     created_at: datetime
-    media_link: str | None = None
 
     model_config = {"from_attributes": True}
 


### PR DESCRIPTION
## What broke

Boards page shows "Something went wrong" because `media_link` was added to the `Board` SQLAlchemy model in e9f30e8, but the migration was never applied on Railway — so every `/boards/me` query fails with a DB column-not-found error.

## Root cause (and why this keeps happening)

`railway.toml` had no `startCommand`, so Railway was using Nixpacks default (bare `uvicorn`) instead of `start.sh`. That means **`alembic upgrade head` was never running on deploy** — for `vault_hidden` (PR #182) or `media_link` now.

This PR fixes that by adding `startCommand = "sh start.sh"` to `railway.toml`. From this deploy forward, migrations will run automatically on every Railway deploy.

## Changes

- Reverts board model/schema/crud/router to pre-`media_link` state (same pattern as PR #182)
- Adds `startCommand` to `railway.toml` so migrations actually run

## After merging

Railway will redeploy, run `alembic upgrade head` (applying both the `vault_hidden` and `media_link` migrations), then start the server. Once that's done, both features can be re-introduced.