### PR TITLE
fix: board delete 204, admin role, pre-launch security sweep

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -28,12 +28,17 @@ Required Railway environment variables:
 | `AWS_SECRET_ACCESS_KEY` | Your AWS secret |
 | `AWS_REGION` | Your AWS region |
 | `ENVIRONMENT` | `production` |
-| `CORS_ORIGINS` | Your Vercel URL |
-| `PUBLIC_BASE_URL` | Your Vercel URL |
+| `CORS_ORIGINS` | `https://www.checkdd.com` |
+| `PUBLIC_BASE_URL` | `https://www.checkdd.com` |
 
 After deploy, copy the Railway public URL, for example:
 
 `https://your-api.up.railway.app`
+
+If you use a Railway custom domain for the API, use that exact origin instead
+of the Railway-generated URL. For the current public setup, that is likely
+`https://checkdd.com` if the apex domain is attached to Railway and
+`https://www.checkdd.com` is attached to Vercel.
 
 ## 3. Vercel
 
@@ -43,7 +48,7 @@ Required Vercel environment variables:
 
 | Variable | Value |
 | --- | --- |
-| `INTERNAL_API_URL` | Your Railway API URL |
+| `INTERNAL_API_URL` | Your Railway API URL or API custom domain, for example `https://checkdd.com` |
 | `NEXT_PUBLIC_API_PROXY_BASE_URL` | `/backend` |
 
 Notes:
@@ -78,7 +83,7 @@ AWS_REGION=us-east-2
 ## 5. Production checklist
 
 1. Railway API URL works directly.
-2. Vercel has `INTERNAL_API_URL` set to that Railway URL.
-3. Railway `CORS_ORIGINS` includes your Vercel domain.
+2. Vercel has `INTERNAL_API_URL` set to that Railway URL or API custom domain.
+3. Railway `CORS_ORIGINS` includes `https://www.checkdd.com`.
 4. Vercel has been redeployed after env changes.
 5. The deployed browser no longer shows the old `NEXT_PUBLIC_API_URL` error text.

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/lib/auth-context";
+import { apiClient } from "@/lib/api-client";
+import { MobileNav } from "@/components/chrome/mobile-nav";
+
+type Action = "outfit" | "board";
+
+export default function AdminPage() {
+  const router = useRouter();
+  const { user, isAuthenticated, isLoading } = useAuth();
+
+  const [action, setAction] = useState<Action>("outfit");
+  const [targetId, setTargetId] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [feedback, setFeedback] = useState<{ ok: boolean; message: string } | null>(null);
+
+  useEffect(() => {
+    if (!isLoading && (!isAuthenticated || !user?.is_admin)) {
+      router.replace("/");
+    }
+  }, [isLoading, isAuthenticated, user, router]);
+
+  if (isLoading || !isAuthenticated || !user?.is_admin) {
+    return null;
+  }
+
+  async function handleDelete() {
+    const id = targetId.trim();
+    if (!id) return;
+    if (!confirm(`Delete ${action} "${id}"? This cannot be undone.`)) return;
+
+    setBusy(true);
+    setFeedback(null);
+
+    const result =
+      action === "outfit"
+        ? await apiClient.admin.deleteOutfit(id)
+        : await apiClient.admin.deleteBoard(id);
+
+    setFeedback({ ok: result.ok, message: result.message });
+    if (result.ok) setTargetId("");
+    setBusy(false);
+  }
+
+  return (
+    <main className="pb-28 lg:pb-0 lg:pt-16">
+      <div className="mx-auto max-w-xl px-5 py-8">
+        <header className="mb-8">
+          <p className="font-display italic text-5xl text-pink-deep">checkd</p>
+          <h1 className="mt-2 text-2xl font-semibold text-ink">admin</h1>
+          <p className="mt-1 text-sm text-mute">logged in as {user.email}</p>
+        </header>
+
+        <section className="soft-panel p-6 space-y-5">
+          <h2 className="text-base font-semibold text-ink">Delete content</h2>
+
+          <div className="flex gap-3">
+            {(["outfit", "board"] as const).map((t) => (
+              <button
+                key={t}
+                type="button"
+                onClick={() => { setAction(t); setTargetId(""); setFeedback(null); }}
+                className={`rounded-full border px-4 py-1.5 text-sm font-medium transition ${
+                  action === t
+                    ? "border-pink-deep bg-pink-deep text-white"
+                    : "border-line bg-white text-ink hover:border-pink-deep"
+                }`}
+              >
+                {t}
+              </button>
+            ))}
+          </div>
+
+          <div className="space-y-3">
+            <label className="block text-sm text-ink-soft">
+              {action === "outfit" ? "Outfit" : "Board"} ID (UUID)
+            </label>
+            <input
+              type="text"
+              value={targetId}
+              onChange={(e) => { setTargetId(e.target.value); setFeedback(null); }}
+              placeholder={`paste ${action} UUID here`}
+              className="w-full rounded-xl border border-line bg-white px-4 py-2.5 text-sm text-ink outline-none placeholder:text-mute focus:border-pink-deep"
+            />
+            <button
+              type="button"
+              disabled={!targetId.trim() || busy}
+              onClick={() => void handleDelete()}
+              className="rounded-full border border-error bg-error px-5 py-2 text-sm font-semibold text-white transition disabled:opacity-40 hover:opacity-90"
+            >
+              {busy ? "Deleting…" : `Delete ${action}`}
+            </button>
+          </div>
+
+          {feedback ? (
+            <p className={`text-sm ${feedback.ok ? "text-ink" : "text-error"}`}>
+              {feedback.message}
+            </p>
+          ) : null}
+        </section>
+      </div>
+      <MobileNav active="none" />
+    </main>
+  );
+}

--- a/apps/web/app/api/proxy-image/route.ts
+++ b/apps/web/app/api/proxy-image/route.ts
@@ -36,15 +36,19 @@ export async function GET(request: NextRequest) {
 
   const allowed =
     parsed.hostname.endsWith(".amazonaws.com") ||
-    parsed.hostname.endsWith(".cloudfront.net") ||
-    parsed.hostname === "cdn.example.com";
+    parsed.hostname.endsWith(".cloudfront.net");
 
   if (!allowed) {
     return new NextResponse("Origin not allowed", { status: 403 });
   }
 
   const abort = AbortSignal.timeout(FETCH_TIMEOUT_MS);
-  const upstream = await fetch(url, { cache: "force-cache", signal: abort });
+  let upstream: Response;
+  try {
+    upstream = await fetch(parsed.toString(), { cache: "force-cache", signal: abort });
+  } catch {
+    return new NextResponse("Upstream fetch timed out or failed", { status: 504 });
+  }
 
   if (!upstream.ok) {
     return new NextResponse("Upstream fetch failed", { status: 502 });

--- a/apps/web/app/backend/[...path]/route.ts
+++ b/apps/web/app/backend/[...path]/route.ts
@@ -99,6 +99,11 @@ async function proxy(request: NextRequest, path: string[]) {
     headers.set("location", rewriteBodyUrls(location, request));
   }
 
+  // 204/304 carry no body — return immediately to avoid stream issues
+  if (upstreamResponse.status === 204 || upstreamResponse.status === 304) {
+    return new NextResponse(null, { status: upstreamResponse.status, headers });
+  }
+
   const contentType = upstreamResponse.headers.get("content-type") ?? "";
   if (contentType.includes("application/json") || contentType.startsWith("text/")) {
     const body = await upstreamResponse.text();

--- a/apps/web/app/backend/[...path]/route.ts
+++ b/apps/web/app/backend/[...path]/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 
 const DEFAULT_BACKEND_ORIGIN =
   process.env.NODE_ENV === "production"
-    ? "https://api.ootd.app"
+    ? "https://checkdd.com"
     : "http://127.0.0.1:8000";
 const PROXY_PREFIX = "/backend";
 

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -25,6 +25,7 @@ export type AuthUser = {
   profile_image_url?: string | null;
   current_streak?: number | null;
   longest_streak?: number | null;
+  is_admin?: boolean;
 };
 
 export type AuthSessionResponse = {
@@ -954,11 +955,30 @@ export const boardApiClient = {
   }
 };
 
+const adminApiClient = {
+  async deleteOutfit(outfitId: string): Promise<ApiResult<null>> {
+    return sendRequest<null>(`/admin/outfits/${outfitId}`, {
+      method: "DELETE",
+      requiresAuth: true,
+      successMessage: "Outfit deleted."
+    });
+  },
+
+  async deleteBoard(boardId: string): Promise<ApiResult<null>> {
+    return sendRequest<null>(`/admin/boards/${boardId}`, {
+      method: "DELETE",
+      requiresAuth: true,
+      successMessage: "Board deleted."
+    });
+  }
+};
+
 export const apiClient = {
   auth: authApiClient,
   outfits: outfitApiClient,
   users: userApiClient,
   boards: boardApiClient,
+  admin: adminApiClient,
   request: sendRequest,
   clearAccessToken,
   getAccessToken,

--- a/apps/web/lib/auth-context.tsx
+++ b/apps/web/lib/auth-context.tsx
@@ -12,6 +12,7 @@ import {
 import { toAuthErrors, type AuthErrors } from "@/lib/auth";
 import {
   clearAuthSessionCookie,
+  hasAuthSessionCookie,
   setAuthSessionCookie
 } from "@/lib/auth-session";
 
@@ -76,6 +77,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         // Token was rejected by the server (expired early, user deleted, etc.)
         // Fall through to the full refresh flow below.
         clearAccessToken();
+      }
+
+      if (!hasAuthSessionCookie()) {
+        clearAccessToken();
+        setUser(null);
+        setIsLoading(false);
+        return;
       }
 
       // ── Slow path: exchange refresh-token cookie for token + user in one request ───

--- a/apps/web/lib/auth-session.ts
+++ b/apps/web/lib/auth-session.ts
@@ -19,3 +19,13 @@ export function clearAuthSessionCookie() {
 
   document.cookie = `${AUTH_SESSION_COOKIE}=; Path=/; Max-Age=0; SameSite=Lax`;
 }
+
+export function hasAuthSessionCookie() {
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  return document.cookie
+    .split(";")
+    .some((cookie) => cookie.trim() === `${AUTH_SESSION_COOKIE}=${AUTH_SESSION_COOKIE_VALUE}`);
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -6,7 +6,7 @@ import {
 } from "@/lib/auth-session";
 
 const AUTH_ROUTES = new Set(["/login", "/signup"]);
-const PROTECTED_ROUTE_PREFIXES = ["/feed", "/vault", "/upload", "/outfits"];
+const PROTECTED_ROUTE_PREFIXES = ["/admin", "/feed", "/vault", "/upload", "/outfits"];
 
 function withSecurityHeaders(response: NextResponse) {
   response.headers.set("X-Content-Type-Options", "nosniff");

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
+import path from "node:path";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  outputFileTracingRoot: path.join(process.cwd(), "../.."),
   images: {
     remotePatterns: [
       // Production: S3 bucket in any region

--- a/apps/web/tests/smoke.spec.ts
+++ b/apps/web/tests/smoke.spec.ts
@@ -12,7 +12,8 @@ const authUser = {
   email: "test@example.com",
   display_name: "Test Stylist",
   bio: null,
-  profile_image_url: null
+  profile_image_url: null,
+  is_admin: false
 };
 
 const mockOutfit = {
@@ -188,7 +189,7 @@ test.describe("public routes", () => {
 
 test.describe("protected route redirects", () => {
   // These pages pass ?next= in the redirect so users land back after login
-  for (const route of ["/upload", "/feed", "/vault"]) {
+  for (const route of ["/admin", "/upload", "/feed", "/vault"]) {
     test(`redirects logged-out visitor from ${route} to login with next param`, async ({ page }) => {
       await page.goto(route);
       await expect(page).toHaveURL(new RegExp(`/login\\?next=`));

--- a/packages/contracts/auth-contract.md
+++ b/packages/contracts/auth-contract.md
@@ -8,7 +8,7 @@ It is the source of truth for `@otthomas` building the typed API client (Issue 1
 
 ```
 http://localhost:8000   (local dev)
-https://api.ootd.app   (production — TBD on Railway)
+https://checkdd.com     (production API on Railway)
 ```
 
 All endpoints are prefixed with `/auth`.
@@ -57,7 +57,9 @@ Create a new account.
 }
 ```
 
-Sets `Set-Cookie: refresh_token=<token>; HttpOnly; Path=/auth/refresh; SameSite=Lax`
+Sets `Set-Cookie: refresh_token=<token>; HttpOnly; Path=/auth; SameSite=Lax` in local
+development. Production also sets `Secure; SameSite=None` so Vercel and Railway can
+refresh sessions across origins.
 
 **Error responses**
 
@@ -99,7 +101,9 @@ Sign in with email and password.
 }
 ```
 
-Sets `Set-Cookie: refresh_token=<token>; HttpOnly; Path=/auth/refresh; SameSite=Lax`
+Sets `Set-Cookie: refresh_token=<token>; HttpOnly; Path=/auth; SameSite=Lax` in local
+development. Production also sets `Secure; SameSite=None` so Vercel and Railway can
+refresh sessions across origins.
 
 **Error responses**
 
@@ -182,12 +186,13 @@ Authorization: Bearer <access_token>
   "email": "user@example.com",
   "display_name": "Main Character",
   "bio": "outfits only ✨",
-  "profile_image_url": "https://..."
+  "profile_image_url": "https://...",
+  "is_admin": false
 }
 ```
 
 `display_name`, `bio`, and `profile_image_url` may be `null` until the user completes
-their profile.
+their profile. `is_admin` is server-controlled and defaults to `false`.
 
 **Error responses**
 
@@ -237,5 +242,5 @@ The API client should handle both shapes. Treat any non-`ok` response without a
   retry the original request. If refresh also fails, redirect to `/login`.
 - The refresh token cookie is `httpOnly` — you cannot read it from JS. Just call
   `POST /auth/refresh` and the browser sends it automatically.
-- Local dev API base URL: `http://localhost:8000`. Wire via `NEXT_PUBLIC_API_URL`
-  env var.
+- Browser requests should use the same-origin Next.js proxy at `/backend`; Vercel
+  forwards those requests to Railway via `INTERNAL_API_URL`.

--- a/packages/contracts/outfit-contract.md
+++ b/packages/contracts/outfit-contract.md
@@ -7,7 +7,7 @@ Source of truth for `@otthomas` building the upload flow UI (Issue #19).
 
 ```
 http://localhost:8000   (local dev)
-https://api.ootd.app   (production — TBD on Railway)
+https://checkdd.com     (production API on Railway)
 ```
 
 All endpoints are prefixed with `/outfits`.

--- a/services/api/alembic/versions/20260512_h2i3j4k5_add_is_admin_to_users.py
+++ b/services/api/alembic/versions/20260512_h2i3j4k5_add_is_admin_to_users.py
@@ -1,14 +1,14 @@
 """add is_admin to users
 
 Revision ID: h2i3j4k5
-Revises: e8f9a0b1
+Revises: f0a1b2c3
 Create Date: 2026-05-12
 """
 from alembic import op
 import sqlalchemy as sa
 
 revision = "h2i3j4k5"
-down_revision = "e8f9a0b1"
+down_revision = "f0a1b2c3"
 branch_labels = None
 depends_on = None
 

--- a/services/api/alembic/versions/20260512_h2i3j4k5_add_is_admin_to_users.py
+++ b/services/api/alembic/versions/20260512_h2i3j4k5_add_is_admin_to_users.py
@@ -1,0 +1,24 @@
+"""add is_admin to users
+
+Revision ID: h2i3j4k5
+Revises: c5d6e7f8
+Create Date: 2026-05-12
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "h2i3j4k5"
+down_revision = "c5d6e7f8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("is_admin", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "is_admin")

--- a/services/api/alembic/versions/20260512_h2i3j4k5_add_is_admin_to_users.py
+++ b/services/api/alembic/versions/20260512_h2i3j4k5_add_is_admin_to_users.py
@@ -1,14 +1,14 @@
 """add is_admin to users
 
 Revision ID: h2i3j4k5
-Revises: c5d6e7f8
+Revises: e8f9a0b1
 Create Date: 2026-05-12
 """
 from alembic import op
 import sqlalchemy as sa
 
 revision = "h2i3j4k5"
-down_revision = "c5d6e7f8"
+down_revision = "e8f9a0b1"
 branch_labels = None
 depends_on = None
 

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -33,7 +33,7 @@ class Settings(BaseSettings):
     anthropic_api_key: str = ""
 
     # Public frontend base URL — used for shareable links and OG tags
-    public_base_url: str = "https://ootd.app"
+    public_base_url: str = "https://www.checkdd.com"
 
     # Admin secret for internal maintenance endpoints (board cleanup, etc.)
     # Set this to a long random string in production. Empty = endpoint disabled.
@@ -41,7 +41,7 @@ class Settings(BaseSettings):
 
     # CORS — comma-separated list of allowed origins.
     # Defaults to localhost:3000 for local dev. Set in production to your real domain.
-    # Example: ALLOWED_ORIGINS=https://ootd.app,https://www.ootd.app
+    # Example: CORS_ORIGINS=https://www.checkdd.com
     allowed_origins: list[str] = []
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")

--- a/services/api/app/dependencies.py
+++ b/services/api/app/dependencies.py
@@ -76,6 +76,13 @@ def get_current_user(
     return user
 
 
+def require_admin(current_user: User = Depends(get_current_user)) -> User:
+    """Dependency for admin-only routes. Returns the user or raises 403."""
+    if not current_user.is_admin:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required.")
+    return current_user
+
+
 def get_optional_user(
     authorization: str | None = Header(default=None),
     db: Session = Depends(get_db),

--- a/services/api/app/dependencies.py
+++ b/services/api/app/dependencies.py
@@ -11,6 +11,23 @@ from app.models.user import User
 from app.services.auth import decode_access_token
 
 
+def _unauthenticated(detail: str = "Not authenticated.") -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail=detail,
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+def _parse_user_id(user_id: str | None) -> uuid.UUID:
+    if not user_id:
+        raise _unauthenticated()
+    try:
+        return uuid.UUID(user_id)
+    except ValueError:
+        raise _unauthenticated()
+
+
 def get_db() -> Generator[Session, None, None]:
     db = SessionLocal()
     try:
@@ -34,44 +51,20 @@ def get_current_user(
             ...
     """
     if not authorization or not authorization.startswith("Bearer "):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Not authenticated.",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+        raise _unauthenticated()
 
     token = authorization.removeprefix("Bearer ")
 
     try:
         payload = decode_access_token(token)
     except ExpiredSignatureError:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Token expired.",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+        raise _unauthenticated("Token expired.")
     except JWTError:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Not authenticated.",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+        raise _unauthenticated()
 
-    user_id: str | None = payload.get("sub")
-    if not user_id:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Not authenticated.",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    user = user_crud.get_by_id(db, uuid.UUID(user_id))
+    user = user_crud.get_by_id(db, _parse_user_id(payload.get("sub")))
     if not user:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Not authenticated.",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+        raise _unauthenticated()
 
     return user
 
@@ -96,9 +89,6 @@ def get_optional_user(
     try:
         token = authorization.removeprefix("Bearer ")
         payload = decode_access_token(token)
-        user_id: str | None = payload.get("sub")
-        if not user_id:
-            return None
-        return user_crud.get_by_id(db, uuid.UUID(user_id))
-    except (JWTError, ExpiredSignatureError):
+        return user_crud.get_by_id(db, _parse_user_id(payload.get("sub")))
+    except (HTTPException, JWTError, ExpiredSignatureError):
         return None

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from app.config import settings
-from app.routers import auth, boards, health, notifications, outfits, users
+from app.routers import admin, auth, boards, health, notifications, outfits, users
 from app.services.storage import LOCAL_UPLOADS_DIR
 
 logger = logging.getLogger("ootd.api")
@@ -57,6 +57,7 @@ app.include_router(outfits.router)
 app.include_router(users.router)
 app.include_router(boards.router)
 app.include_router(notifications.router)
+app.include_router(admin.router)
 
 # Dev-mode local file storage — only mounted when S3 is not configured.
 # In production S3_BUCKET is set so this block is skipped.

--- a/services/api/app/models/user.py
+++ b/services/api/app/models/user.py
@@ -23,6 +23,7 @@ class User(Base):
     current_streak: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
     longest_streak: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
     last_outfit_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    is_admin: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=text("now()")
     )

--- a/services/api/app/routers/admin.py
+++ b/services/api/app/routers/admin.py
@@ -1,0 +1,37 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.crud import board as board_crud
+from app.crud import outfit as outfit_crud
+from app.dependencies import get_db, require_admin
+from app.models.user import User
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+@router.delete("/outfits/{outfit_id}", status_code=status.HTTP_204_NO_CONTENT)
+def admin_delete_outfit(
+    outfit_id: uuid.UUID,
+    _admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> None:
+    """Admin: delete any outfit regardless of ownership."""
+    outfit = outfit_crud.get_outfit_with_items(db, outfit_id)
+    if not outfit:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Outfit not found.")
+    outfit_crud.delete_outfit(db, outfit)
+
+
+@router.delete("/boards/{board_id}", status_code=status.HTTP_204_NO_CONTENT)
+def admin_delete_board(
+    board_id: uuid.UUID,
+    _admin: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> None:
+    """Admin: delete any board regardless of ownership."""
+    board = board_crud.get_board(db, board_id)
+    if not board:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Board not found.")
+    board_crud.delete_board(db, board)

--- a/services/api/app/routers/boards.py
+++ b/services/api/app/routers/boards.py
@@ -371,7 +371,7 @@ def cleanup_expired_boards(
     Render cron, or AWS EventBridge). Returns the number of boards deleted.
 
     Example cron (GitHub Actions):
-        curl -X POST https://api.ootd.app/boards/admin/cleanup \\
+        curl -X POST https://checkdd.com/boards/admin/cleanup \\
              -H "X-Admin-Secret: $ADMIN_SECRET"
     """
     if not settings.admin_secret:

--- a/services/api/app/schemas/auth.py
+++ b/services/api/app/schemas/auth.py
@@ -41,6 +41,7 @@ class UserResponse(BaseModel):
     profile_image_url: str | None
     current_streak: int = 0
     longest_streak: int = 0
+    is_admin: bool = False
 
     model_config = {"from_attributes": True}
 

--- a/services/api/tests/test_auth.py
+++ b/services/api/tests/test_auth.py
@@ -4,6 +4,10 @@ Postgres test database with a full request/response cycle.
 
 Each test class is isolated: the conftest wipes all rows between tests.
 """
+from jose import jwt
+
+from app.config import settings
+from app.services.auth import ALGORITHM
 
 REGISTER_URL = "/auth/register"
 LOGIN_URL = "/auth/login"
@@ -238,6 +242,11 @@ class TestMe:
 
     def test_invalid_token_returns_401(self, client):
         res = client.get(ME_URL, headers=_bearer("not.a.real.token"))
+        assert res.status_code == 401
+
+    def test_signed_token_with_malformed_subject_returns_401(self, client):
+        token = jwt.encode({"sub": "not-a-uuid"}, settings.secret_key, algorithm=ALGORITHM)
+        res = client.get(ME_URL, headers=_bearer(token))
         assert res.status_code == 401
 
     def test_malformed_auth_header_returns_401(self, client):


### PR DESCRIPTION
## Summary
- **Board delete flash fix** — proxy now explicitly returns `NextResponse(null)` for 204/304 responses instead of passing a null body stream through Next.js, which was causing the frontend to briefly show "something went wrong" even though the delete succeeded
- **Admin role** — `is_admin` bool column on users (default `false`, only grantable via DB), `require_admin` FastAPI dependency, `/admin/outfits/{id}` + `/admin/boards/{id}` DELETE endpoints that bypass ownership, and a guarded `/admin` page to delete content by UUID
- **Security sweep findings** — .env is gitignored ✓, all IDOR checks pass ✓, SQL injection safe (ORM only) ✓, CORS validated ✓, rate limiting on auth ✓. No critical issues found.

## How to grant admin access
Run directly in the DB:
```sql
UPDATE users SET is_admin = true WHERE email = 'your@email.com';
```

## Test plan
- [ ] Delete a board — no more "something went wrong" flash
- [ ] Non-admin hitting `/admin` redirects to `/`
- [ ] Admin at `/admin` can delete outfits and boards by UUID
- [ ] New users have `is_admin = false`