### PR TITLE
hotfix: revert media_link + fix Railway migrations via Procfile

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,8 +1,4 @@
-[build]
-buildCommand = "pip install -r requirements.txt"
-
 [deploy]
-startCommand = "sh start.sh"
 healthcheckPath = "/health"
 healthcheckTimeout = 300
 restartPolicyType = "on_failure"

--- a/services/api/Procfile
+++ b/services/api/Procfile
@@ -1,0 +1,1 @@
+web: alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}


### PR DESCRIPTION
## Summary
- Reverts `media_link` column from Board model/schema/crud/router — the DB migration was never applied on Railway so every boards query returned 500
- Removes incorrect `railway.toml` start command (repo-root `railway.toml` is not read when Railway service root is `services/api/`)
- Adds `services/api/Procfile` so Nixpacks runs `alembic upgrade head` before starting uvicorn on every deploy

## Why Procfile instead of railway.toml
Railway's `railway.toml` is read relative to the service's configured root directory. If that root is `services/api/`, the repo-root `railway.toml` has no effect. A `Procfile` placed in `services/api/` is read directly by Nixpacks from the detected Python app root — no ambiguity.

## After merging
Once this deploys and migrations run, the `media_link` feature can be re-added safely.

## Test plan
- [ ] Boards page loads without error after deploy
- [ ] Railway deploy logs show `Running database migrations...` before server start
- [ ] `alembic upgrade head` applies `e8f9a0b1` (add_media_link_to_boards) migration