### PR TITLE
feat: user feedback round 1 — vault hidden, media link, instagram, vibe check, UI polish

### DIFF
--- a/apps/web/app/boards/[id]/page.tsx
+++ b/apps/web/app/boards/[id]/page.tsx
@@ -171,7 +171,7 @@ function MediaLinkRow({
       <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0 text-mute" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
         <path d="M12 5v14M5 12h14" />
       </svg>
-      <span className="text-[0.72rem] text-mute">add a link — pinterest, partiful, etc.</span>
+      <span className="text-[0.72rem] text-mute">add a link: pinterest, partiful, etc.</span>
     </button>
   );
 }

--- a/apps/web/app/boards/join/[code]/page.tsx
+++ b/apps/web/app/boards/join/[code]/page.tsx
@@ -142,7 +142,7 @@ export default function JoinBoardPage({ params }: { params: Promise<{ code: stri
             style={{ background: "linear-gradient(135deg, #fce7f3 0%, #fdf2f8 100%)" }}
           >
             <p className="text-[0.65rem] font-semibold uppercase tracking-[0.22em] text-pink-deep/60 mb-3">
-              you&apos;re invited to
+              join my board on checkd
             </p>
             <h1 className="font-display italic text-[2rem] leading-[1.1] tracking-[-0.04em] text-ink">
               {board?.name}

--- a/apps/web/app/boards/page.tsx
+++ b/apps/web/app/boards/page.tsx
@@ -297,7 +297,7 @@ export default function BoardsPage() {
               </div>
               <h2 className="mt-5 text-3xl text-ink">no boards yet</h2>
               <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-ink-soft">
-                Boards are private spaces for an event — create one and invite your crew to post their looks together.
+                Boards are private spaces for an event. create one and invite your crew to post their looks together.
               </p>
               <button
                 type="button"

--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -122,7 +122,7 @@ function WhoToFollowRail({
       <p className="mb-2 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-mute">
         People to follow
       </p>
-      <div className="flex gap-2 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      <div className="-mx-4 flex gap-2 overflow-x-auto px-4 pb-1 sm:-mx-6 sm:px-6 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         {loading
           ? Array.from({ length: 4 }).map((_, i) => (
               <div

--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -418,32 +418,6 @@ function BoardsActivityTab() {
   );
 }
 
-// ── Streak rail card ─────────────────────────────────────────────────────────
-
-function StreakCard({ streak, longest }: { streak: number; longest: number }) {
-  const isAlive = streak > 0;
-  return (
-    <div className="rounded-2xl bg-pink-soft p-5">
-      <p className="text-[10px] uppercase tracking-widest text-mute">your streak</p>
-      <p
-        className="mt-1 font-display leading-none text-ink"
-        style={{ fontSize: 40, letterSpacing: "-0.02em" }}
-      >
-        {streak} {streak === 1 ? "day" : "days"}
-      </p>
-      <p className="mt-2 text-xs leading-5 text-ink-soft">
-        {isAlive
-          ? "post today's fit before midnight to keep it going."
-          : "post today's fit to start your streak."}
-      </p>
-      {longest > 1 && (
-        <p className="mt-3 text-[10px] text-mute">
-          best: {longest} days
-        </p>
-      )}
-    </div>
-  );
-}
 
 // ── Page ──────────────────────────────────────────────────────────────────────
 
@@ -515,25 +489,13 @@ export default function FeedPage() {
         {/* ── Pill tabs ──────────────────────────────────────────────── */}
         <TabSwitcher active={activeTab} onChange={setActiveTab} />
 
-        {/* ── Tab content + desktop streak rail ────────────────────── */}
-        <div className="lg:grid lg:grid-cols-[1fr_256px] lg:gap-8 lg:px-8">
-          <div className="px-4 sm:px-5 lg:px-0">
-            {activeTab === "vault" ? (
-              <VaultFeedTab displayName={displayName} />
-            ) : (
-              <BoardsActivityTab />
-            )}
-          </div>
-
-          {/* Streak rail — desktop only */}
-          <aside className="hidden lg:block">
-            <div className="sticky top-20 space-y-3 pt-1">
-              <StreakCard
-                streak={user?.current_streak ?? 0}
-                longest={user?.longest_streak ?? 0}
-              />
-            </div>
-          </aside>
+        {/* ── Tab content ──────────────────────────────────────────── */}
+        <div className="px-4 sm:px-5 lg:px-8">
+          {activeTab === "vault" ? (
+            <VaultFeedTab displayName={displayName} />
+          ) : (
+            <BoardsActivityTab />
+          )}
         </div>
       </div>
 

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -48,7 +48,7 @@ function StepWelcome({ onNext }: { onNext: () => void }) {
         your fit diary<br />starts here.
       </h1>
       <p className="mt-4 max-w-xs text-sm leading-6 text-ink-soft/70">
-        Log every look, revisit your style history, and see how your taste evolves — one outfit at a time.
+        Log every look, revisit your style history, and see how your taste evolves. one outfit at a time.
       </p>
       <button
         type="button"
@@ -195,7 +195,7 @@ function StepUpload({ onDone }: { onDone: () => void }) {
         Upload your first fit
       </h2>
       <p className="mt-3 max-w-xs text-sm leading-6 text-ink-soft/70">
-        Drop your outfit photo and get an instant vibe check — our AI will tag your style and kick off your archive.
+        Drop your outfit photo and get an instant vibe check. our AI will tag your style and kick off your archive.
       </p>
 
       <Link

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -194,7 +194,7 @@ export default async function HomePage() {
                   href="/signup"
                   className="inline-flex h-10 items-center rounded-full bg-ink px-7 text-sm font-medium text-paper transition hover:opacity-90"
                 >
-                  get started — it&rsquo;s free
+                  get started
                 </Link>
                 <Link
                   href="/login"
@@ -253,14 +253,14 @@ export default async function HomePage() {
             never forget what you wore<br className="hidden sm:block" /> on your best night out.
           </p>
           <p className="mx-auto mt-5 max-w-md text-base leading-7 text-ink-soft">
-            checkd is a soft place to keep your style history — for yourself, and the
+            checkd is a soft place to keep your style history, for yourself and the
             friends who were there.
           </p>
         </div>
 
         <div className="mt-14 grid gap-3 sm:grid-cols-3">
           {[
-            { label: "log a fit", body: "upload a photo and add details about what you're wearing — brand, category, color, all of it." },
+            { label: "log a fit", body: "upload a photo and add details about what you're wearing: brand, category, color, all of it." },
             { label: "share with your board", body: "create an event board for a trip or a night out and invite your girls to post their looks." },
             { label: "get your vibe check", body: "our ai reads the room and gives your fit a vibe check so you always know the energy you're giving." },
           ].map((step, i) => (
@@ -287,7 +287,7 @@ export default async function HomePage() {
           archive the fits.
         </h2>
         <p className="mx-auto mt-5 max-w-sm text-base leading-7 text-ink-soft">
-          start your vault for free — no subscription, no algorithm, just your style.
+          start your vault for free. no algorithm, just your style.
         </p>
         <div className="mt-10 flex justify-center gap-3">
           {isLoggedIn ? (

--- a/apps/web/app/profile/[username]/page.tsx
+++ b/apps/web/app/profile/[username]/page.tsx
@@ -256,6 +256,16 @@ export default function PublicProfilePage({
                 {bio ? (
                   <p className="mt-3 text-sm leading-6 text-ink-soft">{bio}</p>
                 ) : null}
+                {profile?.instagram_handle ? (
+                  <a
+                    href={`https://instagram.com/${profile.instagram_handle}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-2 inline-block text-sm text-pink-deep hover:underline"
+                  >
+                    @{profile.instagram_handle}
+                  </a>
+                ) : null}
 
                 {isAuthenticated ? (
                   <button

--- a/apps/web/app/profile/edit/page.tsx
+++ b/apps/web/app/profile/edit/page.tsx
@@ -123,6 +123,7 @@ export default function EditProfilePage() {
   const [displayName, setDisplayName] = useState("");
   const [username, setUsername] = useState("");
   const [bio, setBio] = useState("");
+  const [instagramHandle, setInstagramHandle] = useState("");
   const [avatarSrc, setAvatarSrc] = useState<string | null>(null);
 
   const [avatarUploading, setAvatarUploading] = useState(false);
@@ -149,6 +150,7 @@ export default function EditProfilePage() {
     setUsername(user.username ?? "");
     setBio(user.bio ?? "");
     setAvatarSrc(user.profile_image_url ?? null);
+    setInstagramHandle((user as { instagram_handle?: string | null }).instagram_handle ?? "");
   }, [user]);
 
   const checkUsername = useCallback(
@@ -216,6 +218,7 @@ export default function EditProfilePage() {
       display_name: displayName.trim() || null,
       username: username.trim() || null,
       bio: bio.trim() || null,
+      instagram_handle: instagramHandle.trim().replace(/^@/, "") || null,
     });
 
     if (result.ok) {
@@ -347,6 +350,28 @@ export default function EditProfilePage() {
               {fieldErrors.username ? (
                 <p className="mt-1.5 text-xs text-error">{fieldErrors.username}</p>
               ) : null}
+            </div>
+
+            {/* Instagram handle */}
+            <div>
+              <label htmlFor="instagram" className="block text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-mute">
+                Instagram
+              </label>
+              <div className="relative mt-2">
+                <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-sm text-mute">
+                  @
+                </span>
+                <input
+                  id="instagram"
+                  type="text"
+                  value={instagramHandle}
+                  onChange={(e) => setInstagramHandle(e.target.value.replace(/^@/, ""))}
+                  placeholder="yourhandle"
+                  maxLength={30}
+                  disabled={isSaving}
+                  className="w-full rounded-2xl border border-line bg-white/70 py-3 pl-8 pr-4 text-sm text-ink placeholder:text-mute/40 outline-none transition focus:border-pink-deep/40 focus:ring-2 focus:ring-pink-deep/12 disabled:opacity-50"
+                />
+              </div>
             </div>
 
             {/* Bio */}

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -408,6 +408,21 @@ export default function ProfilePage() {
               </div>
             </div>
 
+            {/* Instagram */}
+            {profile?.instagram_handle ? (
+              <div className="rounded-2xl border border-line bg-white px-5 py-4">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-mute">instagram</p>
+                <a
+                  href={`https://instagram.com/${profile.instagram_handle}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-2 inline-block text-sm text-pink-deep hover:underline"
+                >
+                  @{profile.instagram_handle}
+                </a>
+              </div>
+            ) : null}
+
             {/* Member since */}
             {profile?.created_at ? (
               <div className="rounded-2xl border border-line bg-white px-5 py-4">

--- a/apps/web/app/vault/page.tsx
+++ b/apps/web/app/vault/page.tsx
@@ -209,11 +209,18 @@ export default function VaultPage() {
         {/* vault header */}
         <header className="flex items-end justify-between bg-paper" style={{ padding: "16px 20px 10px" }}>
           <div>
-            <h1 className="font-display italic text-ink" style={{ fontSize: 32, lineHeight: 1, letterSpacing: "-0.02em" }}>
-              my vault.
-            </h1>
+            <div className="flex items-center gap-2.5">
+              <h1 className="font-display italic text-ink" style={{ fontSize: 32, lineHeight: 1, letterSpacing: "-0.02em" }}>
+                my vault.
+              </h1>
+              {user?.current_streak ? (
+                <span className="flex items-center gap-1 rounded-full bg-pink-soft px-2 py-0.5 text-[0.65rem] font-semibold text-pink-deep" style={{ marginBottom: 2 }}>
+                  🔥 {user.current_streak}
+                </span>
+              ) : null}
+            </div>
             <p className="text-mute" style={{ fontSize: 11.5, marginTop: 3 }}>
-              {outfits.length} fits{user?.current_streak ? ` · ${user.current_streak} day streak` : ""} · {displayName}
+              {outfits.length} fits · {displayName}
             </p>
           </div>
           <Link

--- a/apps/web/components/auth/auth-shell.tsx
+++ b/apps/web/components/auth/auth-shell.tsx
@@ -21,7 +21,7 @@ const shellCopy = {
     heading: "create account",
     headingSize: 40,
     headingMarginTop: 8,
-    eyebrow: "welcome — let's set you up.",
+    eyebrow: "welcome. let's set you up.",
     alternateLabel: "have an account?",
     alternateHref: "/login",
     alternateCta: "log in"

--- a/apps/web/components/outfits/outfit-detail-view.tsx
+++ b/apps/web/components/outfits/outfit-detail-view.tsx
@@ -175,7 +175,7 @@ function CommentsSection({ outfitId }: { outfitId: string }) {
           ))}
         </div>
       ) : comments.length === 0 ? (
-        <p className="py-4 text-center text-sm text-mute">no comments yet — be first ✨</p>
+        <p className="py-4 text-center text-sm text-mute">no comments yet. be first ✨</p>
       ) : (
         <ul className="divide-y divide-line/40">
           {comments.map((comment) => (

--- a/apps/web/components/upload/upload-flow.tsx
+++ b/apps/web/components/upload/upload-flow.tsx
@@ -283,7 +283,7 @@ export function UploadFlow() {
         </p>
         <p className="text-mute" style={{ fontSize: 13, marginBottom: 20 }}>
           {currentStep === 1 && "pick the photo that best captures the look."}
-          {currentStep === 2 && "add one row per item — brand, category, color."}
+          {currentStep === 2 && "add one row per item: brand, category, color."}
           {currentStep === 3 && "caption, event, and date are all optional."}
           {currentStep === 4 && "everything look right? go ahead and post it."}
         </p>

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -152,6 +152,7 @@ export type PublicProfile = {
   display_name: string | null;
   bio: string | null;
   profile_image_url: string | null;
+  instagram_handle?: string | null;
   follower_count: number;
   following_count: number;
   created_at: string;
@@ -750,6 +751,7 @@ export const userApiClient = {
     display_name?: string | null;
     bio?: string | null;
     username?: string | null;
+    instagram_handle?: string | null;
   }): Promise<ApiResult<AuthUser>> {
     return sendRequest<AuthUser>("/users/me", {
       method: "PATCH",
@@ -836,7 +838,7 @@ export const userApiClient = {
 // ── Boards ────────────────────────────────────────────────────────────────────
 
 export const boardApiClient = {
-  async create(input: { name: string; event_date?: string }): Promise<ApiResult<Board>> {
+  async create(input: { name: string; event_date?: string; media_link?: string | null }): Promise<ApiResult<Board>> {
     return sendRequest<Board>("/boards", {
       method: "POST",
       body: input,

--- a/services/api/alembic/versions/20260513_g1h2i3j4_add_instagram_handle_to_users.py
+++ b/services/api/alembic/versions/20260513_g1h2i3j4_add_instagram_handle_to_users.py
@@ -1,0 +1,25 @@
+"""add instagram_handle to users
+
+Revision ID: g1h2i3j4
+Revises: f0a1b2c3
+Create Date: 2026-05-13
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "g1h2i3j4"
+down_revision = "f0a1b2c3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("instagram_handle", sa.String(30), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "instagram_handle")

--- a/services/api/app/crud/board.py
+++ b/services/api/app/crud/board.py
@@ -48,6 +48,7 @@ def create_board(
     creator_id: uuid.UUID,
     name: str,
     event_date=None,
+    media_link: str | None = None,
 ) -> Board:
     """Create a board and add the creator as the first member."""
     board = Board(
@@ -56,6 +57,7 @@ def create_board(
         event_date=event_date,
         invite_code=_generate_invite_code(db),
         expires_at=_expires_at(event_date),
+        media_link=media_link,
     )
     db.add(board)
     db.flush()
@@ -74,9 +76,17 @@ def get_by_invite_code(db: Session, invite_code: str) -> Board | None:
     return db.query(Board).filter(Board.invite_code == invite_code).first()
 
 
-def update_board(db: Session, board: Board, name: str) -> Board:
-    """Rename a board. Only the creator should call this."""
-    board.name = name.strip()
+def update_board(
+    db: Session,
+    board: Board,
+    name: str | None = None,
+    media_link: object = None,
+) -> Board:
+    """Update a board. Only the creator should call this."""
+    if name is not None:
+        board.name = name.strip()
+    if media_link is not None:
+        board.media_link = media_link if media_link != "" else None
     db.commit()
     db.refresh(board)
     return board

--- a/services/api/app/crud/outfit.py
+++ b/services/api/app/crud/outfit.py
@@ -41,6 +41,7 @@ def create_outfit(
     worn_on: date | None = None,
     vibe_check_text: str | None = None,
     vibe_check_tone: str | None = None,
+    vault_hidden: bool = False,
 ) -> Outfit:
     """
     Insert one outfit row and all its clothing_items in a single transaction.
@@ -54,6 +55,7 @@ def create_outfit(
         worn_on=worn_on,
         vibe_check_text=vibe_check_text,
         vibe_check_tone=vibe_check_tone,
+        vault_hidden=vault_hidden,
     )
     db.add(outfit)
     db.flush()  # get outfit.id without committing yet
@@ -100,7 +102,7 @@ def get_user_outfits(
     query = (
         db.query(Outfit)
         .options(selectinload(Outfit.clothing_items))
-        .filter(Outfit.user_id == user_id)
+        .filter(Outfit.user_id == user_id, Outfit.vault_hidden.is_(False))
     )
 
     if cursor:

--- a/services/api/app/crud/user.py
+++ b/services/api/app/crud/user.py
@@ -45,6 +45,7 @@ def update_profile(
     display_name: object = _UNSET,
     bio: object = _UNSET,
     username: object = _UNSET,
+    instagram_handle: object = _UNSET,
 ) -> User:
     """
     Partial update — only fields explicitly passed are written.
@@ -56,6 +57,8 @@ def update_profile(
         user.bio = bio  # type: ignore[assignment]
     if username is not _UNSET:
         user.username = username  # type: ignore[assignment]
+    if instagram_handle is not _UNSET:
+        user.instagram_handle = instagram_handle  # type: ignore[assignment]
     db.commit()
     db.refresh(user)
     return user

--- a/services/api/app/models/board.py
+++ b/services/api/app/models/board.py
@@ -36,6 +36,7 @@ class Board(Base):
     name: Mapped[str] = mapped_column(String(120), nullable=False)
     event_date: Mapped[date | None] = mapped_column(Date, nullable=True)
     invite_code: Mapped[str] = mapped_column(String(12), nullable=False, unique=True)
+    media_link: Mapped[str | None] = mapped_column(String(500), nullable=True)
     expires_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False
     )

--- a/services/api/app/models/outfit.py
+++ b/services/api/app/models/outfit.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import date, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Date, DateTime, ForeignKey, Index, String, text
+from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Index, String, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -29,6 +29,7 @@ class Outfit(Base):
     worn_on: Mapped[date | None] = mapped_column(Date, nullable=True)
     vibe_check_text: Mapped[str | None] = mapped_column(String, nullable=True)
     vibe_check_tone: Mapped[str | None] = mapped_column(String, nullable=True)
+    vault_hidden: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=text("now()")
     )

--- a/services/api/app/models/user.py
+++ b/services/api/app/models/user.py
@@ -20,6 +20,7 @@ class User(Base):
     display_name: Mapped[str | None] = mapped_column(String, nullable=True)
     profile_image_url: Mapped[str | None] = mapped_column(String, nullable=True)
     bio: Mapped[str | None] = mapped_column(String, nullable=True)
+    instagram_handle: Mapped[str | None] = mapped_column(String(30), nullable=True)
     current_streak: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
     longest_streak: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
     last_outfit_date: Mapped[date | None] = mapped_column(Date, nullable=True)

--- a/services/api/app/routers/boards.py
+++ b/services/api/app/routers/boards.py
@@ -61,6 +61,7 @@ def _board_out(db: Session, board) -> BoardOut:
         creator_id=board.creator_id,
         expires_at=board.expires_at,
         member_count=board_crud.member_count(db, board.id),
+        media_link=board.media_link,
         created_at=board.created_at,
     )
 
@@ -79,6 +80,7 @@ def create_board(
         creator_id=current_user.id,
         name=body.name,
         event_date=body.event_date,
+        media_link=body.media_link,
     )
     return _board_out(db, board)
 
@@ -127,7 +129,11 @@ def update_board(
     """Rename a board. Creator only."""
     board = _board_or_404(db, board_id)
     _require_creator(db, board_id, current_user.id)
-    board = board_crud.update_board(db, board, payload.name)
+    board = board_crud.update_board(
+        db, board,
+        name=payload.name,
+        media_link=payload.media_link if payload.media_link is not None else None,
+    )
     return _board_out(db, board)
 
 

--- a/services/api/app/routers/outfits.py
+++ b/services/api/app/routers/outfits.py
@@ -101,6 +101,7 @@ def create_outfit(
         clothing_items=meta.clothing_items,
         vibe_check_text=vibe_check_text,
         vibe_check_tone=vibe_check_tone,
+        vault_hidden=not meta.save_to_vault,
     )
 
     return OutfitOut.model_validate(outfit)

--- a/services/api/app/routers/users.py
+++ b/services/api/app/routers/users.py
@@ -45,6 +45,7 @@ def update_profile(
         display_name=body.display_name if body.display_name is not None else _UNSET,
         bio=body.bio if body.bio is not None else _UNSET,
         username=body.username if body.username is not None else _UNSET,
+        instagram_handle=body.instagram_handle if body.instagram_handle is not None else _UNSET,
     )
     return PublicProfile(
         id=user.id,
@@ -52,6 +53,7 @@ def update_profile(
         display_name=user.display_name,
         bio=user.bio,
         profile_image_url=user.profile_image_url,
+        instagram_handle=user.instagram_handle,
         follower_count=follow_crud.follower_count(db, user.id),
         following_count=follow_crud.following_count(db, user.id),
         created_at=user.created_at,
@@ -88,6 +90,7 @@ def upload_avatar(
         display_name=user.display_name,
         bio=user.bio,
         profile_image_url=user.profile_image_url,
+        instagram_handle=user.instagram_handle,
         follower_count=follow_crud.follower_count(db, user.id),
         following_count=follow_crud.following_count(db, user.id),
         created_at=user.created_at,
@@ -176,6 +179,7 @@ def get_profile(username: str, db: Session = Depends(get_db)) -> PublicProfile:
         display_name=user.display_name,
         bio=user.bio,
         profile_image_url=user.profile_image_url,
+        instagram_handle=user.instagram_handle,
         follower_count=follow_crud.follower_count(db, user.id),
         following_count=follow_crud.following_count(db, user.id),
         created_at=user.created_at,

--- a/services/api/app/schemas/board.py
+++ b/services/api/app/schemas/board.py
@@ -11,10 +11,12 @@ from app.schemas.outfit import BoardOutfitPage, OutfitOut  # noqa: F401 (re-expo
 class CreateBoardRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=120)
     event_date: date | None = None
+    media_link: str | None = None
 
 
 class UpdateBoardRequest(BaseModel):
-    name: str = Field(..., min_length=1, max_length=120)
+    name: str | None = Field(default=None, min_length=1, max_length=120)
+    media_link: str | None = None
 
 
 class BoardOut(BaseModel):
@@ -25,6 +27,7 @@ class BoardOut(BaseModel):
     creator_id: uuid.UUID
     expires_at: datetime
     member_count: int
+    media_link: str | None
     created_at: datetime
 
     model_config = {"from_attributes": True}

--- a/services/api/app/schemas/outfit.py
+++ b/services/api/app/schemas/outfit.py
@@ -33,6 +33,7 @@ class OutfitMetadata(BaseModel):
     event_name: str | None = None
     worn_on: date | None = None
     clothing_items: list[ClothingItemIn] = Field(default_factory=list)
+    save_to_vault: bool = True
 
 
 # ------------------------------------------------------------------ output

--- a/services/api/app/schemas/user.py
+++ b/services/api/app/schemas/user.py
@@ -10,6 +10,7 @@ class PublicProfile(BaseModel):
     display_name: str | None
     bio: str | None
     profile_image_url: str | None
+    instagram_handle: str | None = None
     follower_count: int
     following_count: int
     created_at: datetime
@@ -28,6 +29,7 @@ class UpdateProfileRequest(BaseModel):
     display_name: str | None = Field(default=None, max_length=64)
     bio: str | None = Field(default=None, max_length=160)
     username: str | None = Field(default=None, min_length=2, max_length=30)
+    instagram_handle: str | None = Field(default=None, max_length=30)
 
     @field_validator("username")
     @classmethod

--- a/services/api/app/services/vibe_check.py
+++ b/services/api/app/services/vibe_check.py
@@ -83,7 +83,7 @@ def run_vibe_check(
     try:
         client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
         message = client.messages.create(
-            model="claude-opus-4-5",
+            model="claude-sonnet-4-6",
             max_tokens=256,
             messages=[
                 {


### PR DESCRIPTION
## Summary

- **Vibe check fix**: was silently failing because model ID `claude-opus-4-5` doesn't exist — switched to `claude-sonnet-4-6`. All uploads will now get AI vibe checks.
- **vault_hidden re-enabled**: Outfit model + CRUD filter restored. Upload flow can pass `save_to_vault: false` to hide an outfit from the vault. Migration `d7e8f9a0` already in DB.
- **media_link re-enabled**: Board model + create/update endpoints restored. Pinterest/Partiful links save to boards again. Migration `e8f9a0b1` already in DB.
- **Instagram handle**: New field on users — model, migration (`g1h2i3j4`, chains from `f0a1b2c3`), schema, CRUD, router, edit profile UI, and display on both own and public profile pages.
- **Em dash removal**: Eliminated all `—` from visible UI copy across page.tsx, boards, onboarding, auth-shell, outfit-detail-view, upload-flow.
- **Home page copy**: Fixed "get started — it's free" → "get started"; removed "no subscription" language.
- **Explore page**: Fixed people-to-follow rail being cut at the edge (`-mx-4 px-4` bleed trick).
- **Board invite page**: Updated eyebrow label to "join my board on checkd".

## Test plan

- [ ] Upload a new outfit — should receive a vibe check (check Railway logs)
- [ ] Check `save_to_vault` toggle wiring in upload flow (backend accepts it; frontend toggle UI still pending in a follow-up)
- [ ] Create a board with a Pinterest/Partiful link — verify it saves
- [ ] Edit profile, add instagram handle — verify it appears on profile "about" tab and on public profile
- [ ] Visit explore page on mobile — people-to-follow rail should scroll to edges without clipping
- [ ] Share a board invite link — recipient should see "join my board on checkd"
- [ ] Scan UI for any remaining em dashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)