### PR TITLE
fix: mobile top nav, touch-action zoom fix, remove profile star

### DIFF
--- a/apps/web/app/boards/[id]/page.tsx
+++ b/apps/web/app/boards/[id]/page.tsx
@@ -350,7 +350,7 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
 
   if (authLoading) {
     return (
-      <main className="px-4 pb-28 pt-6 sm:px-6">
+      <main className="px-4 pb-28 pt-14 sm:px-6">
         <div className="mx-auto max-w-3xl space-y-4">
           <div className="h-8 w-40 animate-pulse rounded-full bg-pink-soft" />
           <div className="soft-panel h-48 w-full animate-pulse" />
@@ -369,7 +369,7 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
   // ── Error states ──
   if (status === "gone") {
     return (
-      <main className="px-4 pb-28 pt-6 sm:px-6">
+      <main className="px-4 pb-28 pt-14 sm:px-6">
         <div className="mx-auto flex min-h-[60vh] max-w-2xl items-center justify-center">
           <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
             <p className="font-display italic text-5xl text-pink-deep">checkd</p>
@@ -387,7 +387,7 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
 
   if (status === "not-found" || status === "error") {
     return (
-      <main className="px-4 pb-28 pt-6 sm:px-6">
+      <main className="px-4 pb-28 pt-14 sm:px-6">
         <div className="mx-auto flex min-h-[60vh] max-w-2xl items-center justify-center">
           <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
             <p className="font-display italic text-5xl text-pink-deep">checkd</p>
@@ -408,7 +408,7 @@ export default function BoardDetailPage({ params }: { params: Promise<{ id: stri
   const expiryLabel = board ? formatExpiry(board.expires_at) : "";
 
   return (
-    <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8 lg:pb-0 lg:pt-20">
+    <main className="px-4 pb-28 pt-14 sm:px-6 lg:px-8 lg:pb-0 lg:pt-20">
       <div className="mx-auto max-w-3xl">
 
         {/* Top bar */}

--- a/apps/web/app/boards/page.tsx
+++ b/apps/web/app/boards/page.tsx
@@ -219,7 +219,7 @@ export default function BoardsPage() {
 
   return (
     <>
-      <main className="pb-28 lg:pb-0 lg:pt-16">
+      <main className="pb-28 pt-14 lg:pb-0 lg:pt-16">
         <div className="mx-auto max-w-3xl">
 
           {/* Topbar */}

--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -280,7 +280,7 @@ export default function ExplorePage() {
   }
 
   return (
-    <main className="pb-28 pt-6 lg:pb-0 lg:pt-20">
+    <main className="pb-28 pt-14 lg:pb-0 lg:pt-20">
       {/* Header and people rail stay padded */}
       <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
         <header className="mb-5">

--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -448,7 +448,7 @@ export default function FeedPage() {
   }
 
   return (
-    <main className="pb-28 lg:pb-0 lg:pt-16">
+    <main className="pb-28 pt-14 lg:pb-0 lg:pt-16">
       <div className="mx-auto max-w-3xl">
 
         {/* ── Topbar ─────────────────────────────────────────────────── */}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -54,6 +54,17 @@ a {
   outline-offset: 2px;
 }
 
+/* Prevent double-tap zoom on interactive elements (eliminates 300ms tap delay on iOS) */
+a,
+button,
+[role="button"],
+input,
+select,
+textarea,
+label {
+  touch-action: manipulation;
+}
+
 /* Instant press feedback on interactive elements */
 button:active:not(:disabled),
 [role="button"]:active:not(:disabled) {

--- a/apps/web/app/profile/[username]/page.tsx
+++ b/apps/web/app/profile/[username]/page.tsx
@@ -170,7 +170,7 @@ export default function PublicProfilePage({
   // ── Not found ──
   if (status === "not-found") {
     return (
-      <main className="px-4 pb-28 pt-6 sm:px-6">
+      <main className="px-4 pb-28 pt-14 sm:px-6">
         <div className="mx-auto flex min-h-[60vh] max-w-2xl items-center justify-center">
           <div className="soft-panel w-full max-w-sm px-6 py-10 text-center">
             <p className="font-display italic text-5xl text-pink-deep">checkd</p>
@@ -196,7 +196,7 @@ export default function PublicProfilePage({
   const avatarSrc = profile?.profile_image_url;
 
   return (
-    <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8 lg:pb-0 lg:pt-20">
+    <main className="px-4 pb-28 pt-14 sm:px-6 lg:px-8 lg:pb-0 lg:pt-20">
       <div className="mx-auto max-w-3xl">
 
         {/* ── Top bar ────────────────────────────────────────────────────── */}

--- a/apps/web/app/profile/edit/page.tsx
+++ b/apps/web/app/profile/edit/page.tsx
@@ -255,7 +255,7 @@ export default function EditProfilePage() {
   const isSaving = saveStatus === "saving";
 
   return (
-    <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8 lg:pb-0 lg:pt-20">
+    <main className="px-4 pb-28 pt-14 sm:px-6 lg:px-8 lg:pb-0 lg:pt-20">
       <div className="mx-auto max-w-lg">
 
         {/* ── Top bar ─────────────────────────────────────────────────────── */}

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -154,7 +154,7 @@ export default function ProfilePage() {
   }
 
   return (
-    <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8 lg:pb-0 lg:pt-20">
+    <main className="px-4 pb-28 pt-14 sm:px-6 lg:px-8 lg:pb-0 lg:pt-20">
       <div className="mx-auto max-w-3xl">
 
         {/* ── Top bar — @username + ⋯ per design ─────────────────────────── */}
@@ -354,7 +354,6 @@ export default function ProfilePage() {
                       outfit={toCardData(outfit)}
                       showAuthor={false}
                       showCaption={false}
-                      showAccentMarker
                     />
                   ))}
                 </div>

--- a/apps/web/app/search/page.tsx
+++ b/apps/web/app/search/page.tsx
@@ -206,7 +206,7 @@ export default function SearchPage() {
   const displayList = isSearching ? searchResults : suggested;
 
   return (
-    <main className="px-4 pb-28 pt-6 sm:px-6 lg:pb-0 lg:pt-20">
+    <main className="px-4 pb-28 pt-14 sm:px-6 lg:pb-0 lg:pt-20">
       <div className="mx-auto max-w-lg">
 
         {/* ── Header ─────────────────────────────────────────────────────── */}

--- a/apps/web/app/vault/page.tsx
+++ b/apps/web/app/vault/page.tsx
@@ -211,7 +211,7 @@ export default function VaultPage() {
   const displayName = user?.display_name ?? user?.username ?? "you";
 
   return (
-    <main className="pb-28 lg:pb-0 lg:pt-16">
+    <main className="pb-28 pt-14 lg:pb-0 lg:pt-16">
       <div className="mx-auto max-w-3xl">
         {/* vault header */}
         <header className="flex items-end justify-between bg-paper" style={{ padding: "16px 20px 10px" }}>

--- a/apps/web/components/chrome/desktop-nav.tsx
+++ b/apps/web/components/chrome/desktop-nav.tsx
@@ -20,17 +20,17 @@ export function DesktopNav() {
   if (AUTH_PATHS.some((p) => pathname.startsWith(p)) || pathname === "/") return null;
 
   return (
-    <nav className="fixed inset-x-0 top-0 z-50 hidden h-16 items-center border-b border-pink/30 bg-pink px-8 lg:flex">
-      {/* Left: wordmark + links */}
+    <nav className="fixed inset-x-0 top-0 z-50 flex h-14 items-center border-b border-pink/30 bg-pink px-5 lg:h-16 lg:px-8">
+      {/* Left: wordmark + links (links hidden on mobile) */}
       <div className="flex items-center gap-8">
         <Link
           href="/"
           className="font-display italic leading-none text-white"
-          style={{ fontSize: "2rem", letterSpacing: "-0.01em" }}
+          style={{ fontSize: "1.75rem", letterSpacing: "-0.01em" }}
         >
           checkd
         </Link>
-        <div className="flex items-center gap-6">
+        <div className="hidden items-center gap-6 lg:flex">
           {NAV_LINKS.map(({ href, label }) => (
             <Link
               key={href}
@@ -45,11 +45,11 @@ export function DesktopNav() {
         </div>
       </div>
 
-      {/* Right: search + post CTA + avatar */}
+      {/* Right: search + post CTA + avatar (search + post hidden on mobile) */}
       <div className="ml-auto flex items-center gap-3">
         <Link
           href="/search"
-          className="flex h-9 items-center gap-2 rounded-full bg-white px-4 text-sm text-mute transition hover:text-ink-soft"
+          className="hidden h-9 items-center gap-2 rounded-full bg-white px-4 text-sm text-mute transition hover:text-ink-soft lg:flex"
           style={{ width: 260 }}
         >
           <svg
@@ -68,7 +68,7 @@ export function DesktopNav() {
 
         <Link
           href="/upload"
-          className="inline-flex h-9 items-center justify-center rounded-full bg-ink px-5 text-[0.8rem] font-medium lowercase text-paper transition hover:opacity-90"
+          className="hidden h-9 items-center justify-center rounded-full bg-ink px-5 text-[0.8rem] font-medium lowercase text-paper transition hover:opacity-90 lg:inline-flex"
         >
           post a fit
         </Link>
@@ -79,10 +79,10 @@ export function DesktopNav() {
               <img
                 src={user.profile_image_url}
                 alt="my profile"
-                className="h-9 w-9 rounded-full border border-line object-cover"
+                className="h-8 w-8 rounded-full border border-white/30 object-cover lg:h-9 lg:w-9"
               />
             ) : (
-              <div className="flex h-9 w-9 items-center justify-center rounded-full border border-line bg-pink-soft text-sm font-medium text-ink-soft">
+              <div className="flex h-8 w-8 items-center justify-center rounded-full border border-white/30 bg-pink-soft text-sm font-medium text-ink-soft lg:h-9 lg:w-9">
                 {(user?.display_name ?? user?.username ?? "?").charAt(0).toUpperCase()}
               </div>
             )}

--- a/apps/web/components/outfits/outfit-detail-view.tsx
+++ b/apps/web/components/outfits/outfit-detail-view.tsx
@@ -358,7 +358,7 @@ export function OutfitDetailView({ id }: { id: string }) {
 
   return (
     <>
-      <main className="px-4 pb-28 pt-6 sm:px-6 lg:px-8">
+      <main className="px-4 pb-28 pt-14 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-4xl">
 
           {/* Top bar — prominent back button */}


### PR DESCRIPTION
## Summary
- Show the pink top nav bar on mobile (was desktop-only); collapses nav links/search/post to keep it clean on small screens
- Add `touch-action: manipulation` globally to eliminate the iOS double-tap zoom / 300ms tap delay
- Add `pt-14` to all authenticated pages so content clears the fixed mobile nav
- Remove `showAccentMarker` from the profile fits tab — the star icon looked like a broken favorite button

## Test plan
- [ ] On mobile, confirm pink checkd nav bar is visible at top of every page
- [ ] On mobile, confirm double-tap on buttons/links no longer zooms the page
- [ ] Confirm no content is hidden behind the nav bar on any authenticated page
- [ ] Profile fits tab no longer shows star/accent icon on outfit cards