### PR TITLE
fix: sticky bottom nav, story card logo position, save_to_vault toggle

### DIFF
--- a/apps/web/app/boards/[id]/page.tsx
+++ b/apps/web/app/boards/[id]/page.tsx
@@ -79,10 +79,12 @@ function MediaLinkRow({
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
   const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   function startEdit() {
     setDraft(value ?? "");
+    setSaveError(null);
     setEditing(true);
     setTimeout(() => inputRef.current?.focus(), 0);
   }
@@ -90,16 +92,25 @@ function MediaLinkRow({
   async function handleSave() {
     if (saving) return;
     setSaving(true);
+    setSaveError(null);
     const trimmed = draft.trim();
-    const result = await apiClient.boards.update(boardId, { media_link: trimmed || "" });
-    if (result.ok) onSave(result.data.media_link);
+    const result = await apiClient.boards.update(boardId, { media_link: trimmed || null });
+    if (result.ok) {
+      onSave(result.data.media_link);
+      setEditing(false);
+    } else {
+      setSaveError(result.message ?? "Couldn't save link.");
+    }
     setSaving(false);
-    setEditing(false);
   }
 
   if (editing) {
     return (
-      <div className="flex items-center gap-2 rounded-[1.2rem] border border-pink-deep/30 bg-white px-4 py-3">
+      <div className="flex flex-col gap-2">
+        {saveError ? (
+          <p className="rounded-[1rem] border border-error/20 bg-error/5 px-3 py-2 text-xs text-error">{saveError}</p>
+        ) : null}
+        <div className="flex items-center gap-2 rounded-[1.2rem] border border-pink-deep/30 bg-white px-4 py-3">
         <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0 text-pink-deep" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
           <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
           <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
@@ -132,6 +143,7 @@ function MediaLinkRow({
         >
           cancel
         </button>
+      </div>
       </div>
     );
   }

--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -72,35 +72,37 @@ function UserChip({
   const initial = (user.display_name?.trim() || user.username?.trim() || "?").charAt(0).toUpperCase();
 
   return (
-    <div className="flex shrink-0 items-center gap-2 rounded-[1.25rem] border border-line bg-white px-3 py-2">
+    <div className="flex flex-col items-center gap-2 rounded-[1.25rem] border border-line bg-white px-2 py-3 text-center">
       {user.profile_image_url ? (
         <img
           src={user.profile_image_url}
           alt={user.username ?? ""}
-          className="h-8 w-8 shrink-0 rounded-full border border-line object-cover"
+          className="h-10 w-10 rounded-full border border-line object-cover"
         />
       ) : (
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-pink-soft text-xs font-semibold text-ink-soft">
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-pink-soft text-sm font-semibold text-ink-soft">
           {initial}
         </div>
       )}
-      <span className="max-w-[80px] truncate text-xs font-semibold text-ink">
+      <p className="w-full truncate text-[0.68rem] font-semibold text-ink">
         {user.display_name ?? user.username ?? "Unknown"}
-      </span>
+      </p>
       <button
         type="button"
         onClick={following ? onUnfollow : onFollow}
-        className={`shrink-0 rounded-full px-2.5 py-1 text-[0.68rem] font-medium lowercase transition ${
+        className={`w-full rounded-full px-2 py-1 text-[0.65rem] font-medium lowercase transition ${
           following
             ? "border border-line bg-white text-ink-soft hover:border-pink-deep"
             : "bg-ink text-paper hover:opacity-90"
         }`}
       >
-        {following ? "Following" : "Follow"}
+        {following ? "following" : "follow"}
       </button>
     </div>
   );
 }
+
+const PAGE_USERS = 3;
 
 function WhoToFollowRail({
   users,
@@ -115,22 +117,39 @@ function WhoToFollowRail({
   onFollow: (userId: string, followerCount: number) => void;
   onUnfollow: (userId: string, followerCount: number) => void;
 }) {
+  const [page, setPage] = useState(0);
+
   if (!loading && users.length === 0) return null;
+
+  const totalPages = Math.ceil(users.length / PAGE_USERS);
+  const visible = users.slice(page * PAGE_USERS, page * PAGE_USERS + PAGE_USERS);
+  const hasNext = page < totalPages - 1;
 
   return (
     <div className="mb-5">
-      <p className="mb-2 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-mute">
-        People to follow
-      </p>
-      <div className="-mx-4 flex gap-2 overflow-x-auto px-4 pb-1 sm:-mx-6 sm:px-6 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      <div className="mb-2 flex items-center justify-between">
+        <p className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-mute">
+          People to follow
+        </p>
+        {!loading && hasNext ? (
+          <button
+            type="button"
+            onClick={() => setPage((p) => p + 1)}
+            className="flex items-center gap-1 text-[0.65rem] font-semibold text-mute transition hover:text-ink"
+          >
+            more
+            <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="m9 18 6-6-6-6" />
+            </svg>
+          </button>
+        ) : null}
+      </div>
+      <div className="grid grid-cols-3 gap-2">
         {loading
-          ? Array.from({ length: 4 }).map((_, i) => (
-              <div
-                key={i}
-                className="flex h-12 w-44 shrink-0 animate-pulse items-center gap-2 rounded-[1.25rem] border border-line bg-pink-soft px-3"
-              />
+          ? Array.from({ length: PAGE_USERS }).map((_, i) => (
+              <div key={i} className="flex h-12 animate-pulse items-center gap-2 rounded-[1.25rem] border border-line bg-pink-soft px-3" />
             ))
-          : users.map((user) => (
+          : visible.map((user) => (
               <UserChip
                 key={user.id}
                 user={user}

--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -224,7 +224,7 @@ function VaultFeedTab({ displayName }: { displayName: string }) {
     <>
       <section className="grid grid-cols-2 gap-3 sm:gap-4">
         {outfits.map((outfit) => (
-          <OutfitCard key={outfit.id} outfit={toVaultCardData(outfit)} showAccentMarker />
+          <OutfitCard key={outfit.id} outfit={toVaultCardData(outfit)} showCaption={false} showAccentMarker />
         ))}
         {loadingMore
           ? Array.from({ length: 3 }).map((_, i) => <OutfitCardSkeleton key={`skel-${i}`} />)
@@ -490,7 +490,7 @@ export default function FeedPage() {
         <TabSwitcher active={activeTab} onChange={setActiveTab} />
 
         {/* ── Tab content ──────────────────────────────────────────── */}
-        <div className="px-4 sm:px-5 lg:px-8">
+        <div className="px-4 sm:px-6 lg:px-8">
           {activeTab === "vault" ? (
             <VaultFeedTab displayName={displayName} />
           ) : (

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -62,14 +62,8 @@ button:active:not(:disabled),
 
 /* ── Page transitions ────────────────────────────────────────────────────── */
 @keyframes page-enter {
-  from {
-    opacity: 0;
-    transform: translateY(8px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  from { opacity: 0; }
+  to   { opacity: 1; }
 }
 
 main {

--- a/apps/web/app/vault/page.tsx
+++ b/apps/web/app/vault/page.tsx
@@ -236,7 +236,7 @@ export default function VaultPage() {
         </header>
 
         {/* search bar */}
-        <div style={{ padding: "0 20px 12px" }}>
+        <div className="px-4 pb-3 sm:px-6">
           <div className="flex items-center gap-2.5 rounded-full border border-line bg-white px-4" style={{ height: 40 }}>
             <svg viewBox="0 0 24 24" className="h-3.5 w-3.5 shrink-0 text-mute" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round">
               <circle cx="11" cy="11" r="7" /><path d="m21 21-4.35-4.35" />
@@ -259,7 +259,7 @@ export default function VaultPage() {
         </div>
 
         {/* ── Vault grid ─────────────────────────────────────────────── */}
-        <section className="px-4 sm:px-5">
+        <section className="px-4 sm:px-6">
           {errorMessage && vaultStatus !== "loading" ? (
             <div className="my-3 rounded-xl border border-pink-deep/30 bg-pink-soft px-4 py-3 text-sm text-error">
               {errorMessage}
@@ -269,7 +269,7 @@ export default function VaultPage() {
           {vaultStatus === "loading" ? (
             <div className="grid grid-cols-2 gap-3 sm:gap-4">
               {Array.from({ length: 9 }).map((_, i) => (
-                <div key={i} className="aspect-[3/4] w-full animate-pulse bg-pink-soft skeleton-stripe" />
+                <OutfitCardSkeleton key={i} showAuthor={false} />
               ))}
             </div>
           ) : null}
@@ -279,7 +279,7 @@ export default function VaultPage() {
             searchLoading ? (
               <div className="grid grid-cols-2 gap-3 sm:gap-4">
                 {Array.from({ length: 6 }).map((_, i) => (
-                  <div key={i} className="aspect-[3/4] w-full animate-pulse bg-pink-soft skeleton-stripe" />
+                  <OutfitCardSkeleton key={i} showAuthor={false} />
                 ))}
               </div>
             ) : searchResults !== null && searchResults.length === 0 ? (
@@ -303,6 +303,7 @@ export default function VaultPage() {
                     key={outfit.id}
                     href={`/outfits/${outfit.id}?from=vault`}
                     outfit={toCardData(outfit)}
+                    showCaption={false}
                     liked={likes[outfit.id]?.liked}
                     onLike={(e) => { e.preventDefault(); void handleLike(outfit.id); }}
                   />
@@ -333,6 +334,7 @@ export default function VaultPage() {
                     key={outfit.id}
                     href={`/outfits/${outfit.id}?from=vault`}
                     outfit={toCardData(outfit)}
+                    showCaption={false}
                     liked={likes[outfit.id]?.liked}
                     onLike={(e) => { e.preventDefault(); void handleLike(outfit.id); }}
                   />

--- a/apps/web/components/outfits/story-card-sheet.tsx
+++ b/apps/web/components/outfits/story-card-sheet.tsx
@@ -103,12 +103,14 @@ export function StoryCardSheet({ outfitId, imageUrl, wornOn, createdAt, vibeChec
       const LOGO_SIZE = 58;
       const DATE_SIZE = 27;
 
+      // Logo sits below Instagram's story chrome (~progress bar + avatar row)
+      const LOGO_TOP = 260;
       ctx.save();
       ctx.font = `italic 400 ${LOGO_SIZE}px Georgia, serif`;
       ctx.fillStyle = "#F9A8D4";
       ctx.textAlign = "right";
       ctx.textBaseline = "top";
-      ctx.fillText("checkd", W - PAD, PAD);
+      ctx.fillText("checkd", W - PAD, LOGO_TOP);
       ctx.restore();
 
       if (dateLabel) {
@@ -117,7 +119,7 @@ export function StoryCardSheet({ outfitId, imageUrl, wornOn, createdAt, vibeChec
         ctx.fillStyle = "rgba(255,255,255,0.68)";
         ctx.textAlign = "right";
         ctx.textBaseline = "top";
-        ctx.fillText(dateLabel, W - PAD, PAD + LOGO_SIZE + 8);
+        ctx.fillText(dateLabel, W - PAD, LOGO_TOP + LOGO_SIZE + 8);
         ctx.restore();
       }
 

--- a/apps/web/components/upload/upload-flow.tsx
+++ b/apps/web/components/upload/upload-flow.tsx
@@ -64,6 +64,7 @@ export function UploadFlow() {
   });
   const [errors, setErrors] = useState<ValidationErrors>(createEmptyErrors);
   const [submitState, setSubmitState] = useState<SubmitState>({ status: "idle" });
+  const [saveToVault, setSaveToVault] = useState(true);
   const isSubmittingRef = useRef(false); // synchronous guard against double-tap
 
   useEffect(() => {
@@ -213,7 +214,7 @@ export function UploadFlow() {
       if (metadata.eventName.trim()) payload.event_name = metadata.eventName.trim();
       if (metadata.wornOn) payload.worn_on = metadata.wornOn;
 
-      const result = await apiClient.outfits.create({ image: photo, metadata: payload });
+      const result = await apiClient.outfits.create({ image: photo, metadata: { ...payload, save_to_vault: saveToVault } });
       if (!result.ok) throw new Error(result.message);
 
       setSubmitState({ status: "success", message: "Outfit uploaded!" });
@@ -476,6 +477,45 @@ export function UploadFlow() {
               <p className="field-label">date worn <span className="ml-1 font-normal normal-case tracking-normal text-mute">(optional)</span></p>
               <DateSelect value={metadata.wornOn} onChange={(v) => updateMetadata("wornOn", v)} />
             </div>
+
+            {/* Save to vault toggle */}
+            <button
+              type="button"
+              onClick={() => setSaveToVault((v) => !v)}
+              className="flex items-center justify-between border border-line bg-white transition hover:border-ink/30"
+              style={{ borderRadius: "1.5rem", padding: "14px 16px" }}
+            >
+              <div style={{ textAlign: "left" }}>
+                <p style={{ fontSize: 13, fontWeight: 500, color: "var(--ink)" }}>save to my vault</p>
+                <p style={{ fontSize: 11, color: "var(--mute)", marginTop: 2 }}>
+                  {saveToVault ? "visible only to you" : "won't appear in your vault"}
+                </p>
+              </div>
+              <div
+                style={{
+                  width: 42,
+                  height: 24,
+                  borderRadius: 99,
+                  background: saveToVault ? "var(--ink)" : "var(--line)",
+                  position: "relative",
+                  flexShrink: 0,
+                  transition: "background 0.2s",
+                }}
+              >
+                <div
+                  style={{
+                    position: "absolute",
+                    top: 3,
+                    left: saveToVault ? 21 : 3,
+                    width: 18,
+                    height: 18,
+                    borderRadius: "50%",
+                    background: "white",
+                    transition: "left 0.2s",
+                  }}
+                />
+              </div>
+            </button>
           </div>
         ) : null}
 
@@ -523,6 +563,18 @@ export function UploadFlow() {
                 ))}
               </div>
             </div>
+
+            {/* Vault toggle summary */}
+            {!saveToVault ? (
+              <div
+                className="border border-line bg-white"
+                style={{ borderRadius: "1.5rem", padding: "12px 16px" }}
+              >
+                <p style={{ fontSize: 12, color: "var(--mute)" }}>
+                  this outfit <span style={{ color: "var(--ink)", fontWeight: 500 }}>won't be saved</span> to your vault
+                </p>
+              </div>
+            ) : null}
 
             {/* Metadata summary */}
             {(metadata.caption || metadata.eventName || metadata.wornOn) ? (

--- a/services/api/app/routers/boards.py
+++ b/services/api/app/routers/boards.py
@@ -132,7 +132,7 @@ def update_board(
     board = board_crud.update_board(
         db, board,
         name=payload.name,
-        media_link=payload.media_link if payload.media_link is not None else None,
+        media_link=payload.media_link,
     )
     return _board_out(db, board)
 


### PR DESCRIPTION
- Bottom nav: page-enter animation used transform on <main>, breaking position:fixed for MobileNav. Switched to opacity-only fade.
- Story card: moved checkd logo from 64px to 260px from top to clear Instagram story chrome (progress bar + avatar row).
- Upload flow: added save_to_vault toggle on step 3. Defaults on. Wires through to API on submit.