### PR TITLE
feat: login with username, HEIC upload, AI consent, board invite share, explore filter

### DIFF
--- a/apps/web/app/boards/[id]/page.tsx
+++ b/apps/web/app/boards/[id]/page.tsx
@@ -37,12 +37,21 @@ function formatExpiry(d: string) {
 
 // ── Invite link copy ──────────────────────────────────────────────────────────
 
-function InviteCopy({ code }: { code: string }) {
+function InviteCopy({ code, boardName }: { code: string; boardName?: string }) {
   const [copied, setCopied] = useState(false);
   const link = `${typeof window !== "undefined" ? window.location.origin : ""}/boards/join/${code}`;
+  const shareText = `Join my board${boardName ? ` "${boardName}"` : ""} on checkd! ${link}`;
 
-  async function copy() {
-    await navigator.clipboard.writeText(link);
+  async function share() {
+    if (typeof navigator !== "undefined" && navigator.share) {
+      try {
+        await navigator.share({ text: shareText, url: link });
+        return;
+      } catch {
+        // user cancelled or share failed — fall through to clipboard
+      }
+    }
+    await navigator.clipboard.writeText(shareText);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }
@@ -56,10 +65,10 @@ function InviteCopy({ code }: { code: string }) {
       <span className="min-w-0 flex-1 truncate text-[0.72rem] text-mute">{link}</span>
       <button
         type="button"
-        onClick={() => void copy()}
+        onClick={() => void share()}
         className="shrink-0 text-[0.72rem] font-semibold text-pink-deep transition hover:text-[#d94e7a]"
       >
-        {copied ? "Copied!" : "Copy"}
+        {copied ? "Copied!" : "Share"}
       </button>
     </div>
   );
@@ -498,7 +507,7 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
               <div className="mt-4 space-y-3">
                 <div>
                   <p className="mb-2 text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-mute">Invite link</p>
-                  <InviteCopy code={board.invite_code} />
+                  <InviteCopy code={board.invite_code} boardName={board.name} />
                 </div>
                 <div>
                   <p className="mb-2 text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-mute">Board link</p>

--- a/apps/web/app/boards/[id]/upload/page.tsx
+++ b/apps/web/app/boards/[id]/upload/page.tsx
@@ -6,6 +6,17 @@ import { useRouter } from "next/navigation";
 import { apiClient } from "@/lib/api-client";
 import { useAuth } from "@/lib/auth-context";
 
+async function normalizeImageFile(file: File): Promise<File> {
+  const type = file.type.toLowerCase();
+  if (type === "image/heic" || type === "image/heif" || (type === "" && file.name.toLowerCase().endsWith(".heic"))) {
+    const heic2any = (await import("heic2any")).default;
+    const converted = await heic2any({ blob: file, toType: "image/jpeg", quality: 0.92 });
+    const blob = Array.isArray(converted) ? converted[0] : converted;
+    return new File([blob], file.name.replace(/\.heic$/i, ".jpg"), { type: "image/jpeg" });
+  }
+  return file;
+}
+
 type Step = 1 | 2;
 type SubmitStatus = "idle" | "uploading" | "error";
 type BoardStatus = "loading" | "ready" | "not-member" | "expired" | "error";
@@ -49,8 +60,13 @@ export default function BoardUploadPage({ params }: { params: Promise<{ id: stri
   }, [id, isAuthenticated, isLoading]);
 
   function handleFile(file: File) {
-    setPhoto(file);
-    setPreview(URL.createObjectURL(file));
+    normalizeImageFile(file).then((normalized) => {
+      setPhoto(normalized);
+      setPreview(URL.createObjectURL(normalized));
+    }).catch(() => {
+      setPhoto(file);
+      setPreview(URL.createObjectURL(file));
+    });
   }
 
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -61,7 +77,8 @@ export default function BoardUploadPage({ params }: { params: Promise<{ id: stri
   function handleDrop(e: React.DragEvent) {
     e.preventDefault();
     const file = e.dataTransfer.files?.[0];
-    if (file && file.type.startsWith("image/")) handleFile(file);
+    const isImage = file && (file.type.startsWith("image/") || file.name.toLowerCase().endsWith(".heic"));
+    if (isImage) handleFile(file);
   }
 
   async function handlePost() {

--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -46,7 +46,7 @@ function useSentinel(onIntersect: () => void) {
     if (!el) return;
     const obs = new IntersectionObserver(
       ([e]) => { if (e.isIntersecting) cb.current(); },
-      { rootMargin: "200px" }
+      { rootMargin: "600px" }
     );
     obs.observe(el);
     return () => obs.disconnect();
@@ -278,10 +278,9 @@ export default function ExplorePage() {
   }
 
   return (
-    <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8 lg:pb-0 lg:pt-20">
-      <div className="mx-auto max-w-3xl">
-
-        {/* ── Header ─────────────────────────────────────────────────────── */}
+    <main className="pb-28 pt-6 lg:pb-0 lg:pt-20">
+      {/* Header and people rail stay padded */}
+      <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
         <header className="mb-5">
           <div className="mb-4 flex items-center justify-between gap-3">
             <div>
@@ -307,18 +306,20 @@ export default function ExplorePage() {
             onUnfollow={handleUnfollow}
           />
         </header>
+      </div>
 
-        {/* ── Outfit grid ─────────────────────────────────────────────────── */}
-        <section>
-          {gridStatus === "loading" ? (
-            <div className="grid grid-cols-2 gap-0.5">
-              {Array.from({ length: 8 }).map((_, i) => (
-                <OutfitCardSkeleton key={i} compact />
-              ))}
-            </div>
-          ) : null}
+      {/* ── Outfit grid — edge-to-edge on mobile ────────────────────────── */}
+      <section>
+        {gridStatus === "loading" ? (
+          <div className="grid grid-cols-2 gap-0.5">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <OutfitCardSkeleton key={i} compact />
+            ))}
+          </div>
+        ) : null}
 
-          {gridStatus === "ready" && outfits.length === 0 ? (
+        {gridStatus === "ready" && outfits.length === 0 ? (
+          <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
             <div className="soft-panel px-6 py-10 text-center">
               <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-mute">
                 Nothing yet
@@ -331,29 +332,31 @@ export default function ExplorePage() {
                 Find people to follow
               </Link>
             </div>
-          ) : null}
+          </div>
+        ) : null}
 
-          {gridStatus === "ready" && outfits.length > 0 ? (
-            <>
-              <div className="grid grid-cols-2 gap-0.5">
-                {outfits.map((outfit) => (
-                  <OutfitCard
-                    key={outfit.id}
-                    outfit={toCardData(outfit)}
-                    compact
-                  />
-                ))}
-                {loadingMore
-                  ? Array.from({ length: 2 }).map((_, i) => (
-                      <OutfitCardSkeleton key={`skel-${i}`} compact />
-                    ))
-                  : null}
-              </div>
-              {nextCursor ? <div ref={sentinelRef} className="h-px" /> : null}
-            </>
-          ) : null}
+        {gridStatus === "ready" && outfits.length > 0 ? (
+          <>
+            <div className="grid grid-cols-2 gap-0.5">
+              {outfits.map((outfit) => (
+                <OutfitCard
+                  key={outfit.id}
+                  outfit={toCardData(outfit)}
+                  compact
+                />
+              ))}
+              {loadingMore
+                ? Array.from({ length: 4 }).map((_, i) => (
+                    <OutfitCardSkeleton key={`skel-${i}`} compact />
+                  ))
+                : null}
+            </div>
+            {nextCursor ? <div ref={sentinelRef} className="h-px" /> : null}
+          </>
+        ) : null}
 
-          {gridStatus === "error" ? (
+        {gridStatus === "error" ? (
+          <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
             <div className="soft-panel px-6 py-8 text-center">
               <p className="text-sm text-mute">Couldn&rsquo;t load outfits. Try refreshing.</p>
               <button
@@ -364,9 +367,9 @@ export default function ExplorePage() {
                 Refresh
               </button>
             </div>
-          ) : null}
-        </section>
-      </div>
+          </div>
+        ) : null}
+      </section>
 
       <MobileNav active="none" />
     </main>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,6 +3,7 @@ import { Instrument_Serif, Inter } from "next/font/google";
 import type { ReactNode } from "react";
 import { AuthProvider } from "@/lib/auth-context";
 import { DesktopNav } from "@/components/chrome/desktop-nav";
+import { AiConsentModal } from "@/components/ai-consent-modal";
 import "./globals.css";
 
 const display = Instrument_Serif({
@@ -36,6 +37,7 @@ export default function RootLayout({
       <body suppressHydrationWarning>
         <AuthProvider>
           <DesktopNav />
+          <AiConsentModal />
           {children}
         </AuthProvider>
       </body>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -7,7 +7,7 @@ const FEATURES = [
   {
     title: "my vault",
     description:
-      "every outfit you've ever worn, organized and searchable. filter by vibe, date, or clothing item.",
+      "every outfit you've ever worn, organized and searchable. search by date, event, or clothing item.",
     icon: (
       <svg
         viewBox="0 0 24 24"
@@ -287,7 +287,7 @@ export default async function HomePage() {
           archive the fits.
         </h2>
         <p className="mx-auto mt-5 max-w-sm text-base leading-7 text-ink-soft">
-          start your vault for free. no algorithm, just your style.
+          start today. no algorithm, just your style.
         </p>
         <div className="mt-10 flex justify-center gap-3">
           {isLoggedIn ? (

--- a/apps/web/components/ai-consent-modal.tsx
+++ b/apps/web/components/ai-consent-modal.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuth } from "@/lib/auth-context";
+
+const CONSENT_KEY = "checkd_ai_consent_v1";
+
+export function AiConsentModal() {
+  const { isAuthenticated, isLoading } = useAuth();
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    if (!isAuthenticated || isLoading) return;
+    if (typeof localStorage === "undefined") return;
+    if (!localStorage.getItem(CONSENT_KEY)) {
+      setShow(true);
+    }
+  }, [isAuthenticated, isLoading]);
+
+  function accept() {
+    localStorage.setItem(CONSENT_KEY, "accepted");
+    setShow(false);
+  }
+
+  if (!show) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-center" style={{ background: "rgba(0,0,0,0.35)", backdropFilter: "blur(4px)" }}>
+      <div className="w-full max-w-sm rounded-t-[2rem] border border-line bg-paper px-6 pb-10 pt-8 sm:rounded-[2rem] sm:pb-8">
+        <div className="mb-5 flex h-10 w-10 items-center justify-center rounded-full bg-pink-soft">
+          <svg viewBox="0 0 24 24" className="h-5 w-5 text-pink-deep" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20z" />
+            <path d="M12 8v4m0 4h.01" />
+          </svg>
+        </div>
+
+        <h2 className="font-display italic text-2xl leading-snug text-ink">
+          a quick note on AI
+        </h2>
+
+        <p className="mt-3 text-sm leading-6 text-ink-soft">
+          checkd uses AI to generate <strong className="font-medium text-ink">vibe checks</strong> for your outfit photos. When you upload a photo, it's processed by our AI provider to generate a style label.
+        </p>
+
+        <p className="mt-3 text-sm leading-6 text-ink-soft">
+          Your photos and captions may be sent to a third-party AI service. We don't use them to train models. You can turn vibe checks off anytime in your profile settings.
+        </p>
+
+        <button
+          type="button"
+          onClick={accept}
+          className="mt-6 w-full rounded-full bg-ink py-3 text-sm font-medium text-paper transition hover:opacity-90"
+        >
+          got it
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/auth/auth-form.tsx
+++ b/apps/web/components/auth/auth-form.tsx
@@ -80,7 +80,7 @@ export function AuthForm({ mode, next }: AuthFormProps) {
             password: values.password
           })
         : await login({
-            email: values.email.trim().toLowerCase(),
+            email: values.identifier?.trim() ?? values.email.trim().toLowerCase(),
             password: values.password
           });
 
@@ -148,13 +148,13 @@ export function AuthForm({ mode, next }: AuthFormProps) {
           <>
             {/* Login: email or username → password */}
             <Field
-              label="email"
-              name="email"
-              type="email"
-              placeholder="ava@email.com"
-              value={values.email}
+              label="email or username"
+              name="identifier"
+              type="text"
+              placeholder="ava@email.com or @handle"
+              value={values.identifier ?? ""}
               error={errors.email}
-              onChange={(value) => setValue("email", value)}
+              onChange={(value) => setValue("identifier", value)}
             />
             <Field
               label="password"

--- a/apps/web/components/outfits/outfit-card.tsx
+++ b/apps/web/components/outfits/outfit-card.tsx
@@ -175,7 +175,7 @@ export function OutfitCard({
 
   if (compact) {
     return (
-      <Link href={href} className="group relative block overflow-hidden bg-pink-soft/30">
+      <Link href={href} className="group relative block bg-pink-soft/30" style={{ overflow: "hidden" }}>
         <div className="relative aspect-[3/4] w-full overflow-hidden">
           <Image
             src={outfit.imageUrl}
@@ -197,8 +197,8 @@ export function OutfitCard({
         {onLike ? (
           <button
             type="button"
-            onClick={onLike}
             aria-label={liked ? "Unlike" : "Like"}
+            onClick={(e) => { e.stopPropagation(); onLike(e); }}
             className="absolute bottom-1.5 right-1.5 flex h-7 w-7 items-center justify-center rounded-full bg-black/30 backdrop-blur transition hover:bg-black/50"
           >
             <svg

--- a/apps/web/components/upload/upload-flow.tsx
+++ b/apps/web/components/upload/upload-flow.tsx
@@ -6,6 +6,17 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { apiClient } from "@/lib/api-client";
 
+async function normalizeImageFile(file: File): Promise<File> {
+  const type = file.type.toLowerCase();
+  if (type === "image/heic" || type === "image/heif" || (type === "" && file.name.toLowerCase().endsWith(".heic"))) {
+    const heic2any = (await import("heic2any")).default;
+    const converted = await heic2any({ blob: file, toType: "image/jpeg", quality: 0.92 });
+    const blob = Array.isArray(converted) ? converted[0] : converted;
+    return new File([blob], file.name.replace(/\.heic$/i, ".jpg"), { type: "image/jpeg" });
+  }
+  return file;
+}
+
 type UploadItem = {
   id: string;
   brand: string;
@@ -60,11 +71,10 @@ export function UploadFlow() {
   const [metadata, setMetadata] = useState<UploadMetadata>({
     caption: "",
     eventName: "",
-    wornOn: ""
+    wornOn: new Date().toISOString().split("T")[0],
   });
   const [errors, setErrors] = useState<ValidationErrors>(createEmptyErrors);
   const [submitState, setSubmitState] = useState<SubmitState>({ status: "idle" });
-  const [saveToVault, setSaveToVault] = useState(true);
   const isSubmittingRef = useRef(false); // synchronous guard against double-tap
 
   useEffect(() => {
@@ -115,7 +125,8 @@ export function UploadFlow() {
     resetStatus();
     const nextFile = event.target.files?.[0] ?? null;
     if (!nextFile) return;
-    if (!nextFile.type.startsWith("image/")) {
+    const isImage = nextFile.type.startsWith("image/") || nextFile.name.toLowerCase().endsWith(".heic") || nextFile.name.toLowerCase().endsWith(".heif");
+    if (!isImage) {
       setErrorState({ photo: "Choose an image file.", form: "Only image files are supported." });
       event.target.value = "";
       return;
@@ -125,8 +136,14 @@ export function UploadFlow() {
       event.target.value = "";
       return;
     }
-    setPhoto(nextFile);
-    setErrors(createEmptyErrors());
+    // Normalize HEIC/HEIF (Live Photos) to JPEG before storing
+    normalizeImageFile(nextFile).then((normalized) => {
+      setPhoto(normalized);
+      setErrors(createEmptyErrors());
+    }).catch(() => {
+      setPhoto(nextFile); // fallback: use original, let the server handle it
+      setErrors(createEmptyErrors());
+    });
   }
 
   function updateItem(itemId: string, field: keyof Omit<UploadItem, "id">, value: string) {
@@ -214,7 +231,7 @@ export function UploadFlow() {
       if (metadata.eventName.trim()) payload.event_name = metadata.eventName.trim();
       if (metadata.wornOn) payload.worn_on = metadata.wornOn;
 
-      const result = await apiClient.outfits.create({ image: photo, metadata: { ...payload, save_to_vault: saveToVault } });
+      const result = await apiClient.outfits.create({ image: photo, metadata: { ...payload, save_to_vault: true } });
       if (!result.ok) throw new Error(result.message);
 
       setSubmitState({ status: "success", message: "Outfit uploaded!" });
@@ -478,44 +495,6 @@ export function UploadFlow() {
               <DateSelect value={metadata.wornOn} onChange={(v) => updateMetadata("wornOn", v)} />
             </div>
 
-            {/* Save to vault toggle */}
-            <button
-              type="button"
-              onClick={() => setSaveToVault((v) => !v)}
-              className="flex items-center justify-between border border-line bg-white transition hover:border-ink/30"
-              style={{ borderRadius: "1.5rem", padding: "14px 16px" }}
-            >
-              <div style={{ textAlign: "left" }}>
-                <p style={{ fontSize: 13, fontWeight: 500, color: "var(--ink)" }}>save to my vault</p>
-                <p style={{ fontSize: 11, color: "var(--mute)", marginTop: 2 }}>
-                  {saveToVault ? "visible only to you" : "won't appear in your vault"}
-                </p>
-              </div>
-              <div
-                style={{
-                  width: 42,
-                  height: 24,
-                  borderRadius: 99,
-                  background: saveToVault ? "var(--ink)" : "var(--line)",
-                  position: "relative",
-                  flexShrink: 0,
-                  transition: "background 0.2s",
-                }}
-              >
-                <div
-                  style={{
-                    position: "absolute",
-                    top: 3,
-                    left: saveToVault ? 21 : 3,
-                    width: 18,
-                    height: 18,
-                    borderRadius: "50%",
-                    background: "white",
-                    transition: "left 0.2s",
-                  }}
-                />
-              </div>
-            </button>
           </div>
         ) : null}
 
@@ -563,18 +542,6 @@ export function UploadFlow() {
                 ))}
               </div>
             </div>
-
-            {/* Vault toggle summary */}
-            {!saveToVault ? (
-              <div
-                className="border border-line bg-white"
-                style={{ borderRadius: "1.5rem", padding: "12px 16px" }}
-              >
-                <p style={{ fontSize: 12, color: "var(--mute)" }}>
-                  this outfit <span style={{ color: "var(--ink)", fontWeight: 500 }}>won't be saved</span> to your vault
-                </p>
-              </div>
-            ) : null}
 
             {/* Metadata summary */}
             {(metadata.caption || metadata.eventName || metadata.wornOn) ? (

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -522,12 +522,12 @@ export const authApiClient = {
   },
 
   async login(input: {
-    email: string;
+    email: string; // may be email or username — sent as "identifier" to the API
     password: string;
   }): Promise<ApiResult<AuthSessionResponse>> {
     const result = await sendRequest<AuthSessionResponse>("/auth/login", {
       method: "POST",
-      body: input,
+      body: { identifier: input.email, password: input.password },
       successMessage: "Welcome back. The form is now using the shared auth API."
     });
 

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -8,6 +8,7 @@ export type AuthMode = "login" | "signup";
 export type AuthValues = {
   username: string;
   email: string;
+  identifier: string; // login only: email or username
   password: string;
   confirmPassword: string;
 };
@@ -18,6 +19,7 @@ export function createInitialAuthValues(): AuthValues {
   return {
     username: "",
     email: "",
+    identifier: "",
     password: "",
     confirmPassword: ""
   };
@@ -30,10 +32,16 @@ export function validateAuthForm(mode: AuthMode, values: AuthValues): AuthErrors
     errors.username = "Choose a username with at least 3 characters.";
   }
 
-  if (!values.email.trim()) {
-    errors.email = "Email is required.";
-  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(values.email.trim())) {
-    errors.email = "Enter a valid email address.";
+  if (mode === "login") {
+    if (!values.identifier?.trim()) {
+      errors.email = "Email or username is required.";
+    }
+  } else {
+    if (!values.email.trim()) {
+      errors.email = "Email is required.";
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(values.email.trim())) {
+      errors.email = "Enter a valid email address.";
+    }
   }
 
   const passwordByteLength = new TextEncoder().encode(values.password).length;

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ootd-web",
       "version": "0.1.0",
       "dependencies": {
+        "heic2any": "^0.0.4",
         "next": "^15.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -1148,6 +1149,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/heic2any": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
+      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
+      "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "test:smoke": "playwright test tests/smoke.spec.ts"
   },
   "dependencies": {
+    "heic2any": "^0.0.4",
     "next": "^15.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/apps/web/tests/smoke.spec.ts
+++ b/apps/web/tests/smoke.spec.ts
@@ -157,6 +157,10 @@ async function setActiveSession(page: Page) {
       sameSite: "Lax"
     }
   ]);
+  // Pre-accept AI consent so the modal doesn't block test assertions
+  await page.addInitScript(() => {
+    localStorage.setItem("checkd_ai_consent_v1", "accepted");
+  });
 }
 
 // ── Public routes ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

### Backend
- **Login with username or email**: `POST /auth/login` now accepts an `identifier` field (email or @username) instead of email-only
- **Profanity filter**: signup rejects usernames containing disallowed words (`better-profanity` package)
- **Explore fix**: `GET /outfits/explore` now filters out `vault_hidden=true` outfits — board posts with "don't save to vault" no longer appear in discover
- **save_to_vault**: `OutfitMetadata` schema now includes `save_to_vault: bool = True`; when `false`, sets `vault_hidden=true` on the outfit row

### Frontend
- **Homepage copy**: "filter by vibe" removed from vault description; "start your vault for free" → "start today"
- **Board invite**: Share button uses Web Share API on mobile with message `"Join my board 'X' on checkd! [link]"`; falls back to clipboard copy
- **Login form**: field changed to "email or username" accepting either format
- **HEIC/Live Photos**: files converted to JPEG client-side via `heic2any` before upload in both main upload flow and board upload
- **Upload date**: defaults to today's date instead of blank
- **Vault toggle removed**: general upload always saves to vault; toggle only appears in board upload (where it was already present)
- **AI consent modal**: one-time modal shown to all authenticated users on first login (localStorage gated), explaining AI vibe check usage with option to disable in settings
- **Phone bug**: `stopPropagation` added to compact card like button; `overflow-hidden` moved from Tailwind class to inline style to avoid mobile Safari touch target clipping

## Not in this PR
- AI toggle in account settings (needs DB migration — tracking separately)
- Date picker calendar UI matching board picker (tracking separately)