### PR TITLE
fix: feedback round two

### DIFF
--- a/apps/web/app/boards/page.tsx
+++ b/apps/web/app/boards/page.tsx
@@ -239,16 +239,6 @@ export default function BoardsPage() {
               </p>
             </div>
             <div className="flex items-center" style={{ gap: 6 }}>
-              <Link
-                href="/search"
-                aria-label="Search"
-                className="flex items-center justify-center rounded-full border border-line bg-white text-mute"
-                style={{ width: 36, height: 36 }}
-              >
-                <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round">
-                  <circle cx="11" cy="11" r="7" /><path d="m21 21-4.35-4.35" />
-                </svg>
-              </Link>
               <button
                 type="button"
                 onClick={() => setShowCreate(true)}

--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -37,19 +37,21 @@ function toCardData(outfit: FeedOutfitResponse): OutfitCardData {
 }
 
 function useSentinel(onIntersect: () => void) {
-  const sentinelRef = useRef<HTMLDivElement | null>(null);
   const cb = useRef(onIntersect);
   cb.current = onIntersect;
+  const obsRef = useRef<IntersectionObserver | null>(null);
 
-  useEffect(() => {
-    const el = sentinelRef.current;
+  // Callback ref: fires whenever the sentinel mounts/unmounts, so the
+  // observer always attaches even when the element appears after data loads.
+  const sentinelRef = useCallback((el: HTMLDivElement | null) => {
+    if (obsRef.current) { obsRef.current.disconnect(); obsRef.current = null; }
     if (!el) return;
     const obs = new IntersectionObserver(
       ([e]) => { if (e.isIntersecting) cb.current(); },
       { rootMargin: "600px" }
     );
     obs.observe(el);
-    return () => obs.disconnect();
+    obsRef.current = obs;
   }, []);
 
   return sentinelRef;
@@ -308,27 +310,24 @@ export default function ExplorePage() {
         </header>
       </div>
 
-      {/* ── Outfit grid — edge-to-edge on mobile ────────────────────────── */}
-      <section>
+      {/* ── Outfit grid ─────────────────────────────────────────────────── */}
+      <section className="mx-auto max-w-3xl">
         {gridStatus === "loading" ? (
-          <div className="grid grid-cols-2 gap-0.5">
-            {Array.from({ length: 8 }).map((_, i) => (
+          <div className="grid grid-cols-3 gap-0.5">
+            {Array.from({ length: 9 }).map((_, i) => (
               <OutfitCardSkeleton key={i} compact />
             ))}
           </div>
         ) : null}
 
         {gridStatus === "ready" && outfits.length === 0 ? (
-          <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
+          <div className="px-4 sm:px-6 lg:px-8">
             <div className="soft-panel px-6 py-10 text-center">
               <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-mute">
                 Nothing yet
               </p>
               <h2 className="mt-3 text-2xl text-ink">follow some people to see outfits here</h2>
-              <Link
-                href="/search"
-                className="mt-5 btn-primary"
-              >
+              <Link href="/search" className="mt-5 btn-primary">
                 Find people to follow
               </Link>
             </div>
@@ -337,7 +336,7 @@ export default function ExplorePage() {
 
         {gridStatus === "ready" && outfits.length > 0 ? (
           <>
-            <div className="grid grid-cols-2 gap-0.5">
+            <div className="grid grid-cols-3 gap-0.5">
               {outfits.map((outfit) => (
                 <OutfitCard
                   key={outfit.id}
@@ -346,17 +345,17 @@ export default function ExplorePage() {
                 />
               ))}
               {loadingMore
-                ? Array.from({ length: 4 }).map((_, i) => (
+                ? Array.from({ length: 3 }).map((_, i) => (
                     <OutfitCardSkeleton key={`skel-${i}`} compact />
                   ))
                 : null}
             </div>
-            {nextCursor ? <div ref={sentinelRef} className="h-px" /> : null}
+            {nextCursor ? <div ref={sentinelRef} className="h-4" /> : null}
           </>
         ) : null}
 
         {gridStatus === "error" ? (
-          <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
+          <div className="px-4 sm:px-6 lg:px-8">
             <div className="soft-panel px-6 py-8 text-center">
               <p className="text-sm text-mute">Couldn&rsquo;t load outfits. Try refreshing.</p>
               <button


### PR DESCRIPTION
## Summary
- Homepage copy: accurate vault description, "start today" CTA
- Board invite: native share sheet with "Join my board!" text
- HEIC/Live Photos: client-side conversion to JPEG before upload
- AI consent: one-time modal on first login
- Profanity filter on usernames at signup
- Login with username or email
- Save-to-vault toggle removed from general upload, kept in board upload
- Date worn defaults to today in upload flow
- Board posts with "don't save to vault" no longer appear in discover
- Phone image tap bug: stopPropagation + overflow fix
- Discover: 3-column grid, edge-to-edge layout, infinite scroll fixed (callback ref sentinel)
- Boards: removed search icon that incorrectly linked to people search

## Test plan
- [ ] Upload a Live Photo / HEIC — should convert and upload without error
- [ ] Log in with username instead of email
- [ ] Post to a board with "don't save to vault" — should not appear in discover
- [ ] Scroll to bottom of discover — should keep loading more outfits
- [ ] Tap board invite — should open native share sheet on mobile
- [ ] Boards page header has no search icon