### PR TITLE
fix: outfit detail top bar hidden under desktop nav

### DIFF
--- a/apps/web/components/outfits/outfit-detail-view.tsx
+++ b/apps/web/components/outfits/outfit-detail-view.tsx
@@ -358,7 +358,7 @@ export function OutfitDetailView({ id }: { id: string }) {
 
   return (
     <>
-      <main className="px-4 pb-28 pt-14 sm:px-6 lg:px-8">
+      <main className="px-4 pb-28 pt-14 sm:px-6 lg:px-8 lg:pb-12 lg:pt-20">
         <div className="mx-auto max-w-4xl">
 
           {/* Top bar — prominent back button */}


### PR DESCRIPTION
## Problem

When you open an outfit from your vault or discover/explore on **desktop**, the fixed top nav bar overlaps the top of the detail page — covering part of the back/share bar in a weird way.

## Cause

The `DesktopNav` is `fixed` and `lg:h-16` (64px tall) on desktop, but the outfit detail page's `<main>` only had `pt-14` (56px) top padding with no `lg:` override. So the 64px nav overlapped the 56px-offset content by ~8px.

Every other top-level page already accounts for this:
- feed / vault → `lg:pt-16`
- explore / profile → `lg:pt-20`

The outfit detail view was the only one missing it.

## Fix

Added `lg:pt-20 lg:pb-12` to the detail `<main>` (matching the profile-page convention) so the back/share bar clears the desktop nav. `lg:pb-*` because the bottom mobile nav is `lg:hidden`.

One-line Tailwind change, no behavior change on mobile.

## Test plan

- [ ] Desktop (≥1024px): open an outfit from vault and from discover → back/share bar sits fully below the nav, nothing clipped
- [ ] Mobile: unchanged (still `pt-14`)