### PR TITLE
fix: request timeout + guarantee isLoading resets on auth

### DIFF
--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -422,6 +422,8 @@ async function refreshAccessToken(): Promise<ApiResult<AuthRefreshResponse>> {
   return result;
 }
 
+const REQUEST_TIMEOUT_MS = 15_000;
+
 async function sendRequest<T>(
   path: string,
   {
@@ -445,19 +447,27 @@ async function sendRequest<T>(
 
   let response: Response;
 
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
   try {
     response = await fetch(`${DEFAULT_API_BASE_URL}${path}`, {
       method,
       headers: requestHeaders,
       body: body instanceof FormData ? body : body ? JSON.stringify(body) : undefined,
-      credentials: "include"
+      credentials: "include",
+      signal: controller.signal
     });
-  } catch {
+  } catch (err) {
+    clearTimeout(timeoutId);
+    const isTimeout = err instanceof Error && err.name === "AbortError";
     return {
       ok: false,
-      ...normalizeErrorPayload(null, 0, "")
+      ...normalizeErrorPayload(null, 0, isTimeout ? "Request timed out. Please try again." : "")
     };
   }
+
+  clearTimeout(timeoutId);
 
   if (response.status === 401 && requiresAuth && retryOnUnauthorized) {
     const refreshResult = await refreshAccessToken();

--- a/apps/web/lib/auth-context.tsx
+++ b/apps/web/lib/auth-context.tsx
@@ -115,51 +115,45 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   async function login(input: LoginInput): Promise<AuthActionResult> {
     setIsLoading(true);
 
-    const result = await authApiClient.login(input);
+    try {
+      const result = await authApiClient.login(input);
 
-    if (result.ok) {
-      setAuthSessionCookie();
-      setUser(result.data.user);
-      setIsLoading(false);
+      if (result.ok) {
+        setAuthSessionCookie();
+        setUser(result.data.user);
+        return { ok: true, message: result.message };
+      }
 
       return {
-        ok: true,
-        message: result.message
+        ok: false,
+        message: result.message,
+        errors: toAuthErrors(result.errors)
       };
+    } finally {
+      setIsLoading(false);
     }
-
-    setIsLoading(false);
-
-    return {
-      ok: false,
-      message: result.message,
-      errors: toAuthErrors(result.errors)
-    };
   }
 
   async function signup(input: SignupInput): Promise<AuthActionResult> {
     setIsLoading(true);
 
-    const result = await authApiClient.register(input);
+    try {
+      const result = await authApiClient.register(input);
 
-    if (result.ok) {
-      setAuthSessionCookie();
-      setUser(result.data.user);
-      setIsLoading(false);
+      if (result.ok) {
+        setAuthSessionCookie();
+        setUser(result.data.user);
+        return { ok: true, message: result.message };
+      }
 
       return {
-        ok: true,
-        message: result.message
+        ok: false,
+        message: result.message,
+        errors: toAuthErrors(result.errors)
       };
+    } finally {
+      setIsLoading(false);
     }
-
-    setIsLoading(false);
-
-    return {
-      ok: false,
-      message: result.message,
-      errors: toAuthErrors(result.errors)
-    };
   }
 
   async function refreshUser() {


### PR DESCRIPTION
## Summary
- Login button would get stuck in "working..." indefinitely if the backend was slow or unreachable — `fetch` has no built-in timeout
- `setIsLoading(false)` was only called on happy/error paths; any unexpected throw would leave the UI frozen

## Changes
- `api-client.ts` — added 15s `AbortController` timeout to every `sendRequest` call; timeout surfaces as a user-readable error message
- `auth-context.tsx` — wrapped `login` and `signup` in `try/finally` so `setIsLoading(false)` is guaranteed to run regardless of outcome

## Test plan
- [ ] Login with correct credentials → proceeds normally
- [ ] Login with wrong credentials → shows error, button re-enables
- [ ] Kill the API mid-request → button re-enables after ~15s with timeout message