### PR TITLE
feat: monthly checks — animated wrapped-style monthly stats (#61)

### DIFF
--- a/apps/web/app/monthly-checks/page.tsx
+++ b/apps/web/app/monthly-checks/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from "react";
+import { MonthlyChecksClient } from "@/components/monthly-checks/monthly-checks-client";
+
+function LoadingState() {
+  return (
+    <main className="flex h-screen items-center justify-center" style={{ background: "var(--ink)" }}>
+      <p className="font-display italic text-5xl" style={{ color: "var(--pink)" }}>checkd</p>
+    </main>
+  );
+}
+
+export default function MonthlyChecksPage() {
+  return (
+    <Suspense fallback={<LoadingState />}>
+      <MonthlyChecksClient />
+    </Suspense>
+  );
+}

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -9,8 +9,23 @@ import { OutfitCard, OutfitCardSkeleton, type OutfitCardData } from "@/component
 import { useAuth } from "@/lib/auth-context";
 
 type PageStatus = "idle" | "loading" | "ready" | "error";
-type ProfileTab = "fits" | "about";
+type ProfileTab = "fits" | "checks" | "about";
 type FollowSheet = "followers" | "following" | null;
+
+function recentMonths(count: number): string[] {
+  const months: string[] = [];
+  const now = new Date();
+  for (let i = 1; i <= count; i++) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    months.push(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`);
+  }
+  return months;
+}
+
+function formatMonthShort(yyyyMM: string): string {
+  const [y, m] = yyyyMM.split("-").map(Number);
+  return new Date(y, m - 1, 1).toLocaleDateString("en-US", { month: "long", year: "numeric" });
+}
 
 function toCardData(outfit: OutfitResponse): OutfitCardData {
   return {
@@ -299,7 +314,7 @@ export default function ProfilePage() {
 
         {/* ── Profile tabs ─────────────────────────────────────────────── */}
         <div className="flex border-b border-line">
-          {(["fits", "about"] as ProfileTab[]).map((tab) => {
+          {(["fits", "checks", "about"] as ProfileTab[]).map((tab) => {
             const isActive = activeTab === tab;
             return (
               <button
@@ -373,6 +388,30 @@ export default function ProfilePage() {
               </>
             ) : null}
           </section>
+        ) : null}
+
+        {/* ── Tab: checks ─────────────────────────────────────────────────── */}
+        {activeTab === "checks" ? (
+          <div className="px-5 py-6">
+            <p className="mb-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-mute">monthly checks</p>
+            <p className="mb-5 text-xs text-mute">your style, month by month</p>
+            <div className="space-y-2.5">
+              {recentMonths(12).map((m) => (
+                <Link
+                  key={m}
+                  href={`/monthly-checks?month=${m}`}
+                  className="flex items-center justify-between rounded-2xl border border-line bg-white px-5 py-4 transition hover:border-pink-deep"
+                >
+                  <div>
+                    <p className="text-sm font-medium text-ink">{formatMonthShort(m)}</p>
+                  </div>
+                  <svg viewBox="0 0 24 24" className="h-4 w-4 text-mute/50" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                    <path d="m9 18 6-6-6-6" />
+                  </svg>
+                </Link>
+              ))}
+            </div>
+          </div>
         ) : null}
 
         {/* ── Tab: about ──────────────────────────────────────────────────── */}

--- a/apps/web/components/monthly-checks/checks-deck.tsx
+++ b/apps/web/components/monthly-checks/checks-deck.tsx
@@ -1,0 +1,431 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { WrappedStats } from "@/lib/api-client";
+import { ChecksShareSheet } from "./checks-share-sheet";
+
+// slides 0,2,4,6,8 have light bg; 1,3,5,7 have dark bg
+const LIGHT_SLIDES = new Set([0, 2, 4, 6, 8]);
+
+const VIBE_BG: Record<string, string> = {
+  athletic: "#1a3a2a",
+  boho: "#3d2e1a",
+  casual: "#1a2a3d",
+  chic: "#2a1a2e",
+  classic: "#1a2030",
+  edgy: "#111111",
+  feminine: "#3d1a2a",
+  minimalist: "#242424",
+  preppy: "#1a2e1a",
+  streetwear: "#1a1a2e",
+  vintage: "#2e2010",
+};
+
+const VIBE_ACCENT: Record<string, string> = {
+  athletic: "#5ccb8c",
+  boho: "#e0a44a",
+  casual: "#6aabf7",
+  chic: "#c97ad4",
+  classic: "#80a8e0",
+  edgy: "#e05555",
+  feminine: "#f797b8",
+  minimalist: "#aaaaaa",
+  preppy: "#55bb66",
+  streetwear: "#7788ff",
+  vintage: "#d4a852",
+};
+
+function monthName(yyyyMM: string): string {
+  const [y, m] = yyyyMM.split("-").map(Number);
+  return new Date(y, m - 1, 1).toLocaleDateString("en-US", { month: "long", year: "numeric" });
+}
+
+type ChecksDeckProps = {
+  stats: WrappedStats;
+  month: string;
+  username: string;
+  onSlideChange: (isLight: boolean) => void;
+};
+
+export function ChecksDeck({ stats, month, username, onSlideChange }: ChecksDeckProps) {
+  const TOTAL = 9;
+  const [slide, setSlide] = useState(0);
+  const [showShare, setShowShare] = useState(false);
+  const touchStartX = useRef<number | null>(null);
+
+  const isLight = LIGHT_SLIDES.has(slide);
+
+  const goTo = useCallback(
+    (index: number) => {
+      const next = Math.max(0, Math.min(TOTAL - 1, index));
+      setSlide(next);
+      onSlideChange(LIGHT_SLIDES.has(next));
+    },
+    [onSlideChange]
+  );
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "ArrowRight") goTo(slide + 1);
+      if (e.key === "ArrowLeft") goTo(slide - 1);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [slide, goTo]);
+
+  function onTouchStart(e: React.TouchEvent) {
+    touchStartX.current = e.touches[0].clientX;
+  }
+
+  function onTouchEnd(e: React.TouchEvent) {
+    if (touchStartX.current === null) return;
+    const delta = e.changedTouches[0].clientX - touchStartX.current;
+    if (Math.abs(delta) > 48) goTo(slide + (delta < 0 ? 1 : -1));
+    touchStartX.current = null;
+  }
+
+  const vibe = stats.most_worn_vibe ?? "casual";
+  const vibeBg = VIBE_BG[vibe] ?? "#1a1416";
+  const vibeAccent = VIBE_ACCENT[vibe] ?? "#F8C8DC";
+
+  const maxWeek = Math.max(...stats.outfits_by_week.map((w) => w.count), 1);
+  const avgPerWeek =
+    stats.outfits_by_week.length > 0
+      ? Math.round((stats.total_outfits / stats.outfits_by_week.length) * 10) / 10
+      : 0;
+
+  // dot + arrow colors based on current slide
+  const dotActive = isLight ? "#1a1416" : "rgba(255,255,255,0.9)";
+  const dotInactive = isLight ? "rgba(26,20,22,0.15)" : "rgba(255,255,255,0.18)";
+  const arrowCls = isLight
+    ? "bg-ink/[0.07] border border-line text-ink hover:bg-ink/[0.13]"
+    : "bg-white/10 border border-white/20 text-white hover:bg-white/20";
+
+  const cards = [
+    // 0 — Intro
+    <div
+      key="intro"
+      className="flex h-full flex-col items-center justify-center px-8 text-center"
+      style={{ background: "linear-gradient(160deg, #FDEDF3 0%, #F8C8DC 100%)" }}
+    >
+      <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-ink-soft">monthly checks</p>
+      <h1
+        className="mt-4 font-display italic text-ink"
+        style={{ fontSize: "clamp(48px, 13vw, 76px)", lineHeight: 1.05, letterSpacing: "-0.02em" }}
+      >
+        {monthName(month)}
+      </h1>
+      <p className="mt-3 text-sm text-mute">@{username}</p>
+      <p className="mt-14 flex items-center gap-1.5 text-xs text-mute">
+        swipe to see your month
+        <svg viewBox="0 0 24 24" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+          <path d="m9 18 6-6-6-6" />
+        </svg>
+      </p>
+    </div>,
+
+    // 1 — Total outfits
+    <div
+      key="outfits"
+      className="flex h-full flex-col items-center justify-center px-8 text-center"
+      style={{ background: "#1a1416" }}
+    >
+      <p className="text-[10px] font-medium uppercase tracking-[0.24em]" style={{ color: "rgba(255,255,255,0.35)" }}>
+        you posted
+      </p>
+      <p
+        className="mt-2 font-display italic leading-none"
+        style={{ fontSize: "clamp(100px, 30vw, 168px)", color: "#fff" }}
+      >
+        {stats.total_outfits}
+      </p>
+      <p
+        className="font-display italic"
+        style={{ fontSize: "clamp(28px, 8vw, 44px)", color: "var(--pink)", lineHeight: 1 }}
+      >
+        outfits
+      </p>
+      {avgPerWeek > 0 && (
+        <p className="mt-5 text-sm" style={{ color: "rgba(255,255,255,0.3)" }}>
+          ~{avgPerWeek} a week
+        </p>
+      )}
+    </div>,
+
+    // 2 — Streak
+    <div
+      key="streak"
+      className="flex h-full flex-col items-center justify-center px-8 text-center"
+      style={{ background: "var(--paper)" }}
+    >
+      <p className="text-[10px] font-medium uppercase tracking-[0.24em] text-mute">longest streak</p>
+      <p
+        className="mt-2 font-display italic leading-none text-ink"
+        style={{ fontSize: "clamp(100px, 30vw, 168px)" }}
+      >
+        {stats.longest_streak}
+      </p>
+      <p
+        className="font-display italic text-ink-soft"
+        style={{ fontSize: "clamp(24px, 7vw, 36px)", lineHeight: 1 }}
+      >
+        {stats.longest_streak === 1 ? "day" : "days"} in a row
+      </p>
+      {stats.longest_streak >= 7 && (
+        <p className="mt-5 text-sm text-mute">you were on a roll</p>
+      )}
+    </div>,
+
+    // 3 — Vibe
+    <div
+      key="vibe"
+      className="flex h-full flex-col items-center justify-center px-8 text-center"
+      style={{ background: vibeBg }}
+    >
+      <p
+        className="text-[10px] font-medium uppercase tracking-[0.24em]"
+        style={{ color: `${vibeAccent}80` }}
+      >
+        your vibe this month
+      </p>
+      <p
+        className="mt-6 font-display italic leading-none"
+        style={{ fontSize: "clamp(52px, 16vw, 100px)", color: vibeAccent, letterSpacing: "-0.02em" }}
+      >
+        {vibe}
+      </p>
+    </div>,
+
+    // 4 — Colors
+    <div
+      key="colors"
+      className="flex h-full flex-col items-center justify-center px-8 text-center"
+      style={{ background: "var(--pink-soft)" }}
+    >
+      <p className="text-[10px] font-medium uppercase tracking-[0.24em] text-mute">your palette</p>
+      <div className="mt-10 flex gap-6">
+        {stats.top_colors.slice(0, 3).map((c, i) => (
+          <div key={i} className="flex flex-col items-center gap-3">
+            <div
+              className="rounded-full border-2 border-line shadow-sm"
+              style={{ width: 76, height: 76, background: c.color }}
+            />
+            <span className="text-[11px] lowercase text-ink-soft">{c.color}</span>
+          </div>
+        ))}
+      </div>
+    </div>,
+
+    // 5 — Brands
+    <div
+      key="brands"
+      className="flex h-full flex-col items-center justify-center px-8"
+      style={{ background: "#1a1416" }}
+    >
+      <p
+        className="mb-8 text-center text-[10px] font-medium uppercase tracking-[0.24em]"
+        style={{ color: "rgba(255,255,255,0.35)" }}
+      >
+        your labels
+      </p>
+      <div className="w-full max-w-xs space-y-5">
+        {stats.top_brands.slice(0, 3).map((b, i) => (
+          <div key={i} className="flex items-baseline gap-4">
+            <span
+              className="font-display italic shrink-0"
+              style={{ fontSize: 36, lineHeight: 1, color: "rgba(255,255,255,0.15)" }}
+            >
+              {i + 1}
+            </span>
+            <span
+              className="font-display italic text-white"
+              style={{ fontSize: "clamp(22px, 6.5vw, 34px)", lineHeight: 1.1, letterSpacing: "-0.01em" }}
+            >
+              {b.brand}
+            </span>
+          </div>
+        ))}
+        {stats.top_brands.length === 0 && (
+          <p className="text-center text-sm" style={{ color: "rgba(255,255,255,0.3)" }}>
+            no brands tagged yet
+          </p>
+        )}
+      </div>
+    </div>,
+
+    // 6 — Category
+    <div
+      key="category"
+      className="flex h-full flex-col items-center justify-center px-8 text-center"
+      style={{ background: "var(--paper)" }}
+    >
+      <p className="text-[10px] font-medium uppercase tracking-[0.24em] text-mute">you mostly wore</p>
+      <p
+        className="mt-5 font-display italic text-ink"
+        style={{ fontSize: "clamp(44px, 13vw, 80px)", lineHeight: 1.05, letterSpacing: "-0.02em" }}
+      >
+        {stats.top_categories[0]?.category ?? "everything"}
+      </p>
+    </div>,
+
+    // 7 — Weekly rhythm
+    <div
+      key="rhythm"
+      className="flex h-full flex-col items-center justify-center px-8"
+      style={{ background: "#1a1416" }}
+    >
+      <p
+        className="mb-10 text-center text-[10px] font-medium uppercase tracking-[0.24em]"
+        style={{ color: "rgba(255,255,255,0.35)" }}
+      >
+        your weekly rhythm
+      </p>
+      <div
+        className="flex w-full max-w-[280px] items-end justify-center gap-3"
+        style={{ height: 140 }}
+      >
+        {stats.outfits_by_week.map((w, i) => {
+          const pct = (w.count / maxWeek) * 100;
+          return (
+            <div key={i} className="flex flex-1 flex-col items-center gap-2">
+              <span className="text-[10px]" style={{ color: "rgba(255,255,255,0.4)" }}>
+                {w.count > 0 ? w.count : ""}
+              </span>
+              <div
+                className="w-full rounded-t"
+                style={{
+                  height: `${Math.max(pct, 4)}%`,
+                  background: "var(--pink)",
+                  opacity: w.count === 0 ? 0.2 : 1,
+                  minHeight: 3,
+                }}
+              />
+              <span className="text-[9px]" style={{ color: "rgba(255,255,255,0.25)" }}>
+                wk {w.week}
+              </span>
+            </div>
+          );
+        })}
+        {stats.outfits_by_week.length === 0 && (
+          <p className="text-sm" style={{ color: "rgba(255,255,255,0.3)" }}>no data</p>
+        )}
+      </div>
+    </div>,
+
+    // 8 — Summary / share
+    <div
+      key="summary"
+      className="flex h-full flex-col items-center justify-center px-8 text-center"
+      style={{ background: "linear-gradient(160deg, #FDEDF3 0%, #F8C8DC 100%)" }}
+    >
+      <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-ink-soft">
+        {monthName(month)}
+      </p>
+      <p
+        className="mt-4 font-display italic text-ink"
+        style={{ fontSize: "clamp(40px, 12vw, 64px)", lineHeight: 1.05, letterSpacing: "-0.02em" }}
+      >
+        that's a wrap
+      </p>
+      <div className="mt-5 space-y-1 text-sm text-ink-soft">
+        <p>{stats.total_outfits} outfits · {stats.longest_streak}-day streak</p>
+        {stats.most_worn_vibe && <p>{stats.most_worn_vibe} vibes</p>}
+      </div>
+      <div className="mt-10 w-full max-w-[260px] space-y-3">
+        <button type="button" onClick={() => setShowShare(true)} className="btn-primary w-full gap-2.5">
+          <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+            <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
+            <polyline points="16 6 12 2 8 6" />
+            <line x1="12" y1="2" x2="12" y2="15" />
+          </svg>
+          share my checks
+        </button>
+      </div>
+    </div>,
+  ];
+
+  return (
+    <>
+      <div
+        className="relative h-full w-full overflow-hidden"
+        onTouchStart={onTouchStart}
+        onTouchEnd={onTouchEnd}
+        style={{ touchAction: "pan-y" }}
+      >
+        {/* Card track */}
+        <div
+          className="flex h-full"
+          style={{
+            width: "max-content",
+            transform: `translateX(calc(-1 * ${slide} * 100vw))`,
+            transition: "transform 0.38s cubic-bezier(0.22, 1, 0.36, 1)",
+            willChange: "transform",
+          }}
+        >
+          {cards.map((card, i) => (
+            <div key={i} className="h-full shrink-0" style={{ width: "100vw" }}>
+              {card}
+            </div>
+          ))}
+        </div>
+
+        {/* Progress dots */}
+        <div className="absolute bottom-8 left-1/2 z-20 flex -translate-x-1/2 items-center gap-2" style={{ bottom: "max(32px, env(safe-area-inset-bottom))" }}>
+          {cards.map((_, i) => (
+            <button
+              key={i}
+              type="button"
+              onClick={() => goTo(i)}
+              aria-label={`Slide ${i + 1}`}
+              style={{
+                width: i === slide ? 20 : 6,
+                height: 6,
+                borderRadius: 3,
+                background: i === slide ? dotActive : dotInactive,
+                transition: "width 0.2s ease, background 0.2s ease",
+                border: "none",
+                padding: 0,
+                cursor: "pointer",
+              }}
+            />
+          ))}
+        </div>
+
+        {/* Desktop arrows */}
+        {slide > 0 && (
+          <button
+            type="button"
+            onClick={() => goTo(slide - 1)}
+            className={`absolute left-4 top-1/2 z-20 hidden -translate-y-1/2 items-center justify-center rounded-full transition lg:flex ${arrowCls}`}
+            style={{ width: 44, height: 44 }}
+          >
+            <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <path d="m15 18-6-6 6-6" />
+            </svg>
+          </button>
+        )}
+        {slide < TOTAL - 1 && (
+          <button
+            type="button"
+            onClick={() => goTo(slide + 1)}
+            className={`absolute right-4 top-1/2 z-20 hidden -translate-y-1/2 items-center justify-center rounded-full transition lg:flex ${arrowCls}`}
+            style={{ width: 44, height: 44 }}
+          >
+            <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <path d="m9 18 6-6-6-6" />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      {showShare && (
+        <ChecksShareSheet
+          stats={stats}
+          month={month}
+          username={username}
+          onClose={() => setShowShare(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/components/monthly-checks/checks-share-sheet.tsx
+++ b/apps/web/components/monthly-checks/checks-share-sheet.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { WrappedStats } from "@/lib/api-client";
+
+type ChecksShareSheetProps = {
+  stats: WrappedStats;
+  month: string;
+  username: string;
+  onClose: () => void;
+};
+
+function monthLabel(yyyyMM: string): string {
+  const [y, m] = yyyyMM.split("-").map(Number);
+  return new Date(y, m - 1, 1).toLocaleDateString("en-US", { month: "long", year: "numeric" });
+}
+
+export function ChecksShareSheet({ stats, month, username, onClose }: ChecksShareSheetProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [rendered, setRendered] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const fileName = `checkd-monthly-checks-${month}.png`;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const W = 1080;
+    const H = 1920;
+    canvas.width = W;
+    canvas.height = H;
+
+    // ── Background — dark ink
+    ctx.fillStyle = "#1a1416";
+    ctx.fillRect(0, 0, W, H);
+
+    // ── Subtle pink gradient overlay at top
+    const topGrad = ctx.createLinearGradient(0, 0, 0, H * 0.45);
+    topGrad.addColorStop(0, "rgba(248,200,220,0.10)");
+    topGrad.addColorStop(1, "rgba(248,200,220,0)");
+    ctx.fillStyle = topGrad;
+    ctx.fillRect(0, 0, W, H);
+
+    const PAD = 80;
+
+    // ── "checkd" wordmark — top right
+    ctx.save();
+    ctx.font = `italic 400 68px Georgia, "Times New Roman", serif`;
+    ctx.fillStyle = "#F8C8DC";
+    ctx.textAlign = "right";
+    ctx.textBaseline = "top";
+    ctx.fillText("checkd", W - PAD, 120);
+    ctx.restore();
+
+    // ── "monthly checks" label — top right below logo
+    ctx.save();
+    ctx.font = `400 22px Arial, sans-serif`;
+    ctx.fillStyle = "rgba(255,255,255,0.3)";
+    ctx.textAlign = "right";
+    ctx.textBaseline = "top";
+    ctx.fillText("monthly checks", W - PAD, 204);
+    ctx.restore();
+
+    // ── Month name — large centered
+    ctx.save();
+    ctx.font = `italic 400 108px Georgia, "Times New Roman", serif`;
+    ctx.fillStyle = "#ffffff";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "top";
+    ctx.fillText(monthLabel(month), W / 2, 340);
+    ctx.restore();
+
+    // ── Thin divider
+    ctx.save();
+    ctx.strokeStyle = "rgba(255,255,255,0.08)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(PAD, 540);
+    ctx.lineTo(W - PAD, 540);
+    ctx.stroke();
+    ctx.restore();
+
+    // ── Stats row
+    const statY = 620;
+    const statItems = [
+      { value: String(stats.total_outfits), label: "outfits" },
+      { value: `${stats.longest_streak}d`, label: "streak" },
+      { value: String(stats.total_items), label: "items" },
+    ];
+    const colW = (W - PAD * 2) / statItems.length;
+    statItems.forEach(({ value, label }, i) => {
+      const cx = PAD + colW * i + colW / 2;
+      ctx.save();
+      ctx.font = `italic 400 80px Georgia, "Times New Roman", serif`;
+      ctx.fillStyle = "#ffffff";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "top";
+      ctx.fillText(value, cx, statY);
+      ctx.restore();
+
+      ctx.save();
+      ctx.font = `400 24px Arial, sans-serif`;
+      ctx.fillStyle = "rgba(255,255,255,0.3)";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "top";
+      ctx.fillText(label, cx, statY + 96);
+      ctx.restore();
+    });
+
+    // ── Vibe
+    if (stats.most_worn_vibe) {
+      ctx.save();
+      ctx.font = `italic 400 56px Georgia, "Times New Roman", serif`;
+      ctx.fillStyle = "#F8C8DC";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "top";
+      ctx.fillText(`${stats.most_worn_vibe} vibes`, W / 2, 840);
+      ctx.restore();
+    }
+
+    // ── Color swatches
+    if (stats.top_colors.length > 0) {
+      const swatchCount = Math.min(stats.top_colors.length, 3);
+      const swatchSize = 90;
+      const swatchGap = 28;
+      const swatchTotalW = swatchCount * swatchSize + (swatchCount - 1) * swatchGap;
+      const swatchStartX = (W - swatchTotalW) / 2;
+      const swatchY = 1000;
+
+      stats.top_colors.slice(0, 3).forEach((c, i) => {
+        const cx = swatchStartX + i * (swatchSize + swatchGap) + swatchSize / 2;
+        ctx.save();
+        ctx.beginPath();
+        ctx.arc(cx, swatchY + swatchSize / 2, swatchSize / 2, 0, Math.PI * 2);
+        ctx.fillStyle = c.color;
+        ctx.fill();
+        ctx.strokeStyle = "rgba(255,255,255,0.12)";
+        ctx.lineWidth = 2;
+        ctx.stroke();
+        ctx.restore();
+      });
+    }
+
+    // ── Top brand
+    if (stats.top_brands[0]) {
+      ctx.save();
+      ctx.font = `400 22px Arial, sans-serif`;
+      ctx.fillStyle = "rgba(255,255,255,0.25)";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "top";
+      ctx.fillText("top label", W / 2, 1160);
+      ctx.restore();
+
+      ctx.save();
+      ctx.font = `italic 400 52px Georgia, "Times New Roman", serif`;
+      ctx.fillStyle = "rgba(255,255,255,0.7)";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "top";
+      ctx.fillText(stats.top_brands[0].brand, W / 2, 1196);
+      ctx.restore();
+    }
+
+    // ── Thin divider bottom
+    ctx.save();
+    ctx.strokeStyle = "rgba(255,255,255,0.06)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(PAD, 1420);
+    ctx.lineTo(W - PAD, 1420);
+    ctx.stroke();
+    ctx.restore();
+
+    // ── @username — bottom left
+    ctx.save();
+    ctx.font = `400 28px Arial, sans-serif`;
+    ctx.fillStyle = "rgba(255,255,255,0.25)";
+    ctx.textAlign = "left";
+    ctx.textBaseline = "top";
+    ctx.fillText(`@${username}`, PAD, 1460);
+    ctx.restore();
+
+    // ── "checkd.app" — bottom right
+    ctx.save();
+    ctx.font = `400 28px Arial, sans-serif`;
+    ctx.fillStyle = "rgba(255,255,255,0.18)";
+    ctx.textAlign = "right";
+    ctx.textBaseline = "top";
+    ctx.fillText("checkd.app", W - PAD, 1460);
+    ctx.restore();
+
+    setRendered(true);
+  }, [stats, month, username]);
+
+  function handleDownload() {
+    const canvas = canvasRef.current;
+    if (!canvas || !rendered) return;
+    setDownloading(true);
+    canvas.toBlob((blob) => {
+      if (!blob) { setDownloading(false); return; }
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = fileName;
+      a.click();
+      URL.revokeObjectURL(url);
+      setDownloading(false);
+    }, "image/png");
+  }
+
+  function handleNativeShare() {
+    const canvas = canvasRef.current;
+    if (!canvas || !rendered || !navigator.share) return;
+    canvas.toBlob(async (blob) => {
+      if (!blob) return;
+      try {
+        const file = new File([blob], fileName, { type: "image/png" });
+        if (navigator.canShare?.({ files: [file] })) {
+          await navigator.share({ files: [file], title: `my ${monthLabel(month)} checks` });
+        } else {
+          await navigator.share({ title: `my ${monthLabel(month)} checks` });
+        }
+      } catch {
+        // user cancelled
+      }
+    }, "image/png");
+  }
+
+  async function handleCopyLink() {
+    const url = `${window.location.origin}/monthly-checks?month=${month}`;
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  const canNativeShare = typeof navigator !== "undefined" && "share" in navigator;
+
+  return (
+    <div
+      className="animate-fade-in fixed inset-0 z-50 flex items-end justify-center bg-[rgba(26,20,22,0.65)] px-4 pb-4 backdrop-blur-sm sm:items-center sm:pb-0"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="animate-fade-up soft-panel w-full max-w-sm overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 pb-4 pt-5">
+          <h2 className="font-display italic text-2xl tracking-[-0.03em] text-ink">share your checks</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-line text-mute transition hover:text-ink"
+          >
+            <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <path d="M18 6 6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Canvas preview */}
+        <div className="mx-6 mb-5 overflow-hidden rounded-[1.2rem] border border-line bg-ink">
+          <div className="relative aspect-[9/16] w-full">
+            <canvas
+              ref={canvasRef}
+              className="h-full w-full"
+              style={{ display: rendered ? "block" : "none", objectFit: "cover" }}
+            />
+            {!rendered && <div className="absolute inset-0 animate-pulse bg-pink-soft" />}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="space-y-2.5 px-6 pb-6">
+          <button
+            type="button"
+            onClick={handleDownload}
+            disabled={!rendered || downloading}
+            className="btn-primary w-full gap-2.5"
+          >
+            <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+              <polyline points="7 10 12 15 17 10" />
+              <line x1="12" y1="15" x2="12" y2="3" />
+            </svg>
+            {downloading ? "saving…" : "save to camera roll"}
+          </button>
+
+          <div className="flex gap-2.5">
+            <button
+              type="button"
+              onClick={() => void handleCopyLink()}
+              className="flex flex-1 items-center justify-center gap-2 rounded-full border border-line bg-white py-3 text-sm font-medium text-ink-soft transition hover:border-pink-deep/40"
+            >
+              <svg viewBox="0 0 24 24" className="h-3.5 w-3.5 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+                <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+              </svg>
+              {copied ? "copied!" : "copy link"}
+            </button>
+
+            {canNativeShare && (
+              <button
+                type="button"
+                onClick={handleNativeShare}
+                disabled={!rendered}
+                className="flex flex-1 items-center justify-center gap-2 rounded-full border border-line bg-white py-3 text-sm font-medium text-ink-soft transition hover:border-pink-deep/40 disabled:opacity-50"
+              >
+                <svg viewBox="0 0 24 24" className="h-3.5 w-3.5 shrink-0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                  <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
+                  <polyline points="16 6 12 2 8 6" />
+                  <line x1="12" y1="2" x2="12" y2="15" />
+                </svg>
+                share
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/monthly-checks/monthly-checks-client.tsx
+++ b/apps/web/components/monthly-checks/monthly-checks-client.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { apiClient, type WrappedStats } from "@/lib/api-client";
+import { useAuth } from "@/lib/auth-context";
+import { ChecksDeck } from "./checks-deck";
+
+function prevMonth(yyyyMM: string): string {
+  const [y, m] = yyyyMM.split("-").map(Number);
+  if (m === 1) return `${y - 1}-12`;
+  return `${y}-${String(m - 1).padStart(2, "0")}`;
+}
+
+function nextMonth(yyyyMM: string): string {
+  const [y, m] = yyyyMM.split("-").map(Number);
+  if (m === 12) return `${y + 1}-01`;
+  return `${y}-${String(m + 1).padStart(2, "0")}`;
+}
+
+function defaultMonth(): string {
+  const now = new Date();
+  const d = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+function formatMonthLabel(yyyyMM: string): string {
+  const [y, m] = yyyyMM.split("-").map(Number);
+  return new Date(y, m - 1, 1).toLocaleDateString("en-US", { month: "long", year: "numeric" });
+}
+
+export function MonthlyChecksClient() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth();
+
+  const month = searchParams.get("month") ?? defaultMonth();
+  const [stats, setStats] = useState<WrappedStats | null>(null);
+  const [status, setStatus] = useState<"idle" | "loading" | "empty" | "error">("idle");
+  const [slideIsLight, setSlideIsLight] = useState(true);
+
+  const now = new Date();
+  const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+  const isAtLatest = month >= currentMonth;
+
+  useEffect(() => {
+    if (authLoading || !isAuthenticated) return;
+    let active = true;
+    setStats(null);
+    setStatus("loading");
+
+    void apiClient.users.getWrapped(month).then((result) => {
+      if (!active) return;
+      if (!result.ok) { setStatus("error"); return; }
+      if (result.data.total_outfits === 0) { setStatus("empty"); return; }
+      setStats(result.data);
+      setStatus("idle");
+    });
+
+    return () => { active = false; };
+  }, [month, authLoading, isAuthenticated]);
+
+  function navigate(dir: "prev" | "next") {
+    const target = dir === "prev" ? prevMonth(month) : nextMonth(month);
+    router.push(`/monthly-checks?month=${target}`);
+  }
+
+  if (authLoading || !isAuthenticated) {
+    return (
+      <main className="flex h-screen items-center justify-center" style={{ background: "var(--ink)" }}>
+        <p className="font-display italic text-5xl" style={{ color: "var(--pink)" }}>checkd</p>
+      </main>
+    );
+  }
+
+  const controlsDark = !slideIsLight;
+  const btnStyle = controlsDark
+    ? "bg-white/10 border border-white/20 text-white backdrop-blur-sm hover:bg-white/20"
+    : "bg-ink/[0.07] border border-line text-ink backdrop-blur-sm hover:bg-ink/[0.12]";
+  const monthLabelColor = controlsDark ? "text-white/70" : "text-ink-soft";
+
+  return (
+    <main className="relative h-screen overflow-hidden" style={{ background: "var(--ink)" }}>
+      {/* Back */}
+      <Link
+        href="/profile"
+        className={`absolute left-4 top-safe-top z-30 flex h-9 w-9 items-center justify-center rounded-full transition ${btnStyle}`}
+        style={{ top: "max(16px, env(safe-area-inset-top))" }}
+      >
+        <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+          <path d="m15 18-6-6 6-6" />
+        </svg>
+      </Link>
+
+      {/* Month nav */}
+      <div
+        className="absolute left-1/2 z-30 flex -translate-x-1/2 items-center gap-2"
+        style={{ top: "max(16px, env(safe-area-inset-top))" }}
+      >
+        <button
+          type="button"
+          onClick={() => navigate("prev")}
+          className={`flex h-7 w-7 items-center justify-center rounded-full transition ${btnStyle}`}
+        >
+          <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+            <path d="m15 18-6-6 6-6" />
+          </svg>
+        </button>
+        <span className={`text-[11px] font-medium ${monthLabelColor}`}>{formatMonthLabel(month)}</span>
+        <button
+          type="button"
+          onClick={() => navigate("next")}
+          disabled={isAtLatest}
+          className={`flex h-7 w-7 items-center justify-center rounded-full transition disabled:opacity-30 ${btnStyle}`}
+        >
+          <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+            <path d="m9 18 6-6-6-6" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Content */}
+      {status === "loading" && (
+        <div className="flex h-full items-center justify-center">
+          <div className="text-center">
+            <p className="font-display italic text-5xl" style={{ color: "var(--pink)" }}>checkd</p>
+            <p className="mt-3 text-sm" style={{ color: "rgba(255,255,255,0.35)" }}>loading your checks…</p>
+          </div>
+        </div>
+      )}
+
+      {status === "empty" && (
+        <div className="flex h-full items-center justify-center px-8">
+          <div className="text-center">
+            <p className="font-display italic text-4xl" style={{ color: "var(--pink)" }}>no fits yet</p>
+            <p className="mt-3 text-sm leading-6" style={{ color: "rgba(255,255,255,0.4)" }}>
+              you didn't post any outfits in {formatMonthLabel(month)}
+            </p>
+            <Link
+              href="/profile"
+              className="mt-6 inline-flex items-center gap-2 rounded-full px-5 py-3 text-sm transition"
+              style={{ background: "rgba(255,255,255,0.08)", color: "rgba(255,255,255,0.6)" }}
+            >
+              ← back to profile
+            </Link>
+          </div>
+        </div>
+      )}
+
+      {status === "error" && (
+        <div className="flex h-full items-center justify-center px-8">
+          <div className="text-center">
+            <p className="font-display italic text-4xl" style={{ color: "var(--pink)" }}>oops</p>
+            <p className="mt-3 text-sm" style={{ color: "rgba(255,255,255,0.4)" }}>couldn't load your checks</p>
+          </div>
+        </div>
+      )}
+
+      {status === "idle" && stats && (
+        <ChecksDeck
+          stats={stats}
+          month={month}
+          username={user?.username ?? ""}
+          onSlideChange={(isLight) => setSlideIsLight(isLight)}
+        />
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `/monthly-checks` — a full-screen swipeable Spotify Wrapped-style presentation of a user's monthly outfit stats, powered by the existing `/users/me/wrapped` backend endpoint
- Adds a **"checks" archive tab** on the profile page that lists available months as a drop-style release (unlocks on day 25 of each month, starting May 2026)
- Adds a **shareable card** (1080×1920 canvas image) with download, native share, and copy link

## The deck (9 slides)

| # | Card | Background |
|---|------|------------|
| 1 | Intro — month name + @username | Pink gradient |
| 2 | Total outfits posted | Dark ink |
| 3 | Longest streak (days in a row) | Paper |
| 4 | Vibe of the month | Tone-matched dark bg + accent color |
| 5 | Top 3 colors (swatches) | Pink-soft |
| 6 | Top 3 brands ranked | Dark ink |
| 7 | Most-worn category | Paper |
| 8 | Weekly rhythm bar chart | Dark ink |
| 9 | Summary + share button | Pink gradient |

Navigation: swipe on mobile, arrow buttons on desktop, keyboard arrow keys. Progress dots and arrow colors adapt to each slide's light/dark background.

## Archive drop logic

Monthly Checks is a recurring drop — not a retroactive history dump. The rules:

- Feature launches **May 2026**
- Each month unlocks on **day 25** of that month
- Before May 25: the checks tab shows a "coming soon" placeholder
- May 25+: May 2026 appears; a new month is added on the 25th of each subsequent month
- No months before the launch date ever appear

## Files changed

| File | Change |
|------|--------|
| `apps/web/app/monthly-checks/page.tsx` | New — Suspense-wrapped server entry point |
| `apps/web/components/monthly-checks/monthly-checks-client.tsx` | New — auth gate, month picker (prev/next) |
| `apps/web/components/monthly-checks/checks-deck.tsx` | New — swipeable deck + all 9 stat cards |
| `apps/web/components/monthly-checks/checks-share-sheet.tsx` | New — canvas share card |
| `apps/web/app/profile/page.tsx` | Modified — new "checks" tab with drop-based archive |

## Depends on

Backend `/users/me/wrapped?month=YYYY-MM` endpoint — already merged.

Closes #61