### PR TITLE
fix: catch silent login errors, add proxy timeout

### DIFF
--- a/apps/web/app/backend/[...path]/route.ts
+++ b/apps/web/app/backend/[...path]/route.ts
@@ -101,6 +101,7 @@ async function proxy(request: NextRequest, path: string[]) {
 
   const headers = new Headers(upstreamResponse.headers);
   headers.delete("content-length");
+  headers.delete("content-encoding"); // proxy's fetch auto-decompresses; remove to avoid double-decode
   headers.delete("access-control-allow-origin");
   headers.delete("access-control-allow-credentials");
   headers.delete("access-control-allow-methods");

--- a/apps/web/app/backend/[...path]/route.ts
+++ b/apps/web/app/backend/[...path]/route.ts
@@ -66,6 +66,8 @@ function buildUpstreamHeaders(request: NextRequest) {
   return headers;
 }
 
+const PROXY_TIMEOUT_MS = 15_000;
+
 async function proxy(request: NextRequest, path: string[]) {
   const backendOrigin = getBackendOrigin();
   const upstreamUrl = new URL(`${backendOrigin}/${path.join("/")}`);
@@ -75,12 +77,27 @@ async function proxy(request: NextRequest, path: string[]) {
       ? undefined
       : await request.arrayBuffer();
 
-  const upstreamResponse = await fetch(upstreamUrl, {
-    method: request.method,
-    headers: buildUpstreamHeaders(request),
-    body,
-    redirect: "manual"
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), PROXY_TIMEOUT_MS);
+
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: request.method,
+      headers: buildUpstreamHeaders(request),
+      body,
+      redirect: "manual",
+      signal: controller.signal
+    });
+  } catch (err) {
+    clearTimeout(timeoutId);
+    const isTimeout = err instanceof Error && err.name === "AbortError";
+    return new NextResponse(
+      JSON.stringify({ detail: isTimeout ? "Backend request timed out." : "Backend unreachable." }),
+      { status: 504, headers: { "Content-Type": "application/json" } }
+    );
+  }
+  clearTimeout(timeoutId);
 
   const headers = new Headers(upstreamResponse.headers);
   headers.delete("content-length");

--- a/apps/web/components/auth/auth-form.tsx
+++ b/apps/web/components/auth/auth-form.tsx
@@ -72,17 +72,25 @@ export function AuthForm({ mode, next }: AuthFormProps) {
     }
 
     setSubmitState({ status: "submitting" });
-    const result =
-      mode === "signup"
-        ? await signup({
-            username: values.username.trim(),
-            email: values.email.trim().toLowerCase(),
-            password: values.password
-          })
-        : await login({
-            identifier: values.identifier.trim().toLowerCase(),
-            password: values.password
-          });
+
+    let result: Awaited<ReturnType<typeof login>> | null = null;
+    try {
+      result =
+        mode === "signup"
+          ? await signup({
+              username: values.username.trim(),
+              email: values.email.trim().toLowerCase(),
+              password: values.password
+            })
+          : await login({
+              identifier: values.identifier.trim().toLowerCase(),
+              password: values.password
+            });
+    } catch (err) {
+      console.error("[auth-form] unexpected error during submit:", err);
+      setSubmitState({ status: "error", message: "Something went wrong. Please try again." });
+      return;
+    }
 
     if (result.ok) {
       setErrors({});


### PR DESCRIPTION
## Summary
Two gaps that could cause login to silently stay on "working..." forever:

1. **`handleSubmit` had no try/catch** — if `login()` threw for any reason (e.g. unexpected response shape, null access on result.data), the error was silently swallowed and `submitState` was never reset from "submitting". Now wraps the call in try/catch and shows "Something went wrong. Please try again." Also logs the actual error to the console so it's diagnosable.

2. **Proxy had no timeout** — the server-side `fetch` to Railway in the Next.js proxy route had no AbortController, so if Railway was slow or unreachable the Vercel function would hang until Vercel's own timeout (which is silent to the user). Added a matching 15s timeout that returns a proper 504 JSON response.

## Test plan
- [ ] Login with correct credentials works
- [ ] Login with wrong credentials shows error, button re-enables
- [ ] Open browser console — if something unexpected happens you should see `[auth-form] unexpected error during submit:` with the actual error