### PR TITLE
fix: compact image grid on vault/explore/feed, left arrow on people rail, live streak

### DIFF
--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -124,6 +124,7 @@ function WhoToFollowRail({
   const totalPages = Math.ceil(users.length / PAGE_USERS);
   const visible = users.slice(page * PAGE_USERS, page * PAGE_USERS + PAGE_USERS);
   const hasNext = page < totalPages - 1;
+  const hasPrev = page > 0;
 
   return (
     <div className="mb-5">
@@ -131,18 +132,30 @@ function WhoToFollowRail({
         <p className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-mute">
           People to follow
         </p>
-        {!loading && hasNext ? (
-          <button
-            type="button"
-            onClick={() => setPage((p) => p + 1)}
-            className="flex items-center gap-1 text-[0.65rem] font-semibold text-mute transition hover:text-ink"
-          >
-            more
-            <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-              <path d="m9 18 6-6-6-6" />
-            </svg>
-          </button>
-        ) : null}
+        <div className="flex items-center gap-1">
+          {!loading && hasPrev ? (
+            <button
+              type="button"
+              onClick={() => setPage((p) => p - 1)}
+              className="flex items-center gap-1 text-[0.65rem] font-semibold text-mute transition hover:text-ink"
+            >
+              <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="m15 18-6-6 6-6" />
+              </svg>
+            </button>
+          ) : null}
+          {!loading && hasNext ? (
+            <button
+              type="button"
+              onClick={() => setPage((p) => p + 1)}
+              className="flex items-center gap-1 text-[0.65rem] font-semibold text-mute transition hover:text-ink"
+            >
+              <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="m9 18 6-6-6-6" />
+              </svg>
+            </button>
+          ) : null}
+        </div>
       </div>
       <div className="grid grid-cols-3 gap-2">
         {loading
@@ -298,9 +311,9 @@ export default function ExplorePage() {
         {/* ── Outfit grid ─────────────────────────────────────────────────── */}
         <section>
           {gridStatus === "loading" ? (
-            <div className="grid grid-cols-2 gap-3 sm:gap-4">
+            <div className="grid grid-cols-2 gap-0.5">
               {Array.from({ length: 8 }).map((_, i) => (
-                <OutfitCardSkeleton key={i} showAuthor />
+                <OutfitCardSkeleton key={i} compact />
               ))}
             </div>
           ) : null}
@@ -322,19 +335,17 @@ export default function ExplorePage() {
 
           {gridStatus === "ready" && outfits.length > 0 ? (
             <>
-              <div className="grid grid-cols-2 gap-3 sm:gap-4">
+              <div className="grid grid-cols-2 gap-0.5">
                 {outfits.map((outfit) => (
                   <OutfitCard
                     key={outfit.id}
                     outfit={toCardData(outfit)}
-                    showAuthor
-                    showCaption={false}
-                    showAccentMarker={false}
+                    compact
                   />
                 ))}
                 {loadingMore
                   ? Array.from({ length: 2 }).map((_, i) => (
-                      <OutfitCardSkeleton key={`skel-${i}`} showAuthor />
+                      <OutfitCardSkeleton key={`skel-${i}`} compact />
                     ))
                   : null}
               </div>

--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -184,8 +184,8 @@ function VaultFeedTab({ displayName }: { displayName: string }) {
 
   if (status === "loading") {
     return (
-      <section className="grid grid-cols-2 gap-3 sm:gap-4">
-        {Array.from({ length: 6 }).map((_, i) => <OutfitCardSkeleton key={i} />)}
+      <section className="grid grid-cols-2 gap-0.5">
+        {Array.from({ length: 6 }).map((_, i) => <OutfitCardSkeleton key={i} compact />)}
       </section>
     );
   }
@@ -222,12 +222,12 @@ function VaultFeedTab({ displayName }: { displayName: string }) {
 
   return (
     <>
-      <section className="grid grid-cols-2 gap-3 sm:gap-4">
+      <section className="grid grid-cols-2 gap-0.5">
         {outfits.map((outfit) => (
-          <OutfitCard key={outfit.id} outfit={toVaultCardData(outfit)} showCaption={false} showAccentMarker />
+          <OutfitCard key={outfit.id} outfit={toVaultCardData(outfit)} compact />
         ))}
         {loadingMore
-          ? Array.from({ length: 3 }).map((_, i) => <OutfitCardSkeleton key={`skel-${i}`} />)
+          ? Array.from({ length: 3 }).map((_, i) => <OutfitCardSkeleton key={`skel-${i}`} compact />)
           : null}
       </section>
       {cursor ? <div ref={sentinelRef} className="h-px" /> : null}
@@ -490,13 +490,13 @@ export default function FeedPage() {
         <TabSwitcher active={activeTab} onChange={setActiveTab} />
 
         {/* ── Tab content ──────────────────────────────────────────── */}
-        <div className="px-4 sm:px-6 lg:px-8">
-          {activeTab === "vault" ? (
-            <VaultFeedTab displayName={displayName} />
-          ) : (
+        {activeTab === "vault" ? (
+          <VaultFeedTab displayName={displayName} />
+        ) : (
+          <div className="px-4 sm:px-6 lg:px-8">
             <BoardsActivityTab />
-          )}
-        </div>
+          </div>
+        )}
       </div>
 
       <MobileNav active="feed" />

--- a/apps/web/app/vault/page.tsx
+++ b/apps/web/app/vault/page.tsx
@@ -47,7 +47,7 @@ function useSentinel(onIntersect: () => void) {
 
 export default function VaultPage() {
   const router = useRouter();
-  const { isAuthenticated, isLoading, user } = useAuth();
+  const { isAuthenticated, isLoading, user, refreshUser } = useAuth();
 
   // Vault state
   const [vaultStatus, setVaultStatus] = useState<VaultStatus>("idle");
@@ -71,6 +71,13 @@ export default function VaultPage() {
       router.replace("/login");
     }
   }, [isAuthenticated, isLoading, router]);
+
+  // Refresh user on mount to get up-to-date streak data
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) {
+      void refreshUser();
+    }
+  }, [isLoading, isAuthenticated]);
 
   // Load vault
   useEffect(() => {

--- a/apps/web/app/vault/page.tsx
+++ b/apps/web/app/vault/page.tsx
@@ -243,7 +243,7 @@ export default function VaultPage() {
         </header>
 
         {/* search bar */}
-        <div className="px-4 pb-3 sm:px-6">
+        <div className="px-4 pb-2 sm:px-5">
           <div className="flex items-center gap-2.5 rounded-full border border-line bg-white px-4" style={{ height: 40 }}>
             <svg viewBox="0 0 24 24" className="h-3.5 w-3.5 shrink-0 text-mute" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round">
               <circle cx="11" cy="11" r="7" /><path d="m21 21-4.35-4.35" />
@@ -266,17 +266,17 @@ export default function VaultPage() {
         </div>
 
         {/* ── Vault grid ─────────────────────────────────────────────── */}
-        <section className="px-4 sm:px-6">
+        <section>
           {errorMessage && vaultStatus !== "loading" ? (
-            <div className="my-3 rounded-xl border border-pink-deep/30 bg-pink-soft px-4 py-3 text-sm text-error">
+            <div className="mx-4 my-3 rounded-xl border border-pink-deep/30 bg-pink-soft px-4 py-3 text-sm text-error">
               {errorMessage}
             </div>
           ) : null}
 
           {vaultStatus === "loading" ? (
-            <div className="grid grid-cols-2 gap-3 sm:gap-4">
+            <div className="grid grid-cols-2 gap-0.5">
               {Array.from({ length: 9 }).map((_, i) => (
-                <OutfitCardSkeleton key={i} showAuthor={false} />
+                <OutfitCardSkeleton key={i} compact />
               ))}
             </div>
           ) : null}
@@ -284,9 +284,9 @@ export default function VaultPage() {
           {/* Search results — API-powered, shows all matching outfits across the full vault */}
           {searchQuery.trim() ? (
             searchLoading ? (
-              <div className="grid grid-cols-2 gap-3 sm:gap-4">
+              <div className="grid grid-cols-2 gap-0.5">
                 {Array.from({ length: 6 }).map((_, i) => (
-                  <OutfitCardSkeleton key={i} showAuthor={false} />
+                  <OutfitCardSkeleton key={i} compact />
                 ))}
               </div>
             ) : searchResults !== null && searchResults.length === 0 ? (
@@ -304,13 +304,13 @@ export default function VaultPage() {
                 </button>
               </div>
             ) : searchResults !== null ? (
-              <div className="grid grid-cols-2 gap-3 sm:gap-4">
+              <div className="grid grid-cols-2 gap-0.5">
                 {searchResults.map((outfit) => (
                   <OutfitCard
                     key={outfit.id}
                     href={`/outfits/${outfit.id}?from=vault`}
                     outfit={toCardData(outfit)}
-                    showCaption={false}
+                    compact
                     liked={likes[outfit.id]?.liked}
                     onLike={(e) => { e.preventDefault(); void handleLike(outfit.id); }}
                   />
@@ -320,7 +320,7 @@ export default function VaultPage() {
           ) : null}
 
           {vaultStatus === "ready" && outfits.length === 0 && !searchQuery.trim() ? (
-            <div className="px-5 py-16 text-center">
+            <div className="px-5 py-16 text-center mx-4">
               <p className="font-display italic text-2xl text-ink">your archive is ready.</p>
               <p className="mx-auto mt-3 max-w-xs text-sm leading-6 text-ink-soft">
                 it just needs your first look.
@@ -335,20 +335,20 @@ export default function VaultPage() {
 
           {vaultStatus === "ready" && outfits.length > 0 && !searchQuery.trim() ? (
             <>
-              <div className="grid grid-cols-2 gap-3 sm:gap-4">
+              <div className="grid grid-cols-2 gap-0.5">
                 {outfits.map((outfit) => (
                   <OutfitCard
                     key={outfit.id}
                     href={`/outfits/${outfit.id}?from=vault`}
                     outfit={toCardData(outfit)}
-                    showCaption={false}
+                    compact
                     liked={likes[outfit.id]?.liked}
                     onLike={(e) => { e.preventDefault(); void handleLike(outfit.id); }}
                   />
                 ))}
                 {loadingMore
                   ? Array.from({ length: 3 }).map((_, i) => (
-                      <div key={`skel-${i}`} className="aspect-[3/4] w-full animate-pulse bg-pink-soft skeleton-stripe" />
+                      <OutfitCardSkeleton key={`skel-${i}`} compact />
                     ))
                   : null}
               </div>
@@ -357,7 +357,7 @@ export default function VaultPage() {
           ) : null}
 
           {vaultStatus === "error" ? (
-            <div className="mt-4 flex justify-center">
+            <div className="mt-4 flex justify-center px-4">
               <button type="button" onClick={() => router.refresh()} className="rounded-full border border-line bg-white px-4 py-3 text-sm font-medium text-ink-soft transition hover:border-pink-deep">
                 refresh
               </button>

--- a/apps/web/components/outfits/outfit-card.tsx
+++ b/apps/web/components/outfits/outfit-card.tsx
@@ -335,10 +335,18 @@ export function OutfitCard({
 }
 
 export function OutfitCardSkeleton({
-  showAuthor = true
+  showAuthor = true,
+  compact = false,
 }: {
   showAuthor?: boolean;
+  compact?: boolean;
 }) {
+  if (compact) {
+    return (
+      <div className="skeleton-stripe aspect-[3/4] w-full animate-pulse bg-pink-soft" />
+    );
+  }
+
   return (
     <article className="overflow-hidden rounded-xl border border-line bg-white">
       <div className="skeleton-stripe aspect-[4/5] w-full animate-pulse" />


### PR DESCRIPTION
## Summary
- **Compact grid**: vault, explore (discover), and feed vault tab all now use the same full-bleed compact card style — no borders, no info section below, images go edge-to-edge with a 2px gap. Matches Instagram/Pinterest layout.
- **Left arrow on people rail**: the explore page now shows a ← arrow when you're past the first page of suggested users, alongside the existing → arrow.
- **Live streak on vault**: calls `refreshUser()` on vault mount so the streak badge always reflects the current streak from the server, not the cached auth session.

## Streak note
The 🔥 badge shows once `current_streak > 0`. Streak is set to 1 on your first outfit upload and increments each consecutive day you post. If you haven't uploaded yet or there's a gap, streak will be 0. This fix ensures the badge appears as soon as the server has a streak recorded, even if the session was cached before that outfit was uploaded.