### PR TITLE
fix: QA round 2 — timezone dates, board idempotency + a11y, identity masking, monthly clarity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,14 @@ coverage/
 *.log
 Thumbs.db
 .DS_Store
+
+# Local databases & test artifacts
+*.db
+*.sqlite
+*.sqlite3
+test-results/
+playwright-report/
+
+# Local agent/editor state (keep the shared launch config)
+.claude/*
+!.claude/launch.json

--- a/apps/web/app/boards/[id]/upload/page.tsx
+++ b/apps/web/app/boards/[id]/upload/page.tsx
@@ -35,6 +35,10 @@ export default function BoardUploadPage({ params }: { params: Promise<{ id: stri
   const [submitStatus, setSubmitStatus] = useState<SubmitStatus>("idle");
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // Stable idempotency key for this upload attempt — reused on retry so a
+  // failed board-add (after a successful create) doesn't create a duplicate
+  // outfit when the user retries.
+  const idempotencyKeyRef = useRef(crypto.randomUUID());
 
   useEffect(() => {
     if (!isBootstrapping && !isAuthenticated) router.replace("/login");
@@ -86,10 +90,13 @@ export default function BoardUploadPage({ params }: { params: Promise<{ id: stri
     setSubmitStatus("uploading");
     setErrorMsg(null);
 
-    const createResult = await apiClient.outfits.create({
-      image: photo,
-      metadata: { caption: caption.trim() || undefined, clothing_items: [], save_to_vault: saveToVault },
-    });
+    const createResult = await apiClient.outfits.create(
+      {
+        image: photo,
+        metadata: { caption: caption.trim() || undefined, clothing_items: [], save_to_vault: saveToVault },
+      },
+      { idempotencyKey: idempotencyKeyRef.current }
+    );
 
     if (!createResult.ok) {
       setErrorMsg(createResult.message);

--- a/apps/web/app/boards/page.tsx
+++ b/apps/web/app/boards/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiClient, type Board } from "@/lib/api-client";
 import { MobileNav } from "@/components/chrome/mobile-nav";
@@ -34,8 +34,44 @@ function CreateBoardModal({ onClose, onCreate }: {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
 
   useEffect(() => { inputRef.current?.focus(); }, []);
+
+  // Accessibility: restore focus to the trigger when the modal closes, close on
+  // Escape, and trap Tab focus inside the dialog while it's open.
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const focusables = dialogRef.current?.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (!focusables || focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      previouslyFocused?.focus?.();
+    };
+  }, [onClose]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -57,13 +93,23 @@ function CreateBoardModal({ onClose, onCreate }: {
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center bg-[rgba(36,21,28,0.38)] px-4 pb-4 sm:items-center sm:pb-0 backdrop-blur-sm">
-      <div className="soft-panel w-full max-w-md px-6 py-7">
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-[rgba(36,21,28,0.38)] px-4 pb-4 sm:items-center sm:pb-0 backdrop-blur-sm"
+      onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="soft-panel w-full max-w-md px-6 py-7"
+      >
         <div className="mb-5 flex items-center justify-between">
-          <h2 className="font-display italic text-2xl tracking-[-0.03em] text-ink">new board</h2>
+          <h2 id={titleId} className="font-display italic text-2xl tracking-[-0.03em] text-ink">new board</h2>
           <button
             type="button"
             onClick={onClose}
+            aria-label="Close"
             className="flex h-8 w-8 items-center justify-center rounded-full border border-line text-mute transition hover:border-pink-deep/25 hover:text-ink"
           >
             <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/api-client";
 import { MobileNav } from "@/components/chrome/mobile-nav";
 import { useAuth } from "@/lib/auth-context";
+import { parseDisplayDate } from "@/lib/dates";
 import {
   OutfitCard,
   OutfitCardSkeleton,
@@ -67,7 +68,7 @@ function toBoardCardData(outfit: BoardOutfitResponse): OutfitCardData {
 
 function formatEventDate(dateStr: string | null): string | null {
   if (!dateStr) return null;
-  const d = new Date(dateStr);
+  const d = parseDisplayDate(dateStr);
   if (isNaN(d.getTime())) return null;
   return new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric" }).format(d);
 }

--- a/apps/web/app/profile/edit/page.tsx
+++ b/apps/web/app/profile/edit/page.tsx
@@ -4,7 +4,6 @@ import { useEffect, useRef, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { apiClient } from "@/lib/api-client";
 import { useAuth } from "@/lib/auth-context";
-import { MobileNav } from "@/components/chrome/mobile-nav";
 
 const BIO_LIMIT = 160;
 const USERNAME_CHECK_DELAY = 500;
@@ -255,7 +254,7 @@ export default function EditProfilePage() {
   const isSaving = saveStatus === "saving";
 
   return (
-    <main className="px-4 pb-28 pt-14 sm:px-6 lg:px-8 lg:pb-0 lg:pt-20">
+    <main className="px-4 pb-12 pt-14 sm:px-6 lg:px-8 lg:pt-20">
       <div className="mx-auto max-w-lg">
 
         {/* ── Top bar ─────────────────────────────────────────────────────── */}
@@ -461,8 +460,6 @@ export default function EditProfilePage() {
           </div>
         </form>
       </div>
-
-      <MobileNav active="me" />
     </main>
   );
 }

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -380,7 +380,9 @@ export default function ProfilePage() {
 
             {status === "ready" && outfits.length > 0 ? (
               <>
-                <div className="grid grid-cols-3 gap-0.5 pt-0.5">
+                <div className={`grid gap-0.5 pt-0.5 ${
+                  outfits.length === 1 ? "grid-cols-1" : outfits.length === 2 ? "grid-cols-2" : "grid-cols-3"
+                }`}>
                   {outfits.map((outfit) => (
                     <OutfitCard
                       key={outfit.id}

--- a/apps/web/app/search/page.tsx
+++ b/apps/web/app/search/page.tsx
@@ -212,8 +212,9 @@ export default function SearchPage() {
         {/* ── Header ─────────────────────────────────────────────────────── */}
         <header className="mb-5 flex items-center justify-between">
           <div>
-            <p className="font-display italic text-[2.2rem] leading-none text-pink-deep">checkd</p>
-            <p className="mt-1 text-sm text-mute">Find people</p>
+            {/* Desktop nav already shows the brand — hide the duplicate wordmark on mobile. */}
+            <p className="hidden font-display italic text-[2.2rem] leading-none text-pink-deep lg:block">checkd</p>
+            <p className="font-display italic text-[2.2rem] leading-none text-pink-deep lg:mt-1 lg:text-sm lg:font-sans lg:not-italic lg:font-normal lg:text-mute">Find people</p>
           </div>
           <button
             type="button"

--- a/apps/web/components/monthly-checks/monthly-checks-client.tsx
+++ b/apps/web/components/monthly-checks/monthly-checks-client.tsx
@@ -43,6 +43,14 @@ export function MonthlyChecksClient() {
   const now = new Date();
   const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
   const isAtLatest = month >= currentMonth;
+  const isCurrentMonth = month === currentMonth;
+  // The page opens on last completed month by default; caption it so users
+  // aren't confused when a brand-new fit doesn't appear yet.
+  const monthCaption = isCurrentMonth
+    ? "this month"
+    : month === defaultMonth()
+      ? "last month's check"
+      : null;
 
   useEffect(() => {
     if (authLoading || !isAuthenticated) return;
@@ -107,7 +115,12 @@ export function MonthlyChecksClient() {
             <path d="m15 18-6-6 6-6" />
           </svg>
         </button>
-        <span className={`text-[11px] font-medium ${monthLabelColor}`}>{formatMonthLabel(month)}</span>
+        <div className="flex flex-col items-center leading-tight">
+          <span className={`text-[11px] font-medium ${monthLabelColor}`}>{formatMonthLabel(month)}</span>
+          {monthCaption ? (
+            <span className={`text-[9px] uppercase tracking-[0.14em] ${monthLabelColor} opacity-70`}>{monthCaption}</span>
+          ) : null}
+        </div>
         <button
           type="button"
           onClick={() => navigate("next")}
@@ -118,6 +131,15 @@ export function MonthlyChecksClient() {
             <path d="m9 18 6-6-6-6" />
           </svg>
         </button>
+        {!isCurrentMonth ? (
+          <button
+            type="button"
+            onClick={() => router.push(`/monthly-checks?month=${currentMonth}`)}
+            className={`ml-1 rounded-full px-2.5 py-1 text-[10px] font-medium transition ${btnStyle}`}
+          >
+            this month
+          </button>
+        ) : null}
       </div>
 
       {/* Content */}
@@ -137,13 +159,25 @@ export function MonthlyChecksClient() {
             <p className="mt-3 text-sm leading-6" style={{ color: "rgba(255,255,255,0.4)" }}>
               you didn't post any outfits in {formatMonthLabel(month)}
             </p>
-            <Link
-              href="/profile"
-              className="mt-6 inline-flex items-center gap-2 rounded-full px-5 py-3 text-sm transition"
-              style={{ background: "rgba(255,255,255,0.08)", color: "rgba(255,255,255,0.6)" }}
-            >
-              ← back to profile
-            </Link>
+            <div className="mt-6 flex items-center justify-center gap-2">
+              {!isCurrentMonth ? (
+                <button
+                  type="button"
+                  onClick={() => router.push(`/monthly-checks?month=${currentMonth}`)}
+                  className="inline-flex items-center gap-2 rounded-full px-5 py-3 text-sm transition"
+                  style={{ background: "var(--pink)", color: "var(--ink)" }}
+                >
+                  see this month →
+                </button>
+              ) : null}
+              <Link
+                href="/profile"
+                className="inline-flex items-center gap-2 rounded-full px-5 py-3 text-sm transition"
+                style={{ background: "rgba(255,255,255,0.08)", color: "rgba(255,255,255,0.6)" }}
+              >
+                ← back to profile
+              </Link>
+            </div>
           </div>
         </div>
       )}

--- a/apps/web/components/outfits/outfit-card.tsx
+++ b/apps/web/components/outfits/outfit-card.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { parseDisplayDate } from "@/lib/dates";
 
 type OutfitCardAuthor = {
   username?: string | null;
@@ -95,7 +96,9 @@ function formatOutfitDate(value?: string | null) {
     return "Recently";
   }
 
-  const date = new Date(value);
+  // parseDisplayDate anchors date-only worn_on values to local noon so they
+  // don't render a day behind in western timezones.
+  const date = parseDisplayDate(value);
 
   if (Number.isNaN(date.getTime())) {
     return "Recently";

--- a/apps/web/components/outfits/outfit-detail-view.tsx
+++ b/apps/web/components/outfits/outfit-detail-view.tsx
@@ -7,6 +7,7 @@ import { apiClient, type Comment, type OutfitDetailResponse } from "@/lib/api-cl
 import { MobileNav } from "@/components/chrome/mobile-nav";
 import { StoryCardSheet } from "@/components/outfits/story-card-sheet";
 import { useAuth } from "@/lib/auth-context";
+import { formatWornDate } from "@/lib/dates";
 
 type PageStatus = "loading" | "ready" | "not-found" | "error";
 
@@ -30,8 +31,9 @@ function firstSentence(text: string): string {
 }
 
 function formatDate(d?: string | null) {
-  if (!d) return null;
-  return new Intl.DateTimeFormat("en-US", { month: "long", day: "numeric", year: "numeric" }).format(new Date(d));
+  // formatWornDate anchors date-only strings to local noon so a worn_on like
+  // "2026-06-09" doesn't render as the previous day in western timezones.
+  return formatWornDate(d);
 }
 
 function formatCommentDate(iso: string) {

--- a/apps/web/components/outfits/story-card-sheet.tsx
+++ b/apps/web/components/outfits/story-card-sheet.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { parseDisplayDate } from "@/lib/dates";
 
 type StoryCardSheetProps = {
   outfitId: string;
@@ -38,7 +39,7 @@ function firstSentence(text: string): string {
 
 function formatShareDate(dateStr?: string | null): string {
   if (!dateStr) return "";
-  const d = new Date(dateStr);
+  const d = parseDisplayDate(dateStr);
   return d.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" });
 }
 

--- a/apps/web/components/upload/upload-flow.tsx
+++ b/apps/web/components/upload/upload-flow.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { apiClient } from "@/lib/api-client";
 import { EventDatePicker } from "@/components/boards/event-date-picker";
+import { todayLocalISO } from "@/lib/dates";
 
 async function normalizeImageFile(file: File): Promise<File> {
   const type = file.type.toLowerCase();
@@ -72,7 +73,7 @@ export function UploadFlow() {
   const [metadata, setMetadata] = useState<UploadMetadata>({
     caption: "",
     eventName: "",
-    wornOn: new Date().toISOString().split("T")[0],
+    wornOn: todayLocalISO(),
   });
   const [errors, setErrors] = useState<ValidationErrors>(createEmptyErrors);
   const [submitState, setSubmitState] = useState<SubmitState>({ status: "idle" });

--- a/apps/web/lib/dates.ts
+++ b/apps/web/lib/dates.ts
@@ -1,0 +1,40 @@
+/**
+ * Date helpers that keep "worn on" / event dates stable across timezones.
+ *
+ * The core bug these solve: a date-only string like "2026-06-09" parsed with
+ * `new Date("2026-06-09")` is interpreted as UTC midnight. When formatted in a
+ * western timezone (e.g. America/New_York, UTC-4) that renders as the *previous*
+ * day ("June 8"). Anchoring date-only values to local noon avoids the shift.
+ */
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Today's date as a local `YYYY-MM-DD` string (never UTC). */
+export function todayLocalISO(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+/**
+ * Parse a date value into a Date suitable for *display*.
+ * Date-only strings ("YYYY-MM-DD") are anchored to local noon so they never
+ * cross the UTC date boundary. Full timestamps are parsed as-is.
+ */
+export function parseDisplayDate(value: string): Date {
+  if (DATE_ONLY.test(value)) {
+    return new Date(`${value}T12:00:00`);
+  }
+  return new Date(value);
+}
+
+/**
+ * Format a worn / event date (date-only or full ISO) in local time.
+ * Returns null for empty input so callers can conditionally render.
+ */
+export function formatWornDate(
+  value: string | null | undefined,
+  opts: Intl.DateTimeFormatOptions = { month: "long", day: "numeric", year: "numeric" }
+): string | null {
+  if (!value) return null;
+  return new Intl.DateTimeFormat("en-US", opts).format(parseDisplayDate(value));
+}

--- a/apps/web/test-results/.last-run.json
+++ b/apps/web/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}

--- a/services/api/app/routers/users.py
+++ b/services/api/app/routers/users.py
@@ -11,6 +11,7 @@ from app.dependencies import get_current_user, get_db
 from app.models.notification import NotificationType
 from app.models.user import User
 from app.schemas.user import FollowResponse, PublicProfile, SearchResult, UpdateProfileRequest
+from app.utils.identity import public_display_name
 from app.schemas.wrapped import WrappedStats
 from app.services.storage import InvalidImageError, StorageError, upload_image
 from app.services.rate_limit import check_rate_limit, follow_rate_limiter
@@ -135,7 +136,7 @@ def search_users(
         SearchResult(
             id=u.id,
             username=u.username,
-            display_name=u.display_name,
+            display_name=public_display_name(u.display_name, u.username),
             profile_image_url=u.profile_image_url,
             follower_count=follow_crud.follower_count(db, u.id),
         )
@@ -158,7 +159,7 @@ def suggested_users(
         SearchResult(
             id=u.id,
             username=u.username,
-            display_name=u.display_name,
+            display_name=public_display_name(u.display_name, u.username),
             profile_image_url=u.profile_image_url,
             follower_count=follow_crud.follower_count(db, u.id),
         )
@@ -177,7 +178,7 @@ def get_profile(username: str, db: Session = Depends(get_db)) -> PublicProfile:
     return PublicProfile(
         id=user.id,
         username=user.username,
-        display_name=user.display_name,
+        display_name=public_display_name(user.display_name, user.username),
         bio=user.bio,
         profile_image_url=user.profile_image_url,
         instagram_handle=user.instagram_handle,
@@ -242,7 +243,8 @@ def get_followers(
     users = [user_crud.get_by_id(db, r.follower_id) for r in rows]
     return [
         SearchResult(
-            id=u.id, username=u.username, display_name=u.display_name,
+            id=u.id, username=u.username,
+            display_name=public_display_name(u.display_name, u.username),
             profile_image_url=u.profile_image_url,
             follower_count=follow_crud.follower_count(db, u.id),
         )
@@ -264,7 +266,8 @@ def get_following(
     users = [user_crud.get_by_id(db, r.following_id) for r in rows]
     return [
         SearchResult(
-            id=u.id, username=u.username, display_name=u.display_name,
+            id=u.id, username=u.username,
+            display_name=public_display_name(u.display_name, u.username),
             profile_image_url=u.profile_image_url,
             follower_count=follow_crud.follower_count(db, u.id),
         )

--- a/services/api/app/utils/identity.py
+++ b/services/api/app/utils/identity.py
@@ -1,0 +1,36 @@
+"""Helpers for safely presenting user identity on public surfaces.
+
+Some legacy/seed accounts have an email address stored as their display name
+or username. We must never surface a raw email as someone's public identity
+(search, explore, suggestions, profiles). These helpers defensively mask it.
+"""
+
+import re
+
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def looks_like_email(value: str | None) -> bool:
+    """True when value is a bare email address."""
+    return bool(value and _EMAIL_RE.match(value.strip()))
+
+
+def public_display_name(display_name: str | None, username: str | None) -> str | None:
+    """
+    Return a safe public display name, never a raw email address.
+
+    Preference order:
+      1. display_name, if set and not email-like
+      2. username, if set and not email-like
+      3. the local part of whichever email-like value we have (before '@')
+      4. a generic fallback
+    """
+    if display_name and not looks_like_email(display_name):
+        return display_name
+    if username and not looks_like_email(username):
+        return username
+    candidate = (display_name or username or "").strip()
+    if "@" in candidate:
+        local = candidate.split("@", 1)[0].strip()
+        return local or "checkd member"
+    return candidate or "checkd member"

--- a/services/api/tests/test_identity.py
+++ b/services/api/tests/test_identity.py
@@ -1,0 +1,44 @@
+"""Tests for public identity masking — raw emails must never surface as a
+public display name in search / suggested / profile responses."""
+
+from app.utils.identity import looks_like_email, public_display_name
+
+
+class TestLooksLikeEmail:
+    def test_detects_emails(self):
+        assert looks_like_email("chase.primashailey@gmail.com")
+        assert looks_like_email("a@b.co")
+
+    def test_rejects_non_emails(self):
+        assert not looks_like_email("chase")
+        assert not looks_like_email("Cool Stylist")
+        assert not looks_like_email(None)
+        assert not looks_like_email("")
+        assert not looks_like_email("no-at-symbol.com")
+
+
+class TestPublicDisplayName:
+    def test_prefers_clean_display_name(self):
+        assert public_display_name("Cool Stylist", "coolstylist") == "Cool Stylist"
+
+    def test_falls_back_to_username_when_display_is_email(self):
+        assert public_display_name("chase@gmail.com", "chase") == "chase"
+
+    def test_masks_email_when_both_are_emails(self):
+        # The exact case QA hit: display name and username both the raw email.
+        assert public_display_name("chase.primashailey@gmail.com", "chase.primashailey@gmail.com") == "chase.primashailey"
+
+    def test_uses_username_when_display_missing(self):
+        assert public_display_name(None, "realuser") == "realuser"
+
+    def test_generic_fallback_when_nothing_usable(self):
+        assert public_display_name(None, None) == "checkd member"
+
+    def test_never_returns_raw_email(self):
+        for dn, un in [
+            ("a@b.com", "a@b.com"),
+            ("a@b.com", None),
+            (None, "a@b.com"),
+        ]:
+            result = public_display_name(dn, un)
+            assert "@" not in (result or ""), f"leaked email for {dn!r}/{un!r}: {result!r}"


### PR DESCRIPTION
Addresses the actionable items from the second QA + repo audit pass. Several P0/P2 items (upload visibility copy, AI consent persistence, review-image crop, vault single-fit, explore duplicate branding) were already shipped in #206/#208 — this PR covers what remained.

## P0
**#3 Identity masking — no raw emails as public identity**
- New `services/api/app/utils/identity.py`: `public_display_name()` never returns a bare email. Falls back display_name → username → email local-part → "checkd member".
- Applied to search, suggested, followers, following, and public profile responses.
- Tests in `tests/test_identity.py` (incl. the exact QA case: display name + username both `chase.primashailey@gmail.com` → `chase.primashailey`).
- ⚠️ The underlying *data* (the actual user records, plus the `"Asian?"` record) still needs a manual DB cleanup on Railway — code can only defend the display layer.

## P1
**#5 Dates one day behind (timezone)**
- New `apps/web/lib/dates.ts`. Date-only `worn_on` strings were parsed as UTC midnight → rendered the previous day in America/New_York. Now anchored to local noon for display; upload default uses a local date instead of UTC `toISOString()`. Applied across outfit card, outfit detail, feed, story card.

**#6 Board upload idempotency**
- Board upload now passes a stable `Idempotency-Key` per attempt (reused on retry), so a failed board-add after a successful create can't create a duplicate. (Main upload flow already had this.)

**#7 Board create modal accessibility**
- `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, labelled close button, focus trap, Escape to close, focus restore on close, backdrop-click close. `aria-modal` makes the background create controls inert to screen readers.

**#4 Monthly Checks month clarity** (decision: keep previous month, label it)
- Header now captions the month (`last month's check` / `this month`) and shows a "this month" jump when not viewing the current month. Empty state adds a "see this month →" CTA.

## P2 polish
- **#11** Hide the bottom mobile nav on `/profile/edit` (upload + board upload already omit it).
- **#8** Profile single-fit grid: 1 fit full-width, 2 fits two-col, 3+ three-col (mirrors the vault fix).
- **#10** Search page: hide the duplicate `checkd` wordmark on mobile (matches explore).

## Repo hygiene
- **#12** `.gitignore` now covers `*.db`, `test-results/`, `playwright-report/`, and `.claude/` local state (keeping the shared `launch.json`); untracked a committed Playwright run artifact.

## Deferred (separate tasks)
The large refactors — split `api-client.ts` (#13), dedupe upload file handling (#14), extract large page components (#15), dedupe comments UI (#16) — are intentionally **not** in this PR; codex itself advises not refactoring everything at once. Spinning these off separately.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Playwright smoke: 18 passed
- [x] Identity masking assertions verified (CI runs `test_identity.py` on Postgres)
- [ ] Manual: upload a fit today → profile/detail shows today's date (not yesterday)
- [ ] Manual: board create modal — Tab stays trapped, Esc closes, focus returns to trigger
- [ ] Manual: Monthly Checks opens on last month captioned, "this month" jump works