### PR TITLE
feat: vibe check toggle in settings, calendar date picker in upload

### DIFF
--- a/apps/web/app/profile/edit/page.tsx
+++ b/apps/web/app/profile/edit/page.tsx
@@ -124,6 +124,7 @@ export default function EditProfilePage() {
   const [username, setUsername] = useState("");
   const [bio, setBio] = useState("");
   const [instagramHandle, setInstagramHandle] = useState("");
+  const [vibeCheckEnabled, setVibeCheckEnabled] = useState(true);
   const [avatarSrc, setAvatarSrc] = useState<string | null>(null);
 
   const [avatarUploading, setAvatarUploading] = useState(false);
@@ -151,6 +152,7 @@ export default function EditProfilePage() {
     setBio(user.bio ?? "");
     setAvatarSrc(user.profile_image_url ?? null);
     setInstagramHandle((user as { instagram_handle?: string | null }).instagram_handle ?? "");
+    setVibeCheckEnabled(user.vibe_check_enabled ?? true);
   }, [user]);
 
   const checkUsername = useCallback(
@@ -219,6 +221,7 @@ export default function EditProfilePage() {
       username: username.trim() || null,
       bio: bio.trim() || null,
       instagram_handle: instagramHandle.trim().replace(/^@/, "") || null,
+      vibe_check_enabled: vibeCheckEnabled,
     });
 
     if (result.ok) {
@@ -401,6 +404,33 @@ export default function EditProfilePage() {
                 <p className="mt-1.5 text-xs text-error">{fieldErrors.bio}</p>
               ) : null}
             </div>
+          </section>
+
+          {/* ── AI settings ───────────────────────────────────────────────── */}
+          <section className="soft-panel mb-4 px-6 py-5">
+            <p className="mb-3 text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-mute">AI features</p>
+            <button
+              type="button"
+              onClick={() => setVibeCheckEnabled((v) => !v)}
+              disabled={isSaving}
+              className="flex w-full items-center justify-between gap-4 disabled:opacity-50"
+            >
+              <div className="text-left">
+                <p className="text-sm font-medium text-ink">Vibe check</p>
+                <p className="mt-0.5 text-xs text-mute">AI-generated style label on each outfit photo</p>
+              </div>
+              <div
+                className={`relative h-6 w-10 flex-shrink-0 rounded-full border transition-colors duration-200 ${
+                  vibeCheckEnabled ? "border-ink bg-ink" : "border-line bg-line"
+                }`}
+              >
+                <span
+                  className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200 ${
+                    vibeCheckEnabled ? "translate-x-4" : "translate-x-0"
+                  }`}
+                />
+              </div>
+            </button>
           </section>
 
           {/* ── Error banner ──────────────────────────────────────────────── */}

--- a/apps/web/components/boards/event-date-picker.tsx
+++ b/apps/web/components/boards/event-date-picker.tsx
@@ -83,7 +83,7 @@ export function EventDatePicker({ value, onChange }: EventDatePickerProps) {
         style={{ height: "auto", minHeight: 48, paddingTop: 12, paddingBottom: 12 }}
       >
         <span className={`text-sm leading-snug ${triggerLabel ? "text-ink" : "text-mute"}`}>
-          {triggerLabel ?? "Select date & time (optional)"}
+          {triggerLabel ?? "Select a date (optional)"}
         </span>
         <svg
           viewBox="0 0 24 24"

--- a/apps/web/components/upload/upload-flow.tsx
+++ b/apps/web/components/upload/upload-flow.tsx
@@ -5,6 +5,7 @@ import { useEffect, useId, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { apiClient } from "@/lib/api-client";
+import { EventDatePicker } from "@/components/boards/event-date-picker";
 
 async function normalizeImageFile(file: File): Promise<File> {
   const type = file.type.toLowerCase();
@@ -492,7 +493,7 @@ export function UploadFlow() {
 
             <div>
               <p className="field-label">date worn <span className="ml-1 font-normal normal-case tracking-normal text-mute">(optional)</span></p>
-              <DateSelect value={metadata.wornOn} onChange={(v) => updateMetadata("wornOn", v)} />
+              <EventDatePicker value={metadata.wornOn} onChange={(v) => updateMetadata("wornOn", v)} />
             </div>
 
           </div>
@@ -603,90 +604,6 @@ export function UploadFlow() {
           </button>
         )}
       </div>
-    </div>
-  );
-}
-
-// ── Date select — three dropdowns instead of native calendar ─────────────────
-
-const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-const CURRENT_YEAR = new Date().getFullYear();
-const YEARS = Array.from({ length: CURRENT_YEAR - 2019 }, (_, i) => CURRENT_YEAR - i);
-
-function daysInMonth(year: string, month: string): number {
-  const y = parseInt(year, 10);
-  const m = parseInt(month, 10);
-  if (!y || !m) return 31; // no context yet — show max
-  return new Date(y, m, 0).getDate(); // day 0 of next month = last day of this month
-}
-
-function DateSelect({ value, onChange }: { value: string; onChange: (v: string) => void }) {
-  // Use local state so partial picks aren't wiped on re-render.
-  // Parent only receives a value when all three parts are filled.
-  const initial = value ? value.split("-") : ["", "", ""];
-  const [y, setY] = useState(initial[0] ?? "");
-  const [m, setM] = useState(initial[1] ?? "");
-  const [d, setD] = useState(initial[2] ?? "");
-
-  // Clamp day if the selected day exceeds the month's actual length
-  const maxDays = daysInMonth(y, m);
-  const clampedD = d && parseInt(d, 10) > maxDays ? "" : d;
-
-  function commit(nextY: string, nextM: string, nextD: string) {
-    const max = daysInMonth(nextY, nextM);
-    const safeD = nextD && parseInt(nextD, 10) > max ? "" : nextD;
-    if (nextY && nextM && safeD) {
-      onChange(`${nextY}-${nextM.padStart(2, "0")}-${safeD.padStart(2, "0")}`);
-    } else if (!nextY && !nextM && !nextD) {
-      onChange("");
-    }
-  }
-
-  function handleMonthChange(nextM: string) {
-    setM(nextM);
-    // If current day is invalid for new month, reset it
-    const max = daysInMonth(y, nextM);
-    const nextD = d && parseInt(d, 10) > max ? "" : d;
-    if (nextD !== d) setD(nextD);
-    commit(y, nextM, nextD);
-  }
-
-  const selectClass = "flex-1 h-12 rounded-md border border-line bg-white px-3 text-sm text-ink outline-none transition focus:border-pink-deep focus:ring-2 focus:ring-pink/40 appearance-none";
-
-  return (
-    <div className="flex gap-2">
-      <select
-        value={m}
-        onChange={(e) => handleMonthChange(e.target.value)}
-        className={selectClass}
-        style={{ flex: "2" }}
-      >
-        <option value="">month</option>
-        {MONTHS.map((label, i) => (
-          <option key={label} value={String(i + 1).padStart(2, "0")}>{label}</option>
-        ))}
-      </select>
-      <select
-        value={clampedD}
-        onChange={(e) => { setD(e.target.value); commit(y, m, e.target.value); }}
-        className={selectClass}
-      >
-        <option value="">day</option>
-        {Array.from({ length: maxDays }, (_, i) => i + 1).map((n) => (
-          <option key={n} value={String(n)}>{n}</option>
-        ))}
-      </select>
-      <select
-        value={y}
-        onChange={(e) => { setY(e.target.value); commit(e.target.value, m, clampedD); }}
-        className={selectClass}
-        style={{ flex: "1.5" }}
-      >
-        <option value="">year</option>
-        {YEARS.map((yr) => (
-          <option key={yr} value={String(yr)}>{yr}</option>
-        ))}
-      </select>
     </div>
   );
 }

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -25,6 +25,7 @@ export type AuthUser = {
   profile_image_url?: string | null;
   current_streak?: number | null;
   longest_streak?: number | null;
+  vibe_check_enabled?: boolean;
   is_admin?: boolean;
 };
 
@@ -753,6 +754,7 @@ export const userApiClient = {
     bio?: string | null;
     username?: string | null;
     instagram_handle?: string | null;
+    vibe_check_enabled?: boolean;
   }): Promise<ApiResult<AuthUser>> {
     return sendRequest<AuthUser>("/users/me", {
       method: "PATCH",

--- a/services/api/alembic/versions/20260514_i3j4k5l6_add_vibe_check_enabled_to_users.py
+++ b/services/api/alembic/versions/20260514_i3j4k5l6_add_vibe_check_enabled_to_users.py
@@ -1,0 +1,30 @@
+"""add vibe_check_enabled to users
+
+Revision ID: i3j4k5l6m7n8
+Revises: g1h2i3j4
+Create Date: 2026-05-14
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "i3j4k5l6m7n8"
+down_revision = "g1h2i3j4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "vibe_check_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "vibe_check_enabled")

--- a/services/api/app/crud/user.py
+++ b/services/api/app/crud/user.py
@@ -46,6 +46,7 @@ def update_profile(
     bio: object = _UNSET,
     username: object = _UNSET,
     instagram_handle: object = _UNSET,
+    vibe_check_enabled: object = _UNSET,
 ) -> User:
     """
     Partial update — only fields explicitly passed are written.
@@ -59,6 +60,8 @@ def update_profile(
         user.username = username  # type: ignore[assignment]
     if instagram_handle is not _UNSET:
         user.instagram_handle = instagram_handle  # type: ignore[assignment]
+    if vibe_check_enabled is not _UNSET:
+        user.vibe_check_enabled = vibe_check_enabled  # type: ignore[assignment]
     db.commit()
     db.refresh(user)
     return user

--- a/services/api/app/models/user.py
+++ b/services/api/app/models/user.py
@@ -24,6 +24,7 @@ class User(Base):
     current_streak: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
     longest_streak: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
     last_outfit_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    vibe_check_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
     is_admin: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=text("now()")

--- a/services/api/app/routers/outfits.py
+++ b/services/api/app/routers/outfits.py
@@ -84,12 +84,15 @@ def create_outfit(
     except StorageError as exc:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc))
 
-    # Vibe check is best-effort — never blocks outfit creation if it fails.
-    vibe_check_text, vibe_check_tone = run_vibe_check(
-        file_bytes=file_bytes,
-        content_type=content_type,
-        caption=meta.caption,
-    )
+    # Vibe check is best-effort — skipped if user disabled it, never blocks outfit creation.
+    if getattr(current_user, "vibe_check_enabled", True):
+        vibe_check_text, vibe_check_tone = run_vibe_check(
+            file_bytes=file_bytes,
+            content_type=content_type,
+            caption=meta.caption,
+        )
+    else:
+        vibe_check_text, vibe_check_tone = None, None
 
     outfit = outfit_crud.create_outfit(
         db,

--- a/services/api/app/routers/users.py
+++ b/services/api/app/routers/users.py
@@ -46,6 +46,7 @@ def update_profile(
         bio=body.bio if body.bio is not None else _UNSET,
         username=body.username if body.username is not None else _UNSET,
         instagram_handle=body.instagram_handle if body.instagram_handle is not None else _UNSET,
+        vibe_check_enabled=body.vibe_check_enabled if body.vibe_check_enabled is not None else _UNSET,
     )
     return PublicProfile(
         id=user.id,

--- a/services/api/app/schemas/auth.py
+++ b/services/api/app/schemas/auth.py
@@ -41,6 +41,7 @@ class UserResponse(BaseModel):
     profile_image_url: str | None
     current_streak: int = 0
     longest_streak: int = 0
+    vibe_check_enabled: bool = True
     is_admin: bool = False
 
     model_config = {"from_attributes": True}

--- a/services/api/app/schemas/user.py
+++ b/services/api/app/schemas/user.py
@@ -30,6 +30,7 @@ class UpdateProfileRequest(BaseModel):
     bio: str | None = Field(default=None, max_length=160)
     username: str | None = Field(default=None, min_length=2, max_length=30)
     instagram_handle: str | None = Field(default=None, max_length=30)
+    vibe_check_enabled: bool | None = None
 
     @field_validator("username")
     @classmethod


### PR DESCRIPTION
## Summary
- Upload flow date picker swapped from three dropdowns to the same calendar grid used on boards (defaults to today, same UI)
- Edit profile page has a new "AI features" section with a vibe check on/off toggle
- Backend: `vibe_check_enabled` column added to users (migration included), skips Claude API call when disabled
- Boards page: removed search icon that incorrectly navigated to people search
- Discover: 3-column grid, infinite scroll sentinel fixed (callback ref so observer attaches after data loads)

## Test plan
- [ ] Upload flow step 3 — date worn shows calendar picker, today pre-selected
- [ ] Edit profile → AI features → toggle vibe check off → upload outfit → no vibe label appears
- [ ] Scroll to bottom of discover — loads more outfits continuously
- [ ] Boards page header has no search icon