### PR TITLE
fix: resolve alembic multiple heads after is_admin + instagram_handle migrations

### DIFF
--- a/services/api/alembic/versions/20260513_g1h2i3j4_add_instagram_handle_to_users.py
+++ b/services/api/alembic/versions/20260513_g1h2i3j4_add_instagram_handle_to_users.py
@@ -1,7 +1,7 @@
 """add instagram_handle to users
 
 Revision ID: g1h2i3j4
-Revises: f0a1b2c3
+Revises: h2i3j4k5
 Create Date: 2026-05-13
 """
 
@@ -9,7 +9,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = "g1h2i3j4"
-down_revision = "f0a1b2c3"
+down_revision = "h2i3j4k5"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Both migrations chained from f0a1b2c3 (streaks), creating two heads. This updates instagram_handle (g1h2i3j4) to chain from is_admin (h2i3j4k5) instead, restoring a linear migration history. All 204 tests pass locally.