### PR TITLE
Fix monthly fit check crash and hide duplicate search icons on desktop

### DIFF
--- a/apps/web/app/explore/page.tsx
+++ b/apps/web/app/explore/page.tsx
@@ -291,7 +291,7 @@ export default function ExplorePage() {
               </p>
               <p className="mt-1 text-sm text-mute">explore</p>
             </div>
-            <Link href="/search" className="icon-button" aria-label="Search people">
+            <Link href="/search" className="icon-button lg:hidden" aria-label="Search people">
               <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
                 <circle cx="11" cy="11" r="7" />
                 <path d="m21 21-4.35-4.35" />

--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -472,11 +472,11 @@ export default function FeedPage() {
                 <circle cx="12" cy="12" r="9" /><path d="m14.5 9.5-5 2-2 5 5-2 2-5z" />
               </svg>
             </Link>
-            {/* Search */}
+            {/* Search — hidden on desktop where the nav search bar is shown */}
             <Link
               href="/search"
               aria-label="Search"
-              className="flex items-center justify-center rounded-full border border-line bg-white text-mute transition hover:border-pink-deep hover:text-ink"
+              className="flex items-center justify-center rounded-full border border-line bg-white text-mute transition hover:border-pink-deep hover:text-ink lg:hidden"
               style={{ width: 36, height: 36 }}
             >
               <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round">

--- a/services/api/app/crud/wrapped.py
+++ b/services/api/app/crud/wrapped.py
@@ -29,24 +29,23 @@ def get_wrapped_stats(
     """
     Compute monthly wrapped stats for one user.
 
-    Returns a plain dict matching the WrappedStats schema so the router can
-    call WrappedStats(**stats) without any extra transformation.
+    Returns a plain dict matching the WrappedStats schema.
     """
-    month_label = f"{year}-{month:02d}"
     empty = {
-        "month": month_label,
+        "year": year,
+        "month": month,
         "total_outfits": 0,
+        "total_items": 0,
         "top_colors": [],
         "top_brands": [],
-        "top_category": None,
-        "vibe_of_month": None,
-        "most_active_day": None,
+        "top_categories": [],
         "longest_streak": 0,
-        "top_outfit": None,
+        "current_streak": 0,
+        "most_worn_vibe": None,
+        "outfits_by_week": [],
     }
 
     # ── Derived date expression ──────────────────────────────────────────────
-    # worn_on is a Date; created_at is a DateTime — cast to Date before coalesce.
     outfit_date = func.coalesce(Outfit.worn_on, cast(Outfit.created_at, Date))
 
     # ── 1. Fetch all outfits in the month ────────────────────────────────────
@@ -63,7 +62,14 @@ def get_wrapped_stats(
 
     outfit_ids = [o.id for o in outfits]
 
-    # ── 2. Top colors (from clothing items) ──────────────────────────────────
+    # ── 2. Total clothing items ──────────────────────────────────────────────
+    total_items = (
+        db.query(func.count(ClothingItem.id))
+        .filter(ClothingItem.outfit_id.in_(outfit_ids))
+        .scalar() or 0
+    )
+
+    # ── 3. Top colors ────────────────────────────────────────────────────────
     color_rows = (
         db.query(ClothingItem.color, func.count().label("cnt"))
         .filter(ClothingItem.outfit_id.in_(outfit_ids))
@@ -73,9 +79,9 @@ def get_wrapped_stats(
         .limit(3)
         .all()
     )
-    top_colors = [r.color for r in color_rows]
+    top_colors = [{"color": r.color, "count": r.cnt} for r in color_rows]
 
-    # ── 3. Top brands ────────────────────────────────────────────────────────
+    # ── 4. Top brands ────────────────────────────────────────────────────────
     brand_rows = (
         db.query(ClothingItem.brand, func.count().label("cnt"))
         .filter(ClothingItem.outfit_id.in_(outfit_ids))
@@ -85,57 +91,64 @@ def get_wrapped_stats(
         .limit(3)
         .all()
     )
-    top_brands = [r.brand for r in brand_rows]
+    top_brands = [{"brand": r.brand, "count": r.cnt} for r in brand_rows]
 
-    # ── 4. Top category ──────────────────────────────────────────────────────
-    cat_row = (
+    # ── 5. Top categories ────────────────────────────────────────────────────
+    cat_rows = (
         db.query(ClothingItem.category, func.count().label("cnt"))
         .filter(ClothingItem.outfit_id.in_(outfit_ids))
+        .filter(ClothingItem.category.isnot(None))
         .group_by(ClothingItem.category)
         .order_by(func.count().desc())
-        .first()
+        .limit(3)
+        .all()
     )
-    top_category = cat_row.category if cat_row else None
+    top_categories = [{"category": r.category, "count": r.cnt} for r in cat_rows]
 
-    # ── 5. Vibe of the month ─────────────────────────────────────────────────
+    # ── 6. Most worn vibe ────────────────────────────────────────────────────
     vibe_counts = Counter(o.vibe_check_tone for o in outfits if o.vibe_check_tone)
-    vibe_of_month = vibe_counts.most_common(1)[0][0] if vibe_counts else None
+    most_worn_vibe = vibe_counts.most_common(1)[0][0] if vibe_counts else None
 
-    # ── 6. Most active day of week ───────────────────────────────────────────
-    dow_row = (
-        db.query(
-            func.extract("dow", outfit_date).label("dow"),
-            func.count().label("cnt"),
-        )
-        .filter(Outfit.user_id == user_id)
-        .filter(func.extract("year", outfit_date) == year)
-        .filter(func.extract("month", outfit_date) == month)
-        .group_by(func.extract("dow", outfit_date))
-        .order_by(func.count().desc())
-        .first()
-    )
-    most_active_day = _DOW_NAMES[int(dow_row.dow)] if dow_row else None
+    # ── 7. Outfits by week-of-month ──────────────────────────────────────────
+    # Week 1 = days 1-7, week 2 = days 8-14, week 3 = days 15-21, week 4 = 22+
+    week_counter: Counter = Counter()
+    for o in outfits:
+        d = o.worn_on if o.worn_on else o.created_at.date()
+        week_num = min((d.day - 1) // 7 + 1, 4)
+        week_counter[week_num] += 1
+    outfits_by_week = [
+        {"week": w, "count": week_counter.get(w, 0)}
+        for w in range(1, 5)
+    ]
 
-    # ── 7. Longest consecutive-day streak ────────────────────────────────────
+    # ── 8. Longest streak ────────────────────────────────────────────────────
     worn_dates = sorted({
         (o.worn_on if o.worn_on else o.created_at.date())
         for o in outfits
     })
     longest_streak = _longest_streak(worn_dates)
 
-    # ── 8. Top outfit (most tagged clothing items; newest as tiebreaker) ─────
-    top_outfit = max(outfits, key=lambda o: (len(o.clothing_items), o.created_at))
+    # ── 9. Current streak (streak ending on or including the last outfit date) ─
+    all_dates_ever = sorted({
+        (o.worn_on if o.worn_on else o.created_at.date())
+        for o in db.query(Outfit)
+        .filter(Outfit.user_id == user_id)
+        .all()
+    })
+    current_streak = _current_streak(all_dates_ever)
 
     return {
-        "month": month_label,
+        "year": year,
+        "month": month,
         "total_outfits": len(outfits),
+        "total_items": total_items,
         "top_colors": top_colors,
         "top_brands": top_brands,
-        "top_category": top_category,
-        "vibe_of_month": vibe_of_month,
-        "most_active_day": most_active_day,
+        "top_categories": top_categories,
         "longest_streak": longest_streak,
-        "top_outfit": top_outfit,
+        "current_streak": current_streak,
+        "most_worn_vibe": most_worn_vibe,
+        "outfits_by_week": outfits_by_week,
     }
 
 
@@ -153,3 +166,23 @@ def _longest_streak(dates: list[date]) -> int:
         else:
             current = 1
     return best
+
+
+def _current_streak(dates: list[date]) -> int:
+    """Return the current consecutive streak ending today or yesterday."""
+    if not dates:
+        return 0
+    today = date.today()
+    streak = 0
+    check = today
+    date_set = set(dates)
+    while check in date_set:
+        streak += 1
+        check -= timedelta(days=1)
+    # also accept a streak ending yesterday
+    if streak == 0:
+        check = today - timedelta(days=1)
+        while check in date_set:
+            streak += 1
+            check -= timedelta(days=1)
+    return streak

--- a/services/api/app/routers/users.py
+++ b/services/api/app/routers/users.py
@@ -10,7 +10,6 @@ from app.crud import wrapped as wrapped_crud
 from app.dependencies import get_current_user, get_db
 from app.models.notification import NotificationType
 from app.models.user import User
-from app.schemas.outfit import OutfitOut
 from app.schemas.user import FollowResponse, PublicProfile, SearchResult, UpdateProfileRequest
 from app.schemas.wrapped import WrappedStats
 from app.services.storage import InvalidImageError, StorageError, upload_image
@@ -116,8 +115,7 @@ def get_wrapped(
             detail="month must be in YYYY-MM format (e.g. 2026-04).",
         )
     stats = wrapped_crud.get_wrapped_stats(db, current_user.id, year, mon)
-    top_outfit_out = OutfitOut.model_validate(stats["top_outfit"]) if stats["top_outfit"] else None
-    return WrappedStats(**{**stats, "top_outfit": top_outfit_out})
+    return WrappedStats(**stats)
 
 
 @router.get("/search", response_model=list[SearchResult])

--- a/services/api/app/schemas/wrapped.py
+++ b/services/api/app/schemas/wrapped.py
@@ -2,7 +2,25 @@
 
 from pydantic import BaseModel
 
-from app.schemas.outfit import OutfitOut
+
+class ColorCount(BaseModel):
+    color: str
+    count: int
+
+
+class BrandCount(BaseModel):
+    brand: str
+    count: int
+
+
+class CategoryCount(BaseModel):
+    category: str
+    count: int
+
+
+class WeekCount(BaseModel):
+    week: int
+    count: int
 
 
 class WrappedStats(BaseModel):
@@ -13,12 +31,14 @@ class WrappedStats(BaseModel):
     Fields are None / empty when there is no data for that stat.
     """
 
-    month: str                      # "2026-04"
+    year: int
+    month: int
     total_outfits: int
-    top_colors: list[str]           # up to 3, most frequent first
-    top_brands: list[str]           # up to 3, most frequent first
-    top_category: str | None        # single most-used clothing category
-    vibe_of_month: str | None       # most common vibe_check_tone
-    most_active_day: str | None     # e.g. "Monday"
-    longest_streak: int             # consecutive calendar days with an outfit
-    top_outfit: OutfitOut | None    # outfit with the most tagged clothing items
+    total_items: int
+    top_colors: list[ColorCount]
+    top_brands: list[BrandCount]
+    top_categories: list[CategoryCount]
+    longest_streak: int
+    current_streak: int
+    most_worn_vibe: str | None
+    outfits_by_week: list[WeekCount]

--- a/services/api/tests/test_wrapped.py
+++ b/services/api/tests/test_wrapped.py
@@ -1,4 +1,10 @@
-"""Tests for GET /users/me/wrapped."""
+"""Tests for GET /users/me/wrapped.
+
+The wrapped endpoint returns the Monthly Fits Wrapped schema:
+  year, month (ints), total_outfits, total_items,
+  top_colors / top_brands / top_categories (lists of {value, count} objects),
+  longest_streak, current_streak, most_worn_vibe, outfits_by_week.
+"""
 
 import io
 
@@ -52,14 +58,17 @@ class TestWrapped:
         res = client.get(WRAPPED_URL, params={"month": "2020-01"}, headers=_auth(a["access_token"]))
         assert res.status_code == 200
         body = res.json()
+        assert body["year"] == 2020
+        assert body["month"] == 1
         assert body["total_outfits"] == 0
+        assert body["total_items"] == 0
         assert body["top_colors"] == []
         assert body["top_brands"] == []
-        assert body["top_category"] is None
-        assert body["vibe_of_month"] is None
-        assert body["most_active_day"] is None
+        assert body["top_categories"] == []
+        assert body["most_worn_vibe"] is None
         assert body["longest_streak"] == 0
-        assert body["top_outfit"] is None
+        assert body["current_streak"] == 0
+        assert body["outfits_by_week"] == []
 
     def test_total_outfits_count(self, client, monkeypatch):
         _mock_upload(monkeypatch)
@@ -88,7 +97,9 @@ class TestWrapped:
             "clothing_items": [{"category": "top", "color": "blue"}],
         })
         res = client.get(WRAPPED_URL, params={"month": "2026-04"}, headers=_auth(a["access_token"]))
-        assert res.json()["top_colors"] == ["black", "white", "blue"]
+        top_colors = res.json()["top_colors"]
+        assert [c["color"] for c in top_colors] == ["black", "white", "blue"]
+        assert [c["count"] for c in top_colors] == [3, 2, 1]
 
     def test_top_brands(self, client, monkeypatch):
         _mock_upload(monkeypatch)
@@ -103,9 +114,28 @@ class TestWrapped:
             "clothing_items": [{"category": "top", "brand": "Nike"}],
         })
         res = client.get(WRAPPED_URL, params={"month": "2026-04"}, headers=_auth(a["access_token"]))
-        assert res.json()["top_brands"][0] == "Zara"
+        top_brands = res.json()["top_brands"]
+        assert top_brands[0]["brand"] == "Zara"
+        assert top_brands[0]["count"] == 2
 
-    def test_vibe_of_month(self, client, monkeypatch):
+    def test_top_categories(self, client, monkeypatch):
+        _mock_upload(monkeypatch)
+        a = _register(client, USER_A)
+        for _ in range(2):
+            _post_outfit(client, a["access_token"], {
+                "worn_on": "2026-04-01",
+                "clothing_items": [{"category": "top"}],
+            })
+        _post_outfit(client, a["access_token"], {
+            "worn_on": "2026-04-02",
+            "clothing_items": [{"category": "shoes"}],
+        })
+        res = client.get(WRAPPED_URL, params={"month": "2026-04"}, headers=_auth(a["access_token"]))
+        top_categories = res.json()["top_categories"]
+        assert top_categories[0]["category"] == "top"
+        assert top_categories[0]["count"] == 2
+
+    def test_most_worn_vibe(self, client, monkeypatch):
         monkeypatch.setattr("app.routers.outfits.upload_image", lambda **kw: "https://s3.example.com/test.jpg")
         call_count = {"n": 0}
 
@@ -121,7 +151,7 @@ class TestWrapped:
         _post_outfit(client, a["access_token"], {"worn_on": "2026-04-02"})
 
         res = client.get(WRAPPED_URL, params={"month": "2026-04"}, headers=_auth(a["access_token"]))
-        assert res.json()["vibe_of_month"] == "casual"
+        assert res.json()["most_worn_vibe"] == "casual"
 
     def test_longest_streak(self, client, monkeypatch):
         _mock_upload(monkeypatch)
@@ -132,10 +162,10 @@ class TestWrapped:
         res = client.get(WRAPPED_URL, params={"month": "2026-04"}, headers=_auth(a["access_token"]))
         assert res.json()["longest_streak"] == 3
 
-    def test_top_outfit_present(self, client, monkeypatch):
+    def test_total_items_counted(self, client, monkeypatch):
         _mock_upload(monkeypatch)
         a = _register(client, USER_A)
-        # One outfit with 2 items, one with 1 item
+        # One outfit with 2 items, one with 1 item → 3 total
         _post_outfit(client, a["access_token"], {
             "worn_on": "2026-04-01",
             "clothing_items": [
@@ -148,14 +178,26 @@ class TestWrapped:
             "clothing_items": [{"category": "shoes"}],
         })
         res = client.get(WRAPPED_URL, params={"month": "2026-04"}, headers=_auth(a["access_token"]))
-        body = res.json()
-        assert body["top_outfit"] is not None
-        assert len(body["top_outfit"]["clothing_items"]) == 2
+        assert res.json()["total_items"] == 3
 
-    def test_month_label_in_response(self, client):
+    def test_outfits_by_week(self, client, monkeypatch):
+        _mock_upload(monkeypatch)
+        a = _register(client, USER_A)
+        # week 1 (day 3) x2, week 3 (day 17) x1
+        _post_outfit(client, a["access_token"], {"worn_on": "2026-04-03"})
+        _post_outfit(client, a["access_token"], {"worn_on": "2026-04-03"})
+        _post_outfit(client, a["access_token"], {"worn_on": "2026-04-17"})
+        res = client.get(WRAPPED_URL, params={"month": "2026-04"}, headers=_auth(a["access_token"]))
+        by_week = {w["week"]: w["count"] for w in res.json()["outfits_by_week"]}
+        assert by_week[1] == 2
+        assert by_week[3] == 1
+
+    def test_year_and_month_in_response(self, client):
         a = _register(client, USER_A)
         res = client.get(WRAPPED_URL, params={"month": "2026-04"}, headers=_auth(a["access_token"]))
-        assert res.json()["month"] == "2026-04"
+        body = res.json()
+        assert body["year"] == 2026
+        assert body["month"] == 4
 
     def test_outfits_from_other_months_excluded(self, client, monkeypatch):
         _mock_upload(monkeypatch)


### PR DESCRIPTION
## Summary

- **Monthly fit check crash**: The backend `WrappedStats` schema had completely diverged from what the frontend expected — old fields like `top_colors: list[str]`, `vibe_of_month`, and missing `outfits_by_week` caused `map()` calls on undefined values. Rewrote the schema with structured sub-models (`ColorCount`, `BrandCount`, `CategoryCount`, `WeekCount`) and rewrote the CRUD to return all fields the frontend needs.
- **Duplicate search icon**: On desktop, both the nav search bar and a mobile icon-button were visible in feed and explore pages. Added `lg:hidden` to the icon-button link in both pages so it only shows on smaller screens.

## Test plan

- [ ] Navigate to Monthly Fit Check — should load without crashing
- [ ] Verify stats render: top colors, brands, categories, outfits by week, streaks
- [ ] On desktop (≥1024px), confirm only the top search bar is visible in feed and explore
- [ ] On mobile, confirm the search icon button still appears